### PR TITLE
Raise event hero underlay opacity to 0.75

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -83,7 +83,7 @@
     }
     .article-header-underlay {
       background: url("../assets/hero_underlay.png") center / cover no-repeat;
-      opacity: 0.68;
+      opacity: 0.75;
       mix-blend-mode: screen;
     }
     .article-header-wash {


### PR DESCRIPTION
## Summary
- Set ChatGPT underlay opacity to 0.75 for stronger separation from the white title

## Test plan
- [ ] Refresh draft hero and confirm contrast


Made with [Cursor](https://cursor.com)