### PR TITLE
Justify article text without hyphens

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -127,8 +127,11 @@
       margin: 0;
       text-align: justify;
       text-justify: inter-word;
-      hyphens: auto;
-      -webkit-hyphens: auto;
+      hyphens: none;
+      -webkit-hyphens: none;
+      -ms-hyphens: none;
+      word-break: normal;
+      overflow-wrap: normal;
     }
     .article-rail .section-title,
     .article-rail .snapshot,
@@ -411,6 +414,10 @@
       width: 100%;
       text-align: justify;
       text-justify: inter-word;
+      hyphens: none;
+      -webkit-hyphens: none;
+      word-break: normal;
+      overflow-wrap: normal;
       margin-bottom: 0.85rem;
     }
     .data-note:last-child { margin-bottom: 0; }


### PR DESCRIPTION
## Summary
- Body/footer stay `text-align: justify`
- Disable hyphenation (`hyphens: none`) so words do not break mid-word

## Test plan
- [ ] Paragraphs still flush left and right
- [ ] No hyphenated line breaks in Russian body copy


Made with [Cursor](https://cursor.com)