### PR TITLE
Arizona peer chart: top-5 + rank gap, registry naming

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -327,21 +327,15 @@
     .peer-gap {
       display: flex;
       align-items: center;
-      justify-content: center;
-      gap: 0.55rem;
-      margin: 0.35rem 0 0.85rem;
+      justify-content: flex-start;
+      margin: 0.15rem 0 0.55rem;
+      padding-left: 0.15rem;
       color: var(--muted);
-      font-size: 0.75rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-    .peer-gap::before,
-    .peer-gap::after {
-      content: "";
-      flex: 1;
-      height: 1px;
-      background: var(--line);
+      font-size: 1.05rem;
+      font-weight: 500;
+      letter-spacing: 0.35em;
+      line-height: 1;
+      user-select: none;
     }
 
     .stack-era { margin: 1rem 0 0.25rem; width: 100%; }
@@ -866,7 +860,7 @@
     const parts = [];
     rows.forEach((r, idx) => {
       if (!selfInTop && idx === topN) {
-        parts.push(`<div class="peer-gap" aria-hidden="true">место ${rank}</div>`);
+        parts.push(`<div class="peer-gap" aria-hidden="true">···</div>`);
       }
       const v = r[key] || 0;
       const w = ((100 * v) / max).toFixed(1);

--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="noindex,nofollow">
-  <meta name="description" content="4th of July Convention (Финикс): портрет события через очки Jack&Jill WSDC (черновик)">
-  <title>4th of July Convention: портрет события (черновик)</title>
+  <meta name="description" content="4TH of July Convention (Финикс): портрет события через очки Jack&Jill WSDC (черновик)">
+  <title>4TH of July Convention: портрет события (черновик)</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,650;9..144,700&family=Source+Sans+3:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
@@ -324,6 +324,25 @@
     .hbar.is-focus .hbar-value { color: var(--accent); }
     .hbar.is-muted .hbar-fill { background: rgba(26, 31, 46, 0.28); }
     .hbar.is-muted .hbar-meta { color: var(--muted); font-weight: 500; }
+    .peer-gap {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.55rem;
+      margin: 0.35rem 0 0.85rem;
+      color: var(--muted);
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .peer-gap::before,
+    .peer-gap::after {
+      content: "";
+      flex: 1;
+      height: 1px;
+      background: var(--line);
+    }
 
     .stack-era { margin: 1rem 0 0.25rem; width: 100%; }
     .stack-era-row { margin-bottom: 1.15rem; }
@@ -474,7 +493,7 @@
       <div class="article-header-wash"></div>
     </div>
     <div class="article-eyebrow">Цикл · история событий WSDC</div>
-    <h1 class="article-title">4th of July Convention</h1>
+    <h1 class="article-title">4TH of July Convention</h1>
     <p class="article-subtitle">Финикс, Аризона · 1991-2026 · 34 проведения в реестре WSDC</p>
   </header>
 
@@ -489,7 +508,7 @@
     <p class="series-lede">
       Первая статья посвящена ивенту с самой длинной историей проведения и учётным номером 1
       в реестре WSDC:
-      <a href="https://phoenix4thofjuly.com/" rel="noopener noreferrer" target="_blank">4th of July Convention</a>,
+      <a href="https://phoenix4thofjuly.com/" rel="noopener noreferrer" target="_blank">4TH of July Convention</a>,
       который проводится в Финиксе, Аризона, США.
     </p>
 
@@ -539,13 +558,15 @@
     <section class="section" aria-labelledby="peer-title">
       <h2 class="section-title" id="peer-title">Самая длинная, не самая большая</h2>
       <p>
-        Среди событий с 20 и более проведениями Jack&amp;Jill по уровням Arizona первая по числу лет
-        и только седьмая по числу танцоров с очками. Впереди MADjam, Boogie By The Bay, Capital Swing,
+        Среди событий с 20 и более проведениями Jack&amp;Jill по уровням
+        <strong>4TH of July Convention</strong> первый по числу лет
+        и только седьмой по числу танцоров с очками. Впереди MADjam, Boogie By The Bay, Capital Swing,
         Summer Hummer, Liberty Swing, Swing Fling. Рядом по объёму Boston Tea Party.
       </p>
       <p>
         Переключатель ниже показывает тот же круг длинных событий в двух срезах: кто вообще брал очки
-        на ивенте, и кто взял здесь свои первые очки WSDC. «Старый» не значит «крупный по реестру».
+        на ивенте, и кто взял здесь свои первые очки WSDC. В каждом срезе: топ-5, затем разрыв и место
+        4TH of July Convention в общем ранжировании.
       </p>
       <div class="metric-toggles" id="peerToggles" role="tablist" aria-label="Метрика сравнения длинных событий">
         <button type="button" role="tab" data-metric="unique_dancers" class="is-active" aria-selected="true">С очками</button>
@@ -554,7 +575,7 @@
       <div class="bar-chart" id="peerBars" aria-label="Длинные события по выбранной метрике"></div>
       <p class="footnote" id="peerFoot">
         Jack&amp;Jill по уровням · события с ≥20 годами в реестре.
-        Показаны шесть лидеров и Arizona. Подсветка: Phoenix 4th of July.
+        Топ-5 и отдельно 4TH of July Convention с его местом в полном ранжировании.
       </p>
     </section>
 
@@ -615,12 +636,12 @@
     <section class="section" aria-labelledby="launch-title">
       <h2 class="section-title" id="launch-title">Куда уходят те, кто стартовал здесь</h2>
       <p>
-        Для 245 танцоров Arizona стала первым событием с очками WSDC:
+        Для 245 танцоров 4TH of July Convention стал первым событием с очками WSDC:
         около 18% всех, кто когда-либо оставлял здесь очки Jack&amp;Jill по уровням.
       </p>
       <p>
         Дальше карьера почти всегда уходит в остальной календарь. У тех, кто добрался до All-Star
-        и выше, медиана доли карьерных очков вне Arizona около 87%.
+        и выше, медиана доли карьерных очков вне 4TH of July Convention около 87%.
         Чаще вход, чем место, где копят основную массу очков.
       </p>
       <div class="insight-kpis" id="launchKpis"></div>
@@ -649,7 +670,7 @@
     <section class="section" aria-labelledby="ret-title">
       <h2 class="section-title" id="ret-title">Кто возвращается</h2>
       <p>
-        Большинство оставляет след один раз: 63% танцоров с очками на Arizona были здесь
+        Большинство оставляет след один раз: 63% танцоров с очками на 4TH of July Convention были здесь
         только в одном проведении. Три и больше: около 15%.
         Линию держит относительно тонкое ядро регулярных.
       </p>
@@ -702,7 +723,7 @@
 
     <section class="section">
       <p class="closing">
-        Arizona держит самую длинную линию Jack&amp;Jill по уровням в реестре при среднем объёме очков,
+        4TH of July Convention держит самую длинную линию Jack&amp;Jill по уровням в реестре при среднем объёме очков,
         кормит в основном Novice, Intermediate и Advanced и регулярно выпускает стартовавших дальше по календарю.
         Для части это первая запись в WSDC. Для большинства с очками здесь: одно проведение.
         Портрет одного якоря, не рейтинг.
@@ -752,7 +773,7 @@
       </li>
       <li>
         <a href="https://worldsdc.com/hall-of-fame/robert-bryant-1993/" rel="noopener noreferrer" target="_blank">worldsdc.com · Robert Bryant (зал славы, 1993)</a>
-        — один из десяти основателей GPSDC и 4th of July Convention in Phoenix.
+        — один из десяти основателей GPSDC и 4TH of July Convention in Phoenix.
       </li>
       <li>
         <a href="https://worldsdc.com/playground-event-list/" rel="noopener noreferrer" target="_blank">worldsdc.com/playground-event-list</a>
@@ -772,7 +793,7 @@
 </div>
 
 
-<script id="event-metrics" type="application/json">{"event_id":1,"generated":"2026-07-17","definitions":{"skill_jj":"West Coast Swing + Newcomer/Novice/Intermediate/Advanced/All-Star/Champion, points > 0","new_dancers":"dancers whose first-ever WSDC points row (any division, points>0) is Skill JJ at this event","wins":"result_standardized = '1' at this event (Skill JJ)","started_here_notable":"first WSDC points at this event AND Champion points in calendar years >= (max_year - 19); here >= 2007 (last 20 years)","pairs":"All-Star/Champion place-matched Leader+Follower with same result_standardized in {1,2,3,4,5} same event_year+division (JJ finals convention; not stored partner_id)","peer_context":"Among Skill JJ events with >=20 edition years; ranks by unique dancers / first-ever WSDC points at this event / edition years","launchpad":"first-ever WSDC points (any skill JJ result) at this event; highest division and career points share outside this event","division_era_mix":"Share of Skill JJ points at this event by division, aggregated by era (COVID gap years excluded from 2022–2026 bucket)","retention":"Return = scored points at this event in year Y and again in Y+1; editions = distinct years with points here"},"catalog":{"canonical_name":"4TH of July Convention","url":"http://phoenix4thofjuly.com","typical_location":"Phoenix, AZ","typical_city":"Phoenix","typical_state":"Arizona","typical_country":"United States","first_edition_year":1991,"last_edition_year":2026,"edition_count":34,"unique_dancers_all_divisions":1556,"total_result_rows_all_divisions":3169},"skill_jj_kpi":{"unique_dancers":1364,"total_points":8284,"result_rows":2313,"editions_with_results":34,"first_points_here":245,"first_points_share_pct":18.0,"peak_year_dancers":2009,"peak_dancers":100,"peak_year_points":2014,"peak_points":380,"peak_year_new_dancers":1994,"peak_new_dancers":17},"year_gaps":[2020,2021],"champ_window_from_year":2007,"timeseries":[{"event_year":1991,"unique_dancers":1,"total_points":10,"new_dancers":1},{"event_year":1992,"unique_dancers":18,"total_points":88,"new_dancers":11},{"event_year":1993,"unique_dancers":22,"total_points":128,"new_dancers":13},{"event_year":1994,"unique_dancers":25,"total_points":139,"new_dancers":17},{"event_year":1995,"unique_dancers":28,"total_points":142,"new_dancers":9},{"event_year":1996,"unique_dancers":31,"total_points":151,"new_dancers":12},{"event_year":1997,"unique_dancers":37,"total_points":42,"new_dancers":13},{"event_year":1998,"unique_dancers":66,"total_points":186,"new_dancers":16},{"event_year":1999,"unique_dancers":70,"total_points":190,"new_dancers":15},{"event_year":2000,"unique_dancers":62,"total_points":182,"new_dancers":5},{"event_year":2001,"unique_dancers":64,"total_points":184,"new_dancers":6},{"event_year":2002,"unique_dancers":70,"total_points":190,"new_dancers":8},{"event_year":2003,"unique_dancers":80,"total_points":240,"new_dancers":2},{"event_year":2004,"unique_dancers":80,"total_points":240,"new_dancers":1},{"event_year":2005,"unique_dancers":80,"total_points":240,"new_dancers":5},{"event_year":2006,"unique_dancers":76,"total_points":236,"new_dancers":2},{"event_year":2007,"unique_dancers":94,"total_points":366,"new_dancers":6},{"event_year":2008,"unique_dancers":90,"total_points":342,"new_dancers":8},{"event_year":2009,"unique_dancers":100,"total_points":370,"new_dancers":14},{"event_year":2010,"unique_dancers":80,"total_points":312,"new_dancers":4},{"event_year":2011,"unique_dancers":64,"total_points":230,"new_dancers":7},{"event_year":2012,"unique_dancers":79,"total_points":296,"new_dancers":8},{"event_year":2013,"unique_dancers":90,"total_points":373,"new_dancers":3},{"event_year":2014,"unique_dancers":88,"total_points":380,"new_dancers":2},{"event_year":2015,"unique_dancers":81,"total_points":292,"new_dancers":8},{"event_year":2016,"unique_dancers":92,"total_points":333,"new_dancers":3},{"event_year":2017,"unique_dancers":88,"total_points":329,"new_dancers":3},{"event_year":2018,"unique_dancers":64,"total_points":219,"new_dancers":8},{"event_year":2019,"unique_dancers":68,"total_points":239,"new_dancers":7},{"event_year":2022,"unique_dancers":66,"total_points":236,"new_dancers":7},{"event_year":2023,"unique_dancers":92,"total_points":348,"new_dancers":5},{"event_year":2024,"unique_dancers":78,"total_points":308,"new_dancers":4},{"event_year":2025,"unique_dancers":88,"total_points":352,"new_dancers":5},{"event_year":2026,"unique_dancers":92,"total_points":371,"new_dancers":7}],"division_cuts":[{"division":"Newcomer","unique_dancers":53,"total_points":229},{"division":"Novice","unique_dancers":586,"total_points":2643},{"division":"Intermediate","unique_dancers":454,"total_points":1864},{"division":"Advanced","unique_dancers":425,"total_points":1921},{"division":"All-Star","unique_dancers":203,"total_points":1101},{"division":"Champion","unique_dancers":58,"total_points":526}],"top5_by_metric":{"points":[{"dancer_name":"Robert Royston","points_here":47,"editions":11,"wins":4},{"dancer_name":"Michael Kielbasa","points_here":45,"editions":7,"wins":2},{"dancer_name":"Melissa Rutz","points_here":43,"editions":10,"wins":2},{"dancer_name":"Hannah Coda","points_here":39,"editions":4,"wins":2},{"dancer_name":"Danya Svir","points_here":39,"editions":4,"wins":2}],"editions":[{"dancer_name":"Robert Royston","points_here":47,"editions":11,"wins":4},{"dancer_name":"Benji Schwimmer","points_here":35,"editions":11,"wins":4},{"dancer_name":"Melissa Rutz","points_here":43,"editions":10,"wins":2},{"dancer_name":"Tatiana Mollmann","points_here":35,"editions":10,"wins":2},{"dancer_name":"Tony Schubert","points_here":27,"editions":9,"wins":0}],"wins":[{"dancer_name":"Robert Royston","points_here":47,"editions":11,"wins":4},{"dancer_name":"Benji Schwimmer","points_here":35,"editions":11,"wins":4},{"dancer_name":"Dayne Darden","points_here":34,"editions":4,"wins":3},{"dancer_name":"Tom Jennings","points_here":33,"editions":4,"wins":3},{"dancer_name":"Thomas Carter","points_here":27,"editions":4,"wins":3}]},"pairs_as_champ":{"method_note":"Place-matched Leader+Follower (same place 1–5) in All-Star/Champion at this event","by_wins":[{"leader_name":"Robert Royston","follower_name":"Torri Zzaoui","placed_together":3,"wins_together":1,"years":3},{"leader_name":"Robert Royston","follower_name":"Brandi Tobias","placed_together":2,"wins_together":1,"years":2},{"leader_name":"Kyle Redd","follower_name":"Deborah Szekely","placed_together":2,"wins_together":1,"years":2},{"leader_name":"Benji Schwimmer","follower_name":"Laureen Baldovi","placed_together":2,"wins_together":1,"years":2}],"by_placements":[{"leader_name":"Robert Royston","follower_name":"Torri Zzaoui","placed_together":3,"wins_together":1,"years":3},{"leader_name":"Kyle Redd","follower_name":"Deborah Szekely","placed_together":2,"wins_together":1,"years":2},{"leader_name":"Robert Royston","follower_name":"Brandi Tobias","placed_together":2,"wins_together":1,"years":2},{"leader_name":"Benji Schwimmer","follower_name":"Laureen Baldovi","placed_together":2,"wins_together":1,"years":2},{"leader_name":"PJ Turner","follower_name":"Melissa Rutz","placed_together":2,"wins_together":0,"years":2}]},"other_divisions_present":["Invitational","Juniors","Master","Professional","Teacher"],"header_candidates":["assets/hero_fullwidth.png","assets/logo_website.png","assets/logo_estd_1982.png"],"started_here_notable_champ_20y":[{"dancer_name":"Cameo Cross","event_year":2007,"champ_pts_20y":316,"last_champ_year":2026},{"dancer_name":"Katie Schneider","event_year":2000,"champ_pts_20y":41,"last_champ_year":2013},{"dancer_name":"Sharlot Bott","event_year":1992,"champ_pts_20y":37,"last_champ_year":2012},{"dancer_name":"Christopher Hussey","event_year":1999,"champ_pts_20y":14,"last_champ_year":2011},{"dancer_name":"Terry Roseborough","event_year":1999,"champ_pts_20y":8,"last_champ_year":2014},{"dancer_name":"Barry Jones","event_year":1992,"champ_pts_20y":8,"last_champ_year":2013},{"dancer_name":"Carlus Reed","event_year":2008,"champ_pts_20y":7,"last_champ_year":2015},{"dancer_name":"Gary Jobst","event_year":1994,"champ_pts_20y":7,"last_champ_year":2014}],"insights":{"peer_context":{"definition":"Among Skill JJ events with >=20 edition years in registry; ranks by unique dancers / edition years","this_event":"Phoenix 4th of July","editions":34,"unique_dancers":1364,"rank_by_editions":1,"rank_by_unique_among_long":7,"long_events_n":27,"events_total_n":370,"peers_top12_by_unique":[{"event_name":"MADjam","editions":21,"unique_dancers":1652,"total_points":11367,"is_this_event":false,"first_points_here":367},{"event_name":"Boogie By The Bay","editions":31,"unique_dancers":1519,"total_points":11052,"is_this_event":false,"first_points_here":184},{"event_name":"Capital Swing Dance Convention","editions":30,"unique_dancers":1518,"total_points":9210,"is_this_event":false,"first_points_here":329},{"event_name":"Summer Hummer","editions":25,"unique_dancers":1424,"total_points":8549,"is_this_event":false,"first_points_here":337},{"event_name":"Liberty Swing Dance Championships","editions":21,"unique_dancers":1418,"total_points":8356,"is_this_event":false,"first_points_here":243},{"event_name":"Swing Fling","editions":29,"unique_dancers":1370,"total_points":8358,"is_this_event":false,"first_points_here":402},{"event_name":"Phoenix 4th of July","editions":34,"unique_dancers":1364,"total_points":8284,"is_this_event":true,"first_points_here":245},{"event_name":"Boston Tea Party","editions":26,"unique_dancers":1343,"total_points":8173,"is_this_event":false,"first_points_here":402},{"event_name":"Easter Swing","editions":29,"unique_dancers":1286,"total_points":8581,"is_this_event":false,"first_points_here":258},{"event_name":"J&J O'Rama","editions":28,"unique_dancers":1279,"total_points":8554,"is_this_event":false,"first_points_here":141},{"event_name":"SwingTime","editions":31,"unique_dancers":1265,"total_points":7535,"is_this_event":false,"first_points_here":250},{"event_name":"Monterey Swing Fest","editions":31,"unique_dancers":1154,"total_points":7804,"is_this_event":false,"first_points_here":200}],"peers_top12_by_first_points":[{"event_name":"Swing Fling","editions":29,"unique_dancers":1336,"first_points_here":402,"total_points":8138,"is_this_event":false},{"event_name":"Boston Tea Party","editions":26,"unique_dancers":1281,"first_points_here":402,"total_points":7796,"is_this_event":false},{"event_name":"MADjam","editions":21,"unique_dancers":1652,"first_points_here":367,"total_points":11367,"is_this_event":false},{"event_name":"Summer Hummer","editions":25,"unique_dancers":1413,"first_points_here":337,"total_points":8468,"is_this_event":false},{"event_name":"Capital Swing Dance Convention","editions":30,"unique_dancers":1518,"first_points_here":329,"total_points":9210,"is_this_event":false},{"event_name":"Countdown Swing Boston","editions":22,"unique_dancers":937,"first_points_here":304,"total_points":5463,"is_this_event":false},{"event_name":"Easter Swing","editions":30,"unique_dancers":1359,"first_points_here":258,"total_points":9226,"is_this_event":false},{"event_name":"SwingTime","editions":31,"unique_dancers":1265,"first_points_here":250,"total_points":7535,"is_this_event":false},{"event_name":"Phoenix 4th of July","editions":34,"unique_dancers":1364,"first_points_here":245,"total_points":8284,"is_this_event":true},{"event_name":"Liberty Swing Dance Championships","editions":21,"unique_dancers":1418,"first_points_here":243,"total_points":8356,"is_this_event":false},{"event_name":"Bridgetown Swing Boogie","editions":21,"unique_dancers":806,"first_points_here":214,"total_points":5054,"is_this_event":false},{"event_name":"FreZno Dance Classic","editions":26,"unique_dancers":830,"first_points_here":202,"total_points":5289,"is_this_event":false}],"rank_by_first_points_among_long":9},"launchpad":{"definition":"first-ever WSDC points (any skill JJ result) at this event; highest division and career points share outside this event","starters_n":245,"reached_allstar_plus_n":31,"reached_allstar_plus_pct":12.7,"reached_champion_n":16,"reached_champion_pct":6.5,"median_months_to_allstar":76.0,"median_months_to_champion":69.0,"median_career_points_share_outside_pct":66.7,"as_plus_median_career_points_share_outside_pct":87.3,"highest_division_counts":[{"division":"Newcomer","n":14},{"division":"Novice","n":79},{"division":"Intermediate","n":59},{"division":"Advanced","n":62},{"division":"All-Star","n":15},{"division":"Champion","n":16}]},"division_era_mix":{"definition":"Share of Skill JJ points at this event by division, aggregated by era (COVID gap years excluded from 2022–2026 bucket)","eras":[{"era":"1991–1999","total_points":1076,"share_pct":{"Newcomer":18.5,"Novice":35.5,"Intermediate":11.5,"Advanced":34.5},"points":{"Newcomer":199,"Novice":382,"Intermediate":124,"Advanced":371}},{"era":"2000–2009","total_points":2590,"share_pct":{"Newcomer":1.2,"Novice":26.4,"Intermediate":24.9,"Advanced":24.7,"All-Star":17.3,"Champion":5.6},"points":{"Newcomer":30,"Novice":684,"Intermediate":644,"Advanced":640,"All-Star":448,"Champion":144}},{"era":"2010–2019","total_points":3003,"share_pct":{"Novice":33.8,"Intermediate":23.3,"Advanced":18.5,"All-Star":14.6,"Champion":9.8},"points":{"Novice":1016,"Intermediate":700,"Advanced":556,"All-Star":437,"Champion":294}},{"era":"2022–2026","total_points":1615,"share_pct":{"Novice":34.7,"Intermediate":24.5,"Advanced":21.9,"All-Star":13.4,"Champion":5.4},"points":{"Novice":561,"Intermediate":396,"Advanced":354,"All-Star":216,"Champion":88}}]},"retention":{"definition":"Return = scored points at this event in year Y and again in Y+1; editions = distinct years with points here","unique_dancers":1364,"one_edition_n":865,"one_edition_pct":63.4,"three_plus_editions_n":209,"three_plus_editions_pct":15.3,"five_plus_editions_n":55,"one_edition_points_share_pct":39.4,"five_plus_points_share_pct":13.8,"edition_histogram":[{"editions":1,"dancers":865},{"editions":2,"dancers":290},{"editions":3,"dancers":99},{"editions":4,"dancers":55},{"editions":5,"dancers":27},{"editions":6,"dancers":10},{"editions":7,"dancers":8},{"editions":8,"dancers":5},{"editions":9,"dancers":1},{"editions":10,"dancers":2},{"editions":11,"dancers":2}],"next_year_return":[{"from_year":2014,"to_year":2015,"base":88,"returned":20,"rate_pct":22.7},{"from_year":2015,"to_year":2016,"base":81,"returned":33,"rate_pct":40.7},{"from_year":2016,"to_year":2017,"base":92,"returned":22,"rate_pct":23.9},{"from_year":2017,"to_year":2018,"base":88,"returned":17,"rate_pct":19.3},{"from_year":2018,"to_year":2019,"base":64,"returned":18,"rate_pct":28.1},{"from_year":2022,"to_year":2023,"base":66,"returned":16,"rate_pct":24.2},{"from_year":2023,"to_year":2024,"base":92,"returned":12,"rate_pct":13.0},{"from_year":2024,"to_year":2025,"base":78,"returned":27,"rate_pct":34.6},{"from_year":2025,"to_year":2026,"base":88,"returned":27,"rate_pct":30.7}],"return_after_gap":{"from_year":2019,"to_year":2022,"base":68,"returned":14,"rate_pct":20.6,"note":"after COVID gap"},"recent_return_rate_range_pct":[13.0,40.7]}}}</script>
+<script id="event-metrics" type="application/json">{"event_id":1,"generated":"2026-07-17","definitions":{"skill_jj":"West Coast Swing + Newcomer/Novice/Intermediate/Advanced/All-Star/Champion, points > 0","new_dancers":"dancers whose first-ever WSDC points row (any division, points>0) is Skill JJ at this event","wins":"result_standardized = '1' at this event (Skill JJ)","started_here_notable":"first WSDC points at this event AND Champion points in calendar years >= (max_year - 19); here >= 2007 (last 20 years)","pairs":"All-Star/Champion place-matched Leader+Follower with same result_standardized in {1,2,3,4,5} same event_year+division (JJ finals convention; not stored partner_id)","peer_context":"Among Skill JJ events with >=20 edition years; ranks by unique dancers / first-ever WSDC points at this event / edition years","launchpad":"first-ever WSDC points (any skill JJ result) at this event; highest division and career points share outside this event","division_era_mix":"Share of Skill JJ points at this event by division, aggregated by era (COVID gap years excluded from 2022–2026 bucket)","retention":"Return = scored points at this event in year Y and again in Y+1; editions = distinct years with points here"},"catalog":{"canonical_name":"4TH of July Convention","url":"http://phoenix4thofjuly.com","typical_location":"Phoenix, AZ","typical_city":"Phoenix","typical_state":"Arizona","typical_country":"United States","first_edition_year":1991,"last_edition_year":2026,"edition_count":34,"unique_dancers_all_divisions":1556,"total_result_rows_all_divisions":3169},"skill_jj_kpi":{"unique_dancers":1364,"total_points":8284,"result_rows":2313,"editions_with_results":34,"first_points_here":245,"first_points_share_pct":18.0,"peak_year_dancers":2009,"peak_dancers":100,"peak_year_points":2014,"peak_points":380,"peak_year_new_dancers":1994,"peak_new_dancers":17},"year_gaps":[2020,2021],"champ_window_from_year":2007,"timeseries":[{"event_year":1991,"unique_dancers":1,"total_points":10,"new_dancers":1},{"event_year":1992,"unique_dancers":18,"total_points":88,"new_dancers":11},{"event_year":1993,"unique_dancers":22,"total_points":128,"new_dancers":13},{"event_year":1994,"unique_dancers":25,"total_points":139,"new_dancers":17},{"event_year":1995,"unique_dancers":28,"total_points":142,"new_dancers":9},{"event_year":1996,"unique_dancers":31,"total_points":151,"new_dancers":12},{"event_year":1997,"unique_dancers":37,"total_points":42,"new_dancers":13},{"event_year":1998,"unique_dancers":66,"total_points":186,"new_dancers":16},{"event_year":1999,"unique_dancers":70,"total_points":190,"new_dancers":15},{"event_year":2000,"unique_dancers":62,"total_points":182,"new_dancers":5},{"event_year":2001,"unique_dancers":64,"total_points":184,"new_dancers":6},{"event_year":2002,"unique_dancers":70,"total_points":190,"new_dancers":8},{"event_year":2003,"unique_dancers":80,"total_points":240,"new_dancers":2},{"event_year":2004,"unique_dancers":80,"total_points":240,"new_dancers":1},{"event_year":2005,"unique_dancers":80,"total_points":240,"new_dancers":5},{"event_year":2006,"unique_dancers":76,"total_points":236,"new_dancers":2},{"event_year":2007,"unique_dancers":94,"total_points":366,"new_dancers":6},{"event_year":2008,"unique_dancers":90,"total_points":342,"new_dancers":8},{"event_year":2009,"unique_dancers":100,"total_points":370,"new_dancers":14},{"event_year":2010,"unique_dancers":80,"total_points":312,"new_dancers":4},{"event_year":2011,"unique_dancers":64,"total_points":230,"new_dancers":7},{"event_year":2012,"unique_dancers":79,"total_points":296,"new_dancers":8},{"event_year":2013,"unique_dancers":90,"total_points":373,"new_dancers":3},{"event_year":2014,"unique_dancers":88,"total_points":380,"new_dancers":2},{"event_year":2015,"unique_dancers":81,"total_points":292,"new_dancers":8},{"event_year":2016,"unique_dancers":92,"total_points":333,"new_dancers":3},{"event_year":2017,"unique_dancers":88,"total_points":329,"new_dancers":3},{"event_year":2018,"unique_dancers":64,"total_points":219,"new_dancers":8},{"event_year":2019,"unique_dancers":68,"total_points":239,"new_dancers":7},{"event_year":2022,"unique_dancers":66,"total_points":236,"new_dancers":7},{"event_year":2023,"unique_dancers":92,"total_points":348,"new_dancers":5},{"event_year":2024,"unique_dancers":78,"total_points":308,"new_dancers":4},{"event_year":2025,"unique_dancers":88,"total_points":352,"new_dancers":5},{"event_year":2026,"unique_dancers":92,"total_points":371,"new_dancers":7}],"division_cuts":[{"division":"Newcomer","unique_dancers":53,"total_points":229},{"division":"Novice","unique_dancers":586,"total_points":2643},{"division":"Intermediate","unique_dancers":454,"total_points":1864},{"division":"Advanced","unique_dancers":425,"total_points":1921},{"division":"All-Star","unique_dancers":203,"total_points":1101},{"division":"Champion","unique_dancers":58,"total_points":526}],"top5_by_metric":{"points":[{"dancer_name":"Robert Royston","points_here":47,"editions":11,"wins":4},{"dancer_name":"Michael Kielbasa","points_here":45,"editions":7,"wins":2},{"dancer_name":"Melissa Rutz","points_here":43,"editions":10,"wins":2},{"dancer_name":"Hannah Coda","points_here":39,"editions":4,"wins":2},{"dancer_name":"Danya Svir","points_here":39,"editions":4,"wins":2}],"editions":[{"dancer_name":"Robert Royston","points_here":47,"editions":11,"wins":4},{"dancer_name":"Benji Schwimmer","points_here":35,"editions":11,"wins":4},{"dancer_name":"Melissa Rutz","points_here":43,"editions":10,"wins":2},{"dancer_name":"Tatiana Mollmann","points_here":35,"editions":10,"wins":2},{"dancer_name":"Tony Schubert","points_here":27,"editions":9,"wins":0}],"wins":[{"dancer_name":"Robert Royston","points_here":47,"editions":11,"wins":4},{"dancer_name":"Benji Schwimmer","points_here":35,"editions":11,"wins":4},{"dancer_name":"Dayne Darden","points_here":34,"editions":4,"wins":3},{"dancer_name":"Tom Jennings","points_here":33,"editions":4,"wins":3},{"dancer_name":"Thomas Carter","points_here":27,"editions":4,"wins":3}]},"pairs_as_champ":{"method_note":"Place-matched Leader+Follower (same place 1–5) in All-Star/Champion at this event","by_wins":[{"leader_name":"Robert Royston","follower_name":"Torri Zzaoui","placed_together":3,"wins_together":1,"years":3},{"leader_name":"Robert Royston","follower_name":"Brandi Tobias","placed_together":2,"wins_together":1,"years":2},{"leader_name":"Kyle Redd","follower_name":"Deborah Szekely","placed_together":2,"wins_together":1,"years":2},{"leader_name":"Benji Schwimmer","follower_name":"Laureen Baldovi","placed_together":2,"wins_together":1,"years":2}],"by_placements":[{"leader_name":"Robert Royston","follower_name":"Torri Zzaoui","placed_together":3,"wins_together":1,"years":3},{"leader_name":"Kyle Redd","follower_name":"Deborah Szekely","placed_together":2,"wins_together":1,"years":2},{"leader_name":"Robert Royston","follower_name":"Brandi Tobias","placed_together":2,"wins_together":1,"years":2},{"leader_name":"Benji Schwimmer","follower_name":"Laureen Baldovi","placed_together":2,"wins_together":1,"years":2},{"leader_name":"PJ Turner","follower_name":"Melissa Rutz","placed_together":2,"wins_together":0,"years":2}]},"other_divisions_present":["Invitational","Juniors","Master","Professional","Teacher"],"header_candidates":["assets/hero_fullwidth.png","assets/logo_website.png","assets/logo_estd_1982.png"],"started_here_notable_champ_20y":[{"dancer_name":"Cameo Cross","event_year":2007,"champ_pts_20y":316,"last_champ_year":2026},{"dancer_name":"Katie Schneider","event_year":2000,"champ_pts_20y":41,"last_champ_year":2013},{"dancer_name":"Sharlot Bott","event_year":1992,"champ_pts_20y":37,"last_champ_year":2012},{"dancer_name":"Christopher Hussey","event_year":1999,"champ_pts_20y":14,"last_champ_year":2011},{"dancer_name":"Terry Roseborough","event_year":1999,"champ_pts_20y":8,"last_champ_year":2014},{"dancer_name":"Barry Jones","event_year":1992,"champ_pts_20y":8,"last_champ_year":2013},{"dancer_name":"Carlus Reed","event_year":2008,"champ_pts_20y":7,"last_champ_year":2015},{"dancer_name":"Gary Jobst","event_year":1994,"champ_pts_20y":7,"last_champ_year":2014}],"insights":{"peer_context":{"definition":"Among Skill JJ events with >=20 edition years in registry; ranks by unique dancers / edition years","this_event":"4TH of July Convention","editions":34,"unique_dancers":1364,"rank_by_editions":1,"rank_by_unique_among_long":7,"long_events_n":27,"events_total_n":370,"peers_top12_by_unique":[{"event_name":"MADjam","editions":21,"unique_dancers":1652,"total_points":11367,"is_this_event":false,"first_points_here":367},{"event_name":"Boogie By The Bay","editions":31,"unique_dancers":1519,"total_points":11052,"is_this_event":false,"first_points_here":184},{"event_name":"Capital Swing Dance Convention","editions":30,"unique_dancers":1518,"total_points":9210,"is_this_event":false,"first_points_here":329},{"event_name":"Summer Hummer","editions":25,"unique_dancers":1424,"total_points":8549,"is_this_event":false,"first_points_here":337},{"event_name":"Liberty Swing Dance Championships","editions":21,"unique_dancers":1418,"total_points":8356,"is_this_event":false,"first_points_here":243},{"event_name":"Swing Fling","editions":29,"unique_dancers":1370,"total_points":8358,"is_this_event":false,"first_points_here":402},{"event_name":"4TH of July Convention","editions":34,"unique_dancers":1364,"total_points":8284,"is_this_event":true,"first_points_here":245},{"event_name":"Boston Tea Party","editions":26,"unique_dancers":1343,"total_points":8173,"is_this_event":false,"first_points_here":402},{"event_name":"Easter Swing","editions":29,"unique_dancers":1286,"total_points":8581,"is_this_event":false,"first_points_here":258},{"event_name":"J&J O'Rama","editions":28,"unique_dancers":1279,"total_points":8554,"is_this_event":false,"first_points_here":141},{"event_name":"SwingTime","editions":31,"unique_dancers":1265,"total_points":7535,"is_this_event":false,"first_points_here":250},{"event_name":"Monterey Swing Fest","editions":31,"unique_dancers":1154,"total_points":7804,"is_this_event":false,"first_points_here":200}],"peers_top12_by_first_points":[{"event_name":"Swing Fling","editions":29,"unique_dancers":1336,"first_points_here":402,"total_points":8138,"is_this_event":false},{"event_name":"Boston Tea Party","editions":26,"unique_dancers":1281,"first_points_here":402,"total_points":7796,"is_this_event":false},{"event_name":"MADjam","editions":21,"unique_dancers":1652,"first_points_here":367,"total_points":11367,"is_this_event":false},{"event_name":"Summer Hummer","editions":25,"unique_dancers":1413,"first_points_here":337,"total_points":8468,"is_this_event":false},{"event_name":"Capital Swing Dance Convention","editions":30,"unique_dancers":1518,"first_points_here":329,"total_points":9210,"is_this_event":false},{"event_name":"Countdown Swing Boston","editions":22,"unique_dancers":937,"first_points_here":304,"total_points":5463,"is_this_event":false},{"event_name":"Easter Swing","editions":30,"unique_dancers":1359,"first_points_here":258,"total_points":9226,"is_this_event":false},{"event_name":"SwingTime","editions":31,"unique_dancers":1265,"first_points_here":250,"total_points":7535,"is_this_event":false},{"event_name":"4TH of July Convention","editions":34,"unique_dancers":1364,"first_points_here":245,"total_points":8284,"is_this_event":true},{"event_name":"Liberty Swing Dance Championships","editions":21,"unique_dancers":1418,"first_points_here":243,"total_points":8356,"is_this_event":false},{"event_name":"Bridgetown Swing Boogie","editions":21,"unique_dancers":806,"first_points_here":214,"total_points":5054,"is_this_event":false},{"event_name":"FreZno Dance Classic","editions":26,"unique_dancers":830,"first_points_here":202,"total_points":5289,"is_this_event":false}],"rank_by_first_points_among_long":9},"launchpad":{"definition":"first-ever WSDC points (any skill JJ result) at this event; highest division and career points share outside this event","starters_n":245,"reached_allstar_plus_n":31,"reached_allstar_plus_pct":12.7,"reached_champion_n":16,"reached_champion_pct":6.5,"median_months_to_allstar":76.0,"median_months_to_champion":69.0,"median_career_points_share_outside_pct":66.7,"as_plus_median_career_points_share_outside_pct":87.3,"highest_division_counts":[{"division":"Newcomer","n":14},{"division":"Novice","n":79},{"division":"Intermediate","n":59},{"division":"Advanced","n":62},{"division":"All-Star","n":15},{"division":"Champion","n":16}]},"division_era_mix":{"definition":"Share of Skill JJ points at this event by division, aggregated by era (COVID gap years excluded from 2022–2026 bucket)","eras":[{"era":"1991–1999","total_points":1076,"share_pct":{"Newcomer":18.5,"Novice":35.5,"Intermediate":11.5,"Advanced":34.5},"points":{"Newcomer":199,"Novice":382,"Intermediate":124,"Advanced":371}},{"era":"2000–2009","total_points":2590,"share_pct":{"Newcomer":1.2,"Novice":26.4,"Intermediate":24.9,"Advanced":24.7,"All-Star":17.3,"Champion":5.6},"points":{"Newcomer":30,"Novice":684,"Intermediate":644,"Advanced":640,"All-Star":448,"Champion":144}},{"era":"2010–2019","total_points":3003,"share_pct":{"Novice":33.8,"Intermediate":23.3,"Advanced":18.5,"All-Star":14.6,"Champion":9.8},"points":{"Novice":1016,"Intermediate":700,"Advanced":556,"All-Star":437,"Champion":294}},{"era":"2022–2026","total_points":1615,"share_pct":{"Novice":34.7,"Intermediate":24.5,"Advanced":21.9,"All-Star":13.4,"Champion":5.4},"points":{"Novice":561,"Intermediate":396,"Advanced":354,"All-Star":216,"Champion":88}}]},"retention":{"definition":"Return = scored points at this event in year Y and again in Y+1; editions = distinct years with points here","unique_dancers":1364,"one_edition_n":865,"one_edition_pct":63.4,"three_plus_editions_n":209,"three_plus_editions_pct":15.3,"five_plus_editions_n":55,"one_edition_points_share_pct":39.4,"five_plus_points_share_pct":13.8,"edition_histogram":[{"editions":1,"dancers":865},{"editions":2,"dancers":290},{"editions":3,"dancers":99},{"editions":4,"dancers":55},{"editions":5,"dancers":27},{"editions":6,"dancers":10},{"editions":7,"dancers":8},{"editions":8,"dancers":5},{"editions":9,"dancers":1},{"editions":10,"dancers":2},{"editions":11,"dancers":2}],"next_year_return":[{"from_year":2014,"to_year":2015,"base":88,"returned":20,"rate_pct":22.7},{"from_year":2015,"to_year":2016,"base":81,"returned":33,"rate_pct":40.7},{"from_year":2016,"to_year":2017,"base":92,"returned":22,"rate_pct":23.9},{"from_year":2017,"to_year":2018,"base":88,"returned":17,"rate_pct":19.3},{"from_year":2018,"to_year":2019,"base":64,"returned":18,"rate_pct":28.1},{"from_year":2022,"to_year":2023,"base":66,"returned":16,"rate_pct":24.2},{"from_year":2023,"to_year":2024,"base":92,"returned":12,"rate_pct":13.0},{"from_year":2024,"to_year":2025,"base":78,"returned":27,"rate_pct":34.6},{"from_year":2025,"to_year":2026,"base":88,"returned":27,"rate_pct":30.7}],"return_after_gap":{"from_year":2019,"to_year":2022,"base":68,"returned":14,"rate_pct":20.6,"note":"after COVID gap"},"recent_return_rate_range_pct":[13.0,40.7]}}}</script>
 <script>
 
 (function () {
@@ -794,12 +815,17 @@
   }
 
   function shortEventName(name) {
-    if (name === "Phoenix 4th of July") return "Phoenix 4th of July";
-    return name
+    if (!name) return "";
+    if (name === "Phoenix 4th of July" || name === "4TH of July Convention") {
+      return "4TH of July Convention";
+    }
+    return String(name)
+      .replace("Mid-Atlantic Dance Jam", "MADjam")
       .replace(" Dance Championships", "")
       .replace(" Championships", "")
       .replace(" Dance Convention", "")
-      .replace(" Convention", "");
+      .replace(" Convention", "")
+      .trim();
   }
 
   function hbar(label, valueText, pct, focus, muted) {
@@ -820,31 +846,42 @@
     const all = key === "first_points_here"
       ? (pc.peers_top12_by_first_points || [])
       : (pc.peers_top12_by_unique || []);
-    const top = all.slice(0, 6);
-    const self = all.find((r) => r.is_this_event);
-    const rows = self && !top.some((r) => r.is_this_event) ? top.concat([self]) : top;
+    const rank = key === "first_points_here"
+      ? (pc.rank_by_first_points_among_long || 9)
+      : (pc.rank_by_unique_among_long || 7);
+    const self = all.find((r) => r.is_this_event) || {
+      event_name: "4TH of July Convention",
+      editions: pc.editions,
+      unique_dancers: pc.unique_dancers,
+      first_points_here: M.skill_jj_kpi.first_points_here,
+      is_this_event: true
+    };
+    const topN = 5;
+    const leaders = all.filter((r) => !r.is_this_event).slice(0, topN);
+    const selfInTop = rank <= topN;
+    const rows = selfInTop
+      ? all.slice(0, topN).map((r, i) => ({ ...r, _rank: i + 1 }))
+      : leaders.map((r, i) => ({ ...r, _rank: i + 1 })).concat([{ ...self, _rank: rank }]);
     const max = Math.max(...rows.map((r) => r[key] || 0), 1);
-    document.getElementById("peerBars").innerHTML = rows.map((r) => {
+    const parts = [];
+    rows.forEach((r, idx) => {
+      if (!selfInTop && idx === topN) {
+        parts.push(`<div class="peer-gap" aria-hidden="true">место ${rank}</div>`);
+      }
       const v = r[key] || 0;
       const w = ((100 * v) / max).toFixed(1);
-      return hbar(
-        shortEventName(r.event_name),
-        `${v} · ${r.editions} пр.`,
-        w,
-        r.is_this_event,
-        false
-      );
-    }).join("");
-    const rank = key === "first_points_here"
-      ? (pc.rank_by_first_points_among_long || (rows.findIndex((r) => r.is_this_event) + 1))
-      : (pc.rank_by_unique_among_long || 7);
+      const label = `#${r._rank} ${shortEventName(r.event_name)}`;
+      parts.push(hbar(label, `${v} · ${r.editions} пр.`, w, !!r.is_this_event, false));
+    });
+    document.getElementById("peerBars").innerHTML = parts.join("");
     const foot = document.getElementById("peerFoot");
     if (foot) {
       const what = key === "first_points_here"
         ? "по числу танцоров, у которых первые очки WSDC вообще были Skill JJ на этом событии"
         : "по числу танцоров с очками на событии";
       foot.textContent =
-        `Jack&Jill по уровням · события с ≥20 годами в реестре. Показаны шесть лидеров ${what} и Arizona (${rank}-е место). Подсветка: Phoenix 4th of July.`;
+        `Jack&Jill по уровням · события с ≥20 годами в реестре · ${what}. ` +
+        `Топ-${topN}, затем 4TH of July Convention: ${rank}-е место из ${pc.long_events_n || "…"} длинных событий.`;
     }
   }
 
@@ -882,7 +919,7 @@
   function renderLaunch() {
     const L = M.insights.launchpad;
     document.getElementById("launchKpis").innerHTML = [
-      ["Стартов здесь", L.starters_n, "первые очки WSDC на Arizona"],
+      ["Стартов здесь", L.starters_n, "первые очки WSDC на 4TH of July Convention"],
       ["Дошли до All-Star+", `${String(L.reached_allstar_plus_pct).replace(".", ",")}%`, `${L.reached_allstar_plus_n} из ${L.starters_n}`],
       ["До Champion", `${String(L.reached_champion_pct).replace(".", ",")}%`, `${L.reached_champion_n} из ${L.starters_n}`]
     ].map(([lab, val, note]) =>
@@ -898,7 +935,7 @@
     document.getElementById("launchFoot").innerHTML =
       `Высший дивизион карьеры среди стартовавших здесь. Медиана до первого All-Star ≈ ${Math.round(L.median_months_to_allstar / 12)} лет, ` +
       `до Champion ≈ ${Math.round(L.median_months_to_champion / 12)} лет. ` +
-      `У All-Star и выше медиана доли карьерных очков вне Arizona: ${String(L.as_plus_median_career_points_share_outside_pct).replace(".", ",")}%.`;
+      `У All-Star и выше медиана доли карьерных очков вне 4TH of July Convention: ${String(L.as_plus_median_career_points_share_outside_pct).replace(".", ",")}%.`;
   }
 
   function renderRetention() {
@@ -919,7 +956,7 @@
       return hbar(label, String(h.dancers), w, focus, h.editions === "5+");
     }).join("");
     document.getElementById("retFoot").textContent =
-      "Сколько разных лет танцор оставлял очки Jack&Jill по уровням именно на Arizona. " +
+      "Сколько разных лет танцор оставлял очки Jack&Jill по уровням именно на 4TH of July Convention. " +
       `5+ проведений: ${R.five_plus_editions_n} человек и ${String(R.five_plus_points_share_pct).replace(".", ",")}% всех очков события.`;
   }
 

--- a/events/001-arizona-4th-of-july/metrics/metrics.json
+++ b/events/001-arizona-4th-of-july/metrics/metrics.json
@@ -515,7 +515,7 @@
   "insights": {
     "peer_context": {
       "definition": "Among Skill JJ events with >=20 edition years in registry; ranks by unique dancers / edition years",
-      "this_event": "Phoenix 4th of July",
+      "this_event": "4TH of July Convention",
       "editions": 34,
       "unique_dancers": 1364,
       "rank_by_editions": 1,
@@ -572,7 +572,7 @@
           "first_points_here": 402
         },
         {
-          "event_name": "Phoenix 4th of July",
+          "event_name": "4TH of July Convention",
           "editions": 34,
           "unique_dancers": 1364,
           "total_points": 8284,
@@ -686,7 +686,7 @@
           "is_this_event": false
         },
         {
-          "event_name": "Phoenix 4th of July",
+          "event_name": "4TH of July Convention",
           "editions": 34,
           "unique_dancers": 1364,
           "first_points_here": 245,


### PR DESCRIPTION
## Summary
- Peer comparison chart: top-5 leaders, visual gap, then **4TH of July Convention** with explicit rank (#7 unique / #9 first-points)
- Unify event naming to registry form `4TH of July Convention` in title, body, metrics, and chart labels (calendar aliases stay in footer sources)

## Test plan
- [ ] Open draft: peer toggle «С очками» shows top-5 + gap + `#7 4TH of July Convention`
- [ ] Toggle «Первые очки» shows gap + `#9`
- [ ] No «Phoenix 4th of July» as the main event name in body/title
- [ ] Footer still mentions short calendar name as alias


Made with [Cursor](https://cursor.com)