### PR TITLE
Add series lede for WSDC event history cycle

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -129,6 +129,7 @@
     }
     .article-rail p,
     .article-rail .intro,
+    .article-rail .series-lede,
     .article-rail .meta-line,
     .article-rail .footnote,
     .article-rail .closing,
@@ -147,6 +148,17 @@
       font-size: 1.125rem;
       line-height: 1.7;
       margin: 0 0 1.25rem;
+    }
+    .series-lede {
+      font-size: 1.125rem;
+      line-height: 1.7;
+      margin: 0 0 1.1rem;
+      color: var(--ink);
+    }
+    .series-lede + .intro {
+      margin-top: 0.35rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--line);
     }
     .section { margin: 3.25rem 0; }
     .section-title {
@@ -445,22 +457,32 @@
       <div class="article-header-underlay"></div>
       <div class="article-header-wash"></div>
     </div>
-    <div class="article-eyebrow">Портрет события · Jack&amp;Jill по уровням</div>
+    <div class="article-eyebrow">Цикл · история событий WSDC</div>
     <h1 class="article-title">4th of July Convention</h1>
     <p class="article-subtitle">Финикс, Аризона · 1991-2026 · 34 проведения в реестре WSDC</p>
   </header>
 
   <main class="article-content">
     <div class="article-rail">
+    <p class="series-lede">
+      Этой статьей открываю цикл о истории событий под эгидой WSDC через данные реестра очков.
+      События держат комьюнити: на соревновательной части строится мотивация расти по уровням,
+      а социальная даёт новые знакомства и ощущение, что вокруг люди с тем же увлечением.
+    </p>
+    <p class="series-lede">
+      Начать логично с события с самой длинной линией в этом реестре:
+      4th of July Convention в Финиксе, Аризона.
+    </p>
+
     <p class="intro">
       В 1981 в Финиксе собрали клуб Greater Phoenix Swing Dance Club (GPSDC). Среди основателей
       зал славы WSDC называет Robert Bryant. С 1982 клуб проводит июльский уикенд
-      (на сайте: «46th year») — клубное событие, не корпоративный тур.
+      (на сайте: «46th year»). Это клубное событие, не корпоративный тур.
     </p>
 
     <p class="intro">
       В базе очков WSDC у него номер 1. Jack&amp;Jill по уровням здесь с 1991: самый ранний год в реестре
-      (в том же году ещё Spring Fling, но единица досталась Arizona). До 2026: 34 проведения без 2020-2021 —
+      (в том же году ещё Spring Fling, но единица досталась Arizona). До 2026: 34 проведения без 2020-2021,
       самая длинная такая серия в базе. За год максимум 100 танцоров с очками (2009).
       Длинный якорь календаря, средний по объёму реестра.
     </p>


### PR DESCRIPTION
## Summary
- Add a short series opening above the Arizona event intro
- Update eyebrow to mark the cycle
- Keep event-specific history after a visual break

## Test plan
- [ ] Read the first screen of the draft: cycle purpose → why this event → GPSDC / registry facts
- [ ] No AI-ish padding; title contrast still OK


Made with [Cursor](https://cursor.com)