### PR TITLE
Raise event hero underlay opacity to 0.87

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -83,7 +83,7 @@
     }
     .article-header-underlay {
       background: url("../assets/hero_underlay.png") center / cover no-repeat;
-      opacity: 0.82;
+      opacity: 0.87;
       mix-blend-mode: screen;
     }
     .article-header-wash {


### PR DESCRIPTION
## Summary
- Set ChatGPT underlay opacity to 0.87

## Test plan
- [ ] Refresh draft hero


Made with [Cursor](https://cursor.com)