### PR TITLE
Rewrite Arizona series intro with venue links

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -465,33 +465,41 @@
   <main class="article-content">
     <div class="article-rail">
     <p class="series-lede">
-      Этой статьей открываю цикл о истории событий под эгидой WSDC через данные реестра очков.
-      События держат комьюнити: на соревновательной части строится мотивация расти по уровням,
-      а социальная даёт новые знакомства и ощущение, что вокруг люди с тем же увлечением.
+      Эта статья открывает цикл об истории ивентов WSDC через данные реестра поинтов.
+      Ивенты это связующий элемент комьюнити: на соревновательной части строится мотивация
+      развиваться и улучшать своё танцевание, а социальная даёт возможность знакомиться
+      и общаться с людьми, имеющими те же увлечения.
     </p>
     <p class="series-lede">
-      Начать логично с события с самой длинной линией в этом реестре:
-      4th of July Convention в Финиксе, Аризона.
+      Первая статья посвящена ивенту с самой длинной историей проведения и учётным номером 1
+      в реестре WSDC:
+      <a href="https://phoenix4thofjuly.com/" rel="noopener noreferrer" target="_blank">4th of July Convention</a>,
+      который проводится в Финиксе, Аризона, США.
     </p>
 
     <p class="intro">
-      В 1981 в Финиксе собрали клуб Greater Phoenix Swing Dance Club (GPSDC). Среди основателей
-      зал славы WSDC называет Robert Bryant. С 1982 клуб проводит июльский уикенд
-      (на сайте: «46th year»). Это клубное событие, не корпоративный тур.
+      Ивент берёт своё начало задолго до появления нынешнего реестра WSDC: с открытия в 1981
+      в Финиксе танцевального клуба Greater Phoenix Swing Dance Club (GPSDC). Одним из основателей
+      по информации зала славы WSDC является Robert Bryant. С 1982 клуб проводит июльский уикенд:
+      клубное событие, которое в 1991 году стало одним из первых ивентов в истории WSDC.
     </p>
 
     <p class="intro">
-      В базе очков WSDC у него номер 1. Jack&amp;Jill по уровням здесь с 1991: самый ранний год в реестре
-      (в том же году ещё Spring Fling, но единица досталась Arizona). До 2026: 34 проведения без 2020-2021,
-      самая длинная такая серия в базе. За год максимум 100 танцоров с очками (2009).
-      Длинный якорь календаря, средний по объёму реестра.
+      За период с 1991 по 2026 было проведено 34 ивента (в 2020 и 2021 ивент не проводился
+      в связи с пандемией), и это больше, чем у любого другого ивента WSDC.
+      Рекордным по количеству начисленных на ивенте поинтов в Skill Level номинациях является
+      ивент 2014 года (380). Больше всего уникальных танцоров, которые получили поинты
+      в рамках одного ивента: 2009 (100). Больше всего новых танцоров, получивших свои первые
+      поинты на ивенте: 1994 (17).
     </p>
 
     <p class="meta-line">
-      Площадка: JW Marriott Camelback Inn, Scottsdale ·
-      <a href="https://phoenix4thofjuly.com/" rel="noopener noreferrer" target="_blank">phoenix4thofjuly.com</a> ·
+      Площадка проведения:
+      <a href="https://www.marriott.com/en-us/hotels/phxcb-jw-marriott-scottsdale-camelback-inn-resort-and-spa/overview/" rel="noopener noreferrer" target="_blank">JW Marriott Camelback Inn, Scottsdale</a>.
+      Сайт ивента:
+      <a href="https://phoenix4thofjuly.com/" rel="noopener noreferrer" target="_blank">phoenix4thofjuly.com</a>.
+      Сайт клуба:
       <a href="https://greaterphoenixswingdanceclub.com/" rel="noopener noreferrer" target="_blank">greaterphoenixswingdanceclub.com</a>.
-      Ниже: Jack&amp;Jill по уровням, очки &gt; 0.
     </p>
 
     <div class="snapshot">


### PR DESCRIPTION
## Summary
- Replace series/event intro with the updated copy
- Link event name → phoenix4thofjuly.com
- Link JW Marriott Camelback Inn → Marriott overview page
- Keep club and event site links in the venue block

## Test plan
- [ ] Intro reads as provided
- [ ] Event name, hotel, event site, club site open correctly


Made with [Cursor](https://cursor.com)