### PR TITLE
Soften event hero mix: readable Phoenix accent

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -73,19 +73,22 @@
       inset: 0;
     }
     .article-header-event {
-      inset: -28px;
+      inset: -8px;
       background: url("assets/hero_fullwidth.png") center / cover no-repeat;
-      filter: blur(18px) saturate(1.05);
-      transform: scale(1.04);
+      /* Soft retouch only: keep phoenix / wordmark outlines readable */
+      filter: blur(2.5px) saturate(1.08) contrast(1.05);
+      transform: scale(1.02);
+      opacity: 0.92;
     }
     .article-header-underlay {
       background: url("../assets/hero_underlay.png") center / cover no-repeat;
-      opacity: 0.72;
+      opacity: 0.48;
       mix-blend-mode: screen;
     }
     .article-header-wash {
-      background: var(--hero-slate);
-      opacity: 0.52;
+      background:
+        linear-gradient(180deg, rgba(45, 55, 72, 0.28) 0%, rgba(45, 55, 72, 0.42) 45%, rgba(45, 55, 72, 0.62) 100%);
+      opacity: 1;
     }
     .article-header > *:not(.article-header-media) { position: relative; z-index: 1; }
     .article-eyebrow {

--- a/events/README.md
+++ b/events/README.md
@@ -21,9 +21,9 @@ Shared underlay for every event portrait:
 
 Stack (bottom → top), same brightness family as other article heroes (`#2d3748` wash ≈ 0.5):
 
-1. blurred event asset from the event site (`assets/hero_fullwidth.png` or logo)
-2. locked ChatGPT underlay (`../assets/hero_underlay.png`, screen + opacity)
-3. slate wash (`#2d3748`)
+1. event asset from the event site (`assets/hero_fullwidth.png` or logo), lightly softened so outlines stay recognizable
+2. locked ChatGPT underlay (`../assets/hero_underlay.png`, screen + lighter opacity) as a retouching mix
+3. slate wash (`#2d3748` gradient) for title readability
 4. title / subtitle text
 
 ## Pilot


### PR DESCRIPTION
## Summary
- Reduce event-site asset blur from heavy soft-focus to a light retouch
- Lower ChatGPT underlay opacity so Phoenix outlines stay recognizable in the mix
- Keep a gentler slate wash for title readability

## Test plan
- [ ] Phoenix bird / wordmark outlines are recognizable in the hero
- [ ] Globe underlay still reads as part of the mix
- [ ] Title remains readable


Made with [Cursor](https://cursor.com)