### PR TITLE
Show full unblurred Phoenix mark on event hero

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -73,21 +73,22 @@
       inset: 0;
     }
     .article-header-event {
-      inset: -8px;
-      background: url("assets/hero_fullwidth.png") center / cover no-repeat;
-      /* Soft retouch only: keep phoenix / wordmark outlines readable */
-      filter: blur(2.5px) saturate(1.08) contrast(1.05);
-      transform: scale(1.02);
-      opacity: 0.92;
+      inset: 0;
+      /* contain = show full Phoenix graphic, not cropped by cover */
+      background: url("assets/hero_fullwidth.png") center 42% / contain no-repeat;
+      filter: none;
+      opacity: 0.95;
+      transform: scale(0.82);
+      transform-origin: center center;
     }
     .article-header-underlay {
       background: url("../assets/hero_underlay.png") center / cover no-repeat;
-      opacity: 0.48;
+      opacity: 0.55;
       mix-blend-mode: screen;
     }
     .article-header-wash {
       background:
-        linear-gradient(180deg, rgba(45, 55, 72, 0.28) 0%, rgba(45, 55, 72, 0.42) 45%, rgba(45, 55, 72, 0.62) 100%);
+        linear-gradient(180deg, rgba(45, 55, 72, 0.22) 0%, rgba(45, 55, 72, 0.38) 48%, rgba(45, 55, 72, 0.58) 100%);
       opacity: 1;
     }
     .article-header > *:not(.article-header-media) { position: relative; z-index: 1; }

--- a/events/README.md
+++ b/events/README.md
@@ -21,8 +21,8 @@ Shared underlay for every event portrait:
 
 Stack (bottom → top), same brightness family as other article heroes (`#2d3748` wash ≈ 0.5):
 
-1. event asset from the event site (`assets/hero_fullwidth.png` or logo), lightly softened so outlines stay recognizable
-2. locked ChatGPT underlay (`../assets/hero_underlay.png`, screen + lighter opacity) as a retouching mix
+1. full event asset from the event site (`contain`, slightly scaled down so the whole graphic is visible)
+2. locked ChatGPT underlay (`../assets/hero_underlay.png`, screen mix) as the series retouch layer
 3. slate wash (`#2d3748` gradient) for title readability
 4. title / subtitle text
 


### PR DESCRIPTION
## Summary
- Remove blur from the event-site graphic
- Use `contain` + scale ~0.82 so the full Phoenix element is visible, not cropped
- Keep ChatGPT underlay as a lighter mix behind/over the mark

## Test plan
- [ ] Full phoenix + wordmark visible in hero
- [ ] Underlay still present as mix
- [ ] Title readable


Made with [Cursor](https://cursor.com)