### PR TITLE
Skill Level tooltips + поинты wording

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -621,7 +621,7 @@
           <span class="snapshot-info">
             <span class="info-icon" tabindex="0" role="img" aria-label="Пояснение: уникальные танцоры с очками на этом ивенте">
               <span aria-hidden="true">i</span>
-              <span class="info-tooltip">Количество уникальных танцоров, которые когда-либо получали очки на этом ивенте (Jack&amp;Jill по уровням).</span>
+              <span class="info-tooltip">Количество уникальных танцоров, которые когда-либо получали очки на этом ивенте в Skill Level номинациях (Newcomer–Champion).</span>
             </span>
           </span>
         </div>
@@ -634,7 +634,7 @@
           <span class="snapshot-info">
             <span class="info-icon" tabindex="0" role="img" aria-label="Пояснение: первые очки WSDC именно на этом ивенте">
               <span aria-hidden="true">i</span>
-              <span class="info-tooltip">Количество танцоров, получивших свои первые очки WSDC именно на этом ивенте.</span>
+              <span class="info-tooltip">Количество танцоров, получивших свои первые очки WSDC именно на этом ивенте — и именно в Skill Level номинации.</span>
             </span>
           </span>
         </div>

--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="noindex,nofollow">
-  <meta name="description" content="4TH of July Convention (Финикс): портрет события через очки Jack&Jill WSDC (черновик)">
+  <meta name="description" content="4TH of July Convention (Финикс): портрет события через поинты Jack&Jill WSDC (черновик)">
   <title>4TH of July Convention: портрет события (черновик)</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -619,9 +619,9 @@
         <div class="snapshot-label">
           Танцоры
           <span class="snapshot-info">
-            <span class="info-icon" tabindex="0" role="img" aria-label="Пояснение: уникальные танцоры с очками на этом ивенте">
+            <span class="info-icon" tabindex="0" role="img" aria-label="Пояснение: уникальные танцоры с поинтами на этом ивенте">
               <span aria-hidden="true">i</span>
-              <span class="info-tooltip">Количество уникальных танцоров, которые когда-либо получали очки на этом ивенте в Skill Level номинациях (Newcomer–Champion).</span>
+              <span class="info-tooltip">Количество уникальных танцоров, которые когда-либо получали поинты на этом ивенте в Skill Level номинациях (Newcomer–Champion).</span>
             </span>
           </span>
         </div>
@@ -632,9 +632,9 @@
         <div class="snapshot-label">
           Новые танцоры
           <span class="snapshot-info">
-            <span class="info-icon" tabindex="0" role="img" aria-label="Пояснение: первые очки WSDC именно на этом ивенте">
+            <span class="info-icon" tabindex="0" role="img" aria-label="Пояснение: первые поинты WSDC именно на этом ивенте">
               <span aria-hidden="true">i</span>
-              <span class="info-tooltip">Количество танцоров, получивших свои первые очки WSDC именно на этом ивенте — и именно в Skill Level номинации.</span>
+              <span class="info-tooltip">Количество танцоров, получивших свои первые поинты WSDC именно на этом ивенте — и именно в Skill Level номинации.</span>
             </span>
           </span>
         </div>
@@ -648,17 +648,17 @@
       <p>
         Среди всех ивентов с Jack&amp;Jill по уровням
         <strong>4TH of July Convention</strong> первый по числу лет
-        и только шестой по числу танцоров с очками. Впереди MADjam, Capital Swing, Boogie By The Bay,
+        и только шестой по числу танцоров с поинтами. Впереди MADjam, Capital Swing, Boogie By The Bay,
         Liberty Swing, Summer Hummer. Рядом по объёму Easter Swing.
       </p>
       <p>
-        Переключатель ниже показывает два среза по всем ивентам: кто вообще брал очки
-        на ивенте, и кто взял здесь свои первые очки WSDC. В каждом срезе: топ-5, затем разрыв и место
+        Переключатель ниже показывает два среза по всем ивентам: кто вообще брал поинты
+        на ивенте, и кто взял здесь свои первые поинты WSDC. В каждом срезе: топ-5, затем разрыв и место
         4TH of July Convention в общем ранжировании.
       </p>
       <div class="metric-toggles" id="peerToggles" role="tablist" aria-label="Метрика сравнения ивентов">
-        <button type="button" role="tab" data-metric="unique_dancers" class="is-active" aria-selected="true">С очками</button>
-        <button type="button" role="tab" data-metric="first_points_here" aria-selected="false">Первые очки</button>
+        <button type="button" role="tab" data-metric="unique_dancers" class="is-active" aria-selected="true">С поинтами</button>
+        <button type="button" role="tab" data-metric="first_points_here" aria-selected="false">Первые поинты</button>
       </div>
       <div class="bar-chart" id="peerBars" aria-label="Ивенты по выбранной метрике"></div>
       <p class="footnote" id="peerFoot">
@@ -670,17 +670,17 @@
     <section class="section" aria-labelledby="traj-title">
       <h2 class="section-title" id="traj-title">Что видно по годам</h2>
       <p>
-        После пропуска 2020-2021 ряд снова плотный: 66-92 танцоров с очками, 236-371 очков за год.
+        После пропуска 2020-2021 ряд снова плотный: 66-92 танцоров с поинтами, 236-371 поинтов за год.
         Близко к сильным годам 2010-х, без резкого провала после возвращения.
       </p>
       <p>
-        Пик по танцорам с очками: 2009 (100). По сумме очков: 2014 (380).
-        Больше всего «новых» (первые очки WSDC именно здесь) было в ранние годы реестра:
+        Пик по танцорам с поинтами: 2009 (100). По сумме поинтов: 2014 (380).
+        Больше всего «новых» (первые поинты WSDC именно здесь) было в ранние годы реестра:
         в 1994 таких 17. Сейчас обычно единицы или небольшой десяток в год.
       </p>
       <div class="metric-toggles" id="trajToggles" role="tablist" aria-label="Метрика траектории">
-        <button type="button" role="tab" data-metric="unique_dancers" class="is-active" aria-selected="true">С очками</button>
-        <button type="button" role="tab" data-metric="total_points" aria-selected="false">Очки</button>
+        <button type="button" role="tab" data-metric="unique_dancers" class="is-active" aria-selected="true">С поинтами</button>
+        <button type="button" role="tab" data-metric="total_points" aria-selected="false">Поинты</button>
         <button type="button" role="tab" data-metric="new_dancers" aria-selected="false">Новые</button>
       </div>
       <div class="figure figure-chart chart-wrap">
@@ -696,27 +696,27 @@
     <section class="section" aria-labelledby="era-title">
       <h2 class="section-title" id="era-title">Как менялся состав дивизионов</h2>
       <p>
-        Сумма за всё время по дивизионам мало что даёт: Novice почти всегда сверху, там просто больше записей с очками.
-        Интереснее доли очков по эпохам.
+        Сумма за всё время по дивизионам мало что даёт: Novice почти всегда сверху, там просто больше записей с поинтами.
+        Интереснее доли поинтов по эпохам.
       </p>
       <p>
-        В 1990-х Advanced держал около трети очков события. К 2010-м и особенно к 2022-2026 картина
+        В 1990-х Advanced держал около трети поинтов события. К 2010-м и особенно к 2022-2026 картина
         осела вокруг среднего уровня: примерно треть у Novice, рядом Intermediate и Advanced,
         старшие дивизионы заметно тоньше.
       </p>
       <p>
-        Отдельно уходит Newcomer. Все его очки на этом событии: 1993-1997 и всплеск в 2009 (30 очков).
+        Отдельно уходит Newcomer. Все его поинты на этом событии: 1993-1997 и всплеск в 2009 (30 поинтов).
         С 2010 по 2026: ноль. На диаграмме за две последние эпохи серого сегмента нет; это не баг графика.
       </p>
       <p>
         Сайт сейчас перечисляет дивизионы Jack&amp;Jill так: Novice, Intermediate, Advanced, All Star, Champion.
         Newcomer как уровень WSDC там не указан; номер WSDC просят «для Novice и выше».
         Newcomer Bootcamp на главной (так названо на сайте) похож на программу или воркшоп,
-        а не на Jack&amp;Jill с очками в реестре.
+        а не на Jack&amp;Jill с поинтами в реестре.
       </p>
-      <div id="eraBars" aria-label="Доля очков по дивизионам и эпохам"></div>
+      <div id="eraBars" aria-label="Доля поинтов по дивизионам и эпохам"></div>
       <p class="footnote">
-        Доля очков Jack&amp;Jill по уровням внутри эпохи. 2020-2021 в расчёт не входят.
+        Доля поинтов Jack&amp;Jill по уровням внутри эпохи. 2020-2021 в расчёт не входят.
         Внешние источники по дивизионам и истории клуба: см. футер.
       </p>
     </section>
@@ -724,13 +724,13 @@
     <section class="section" aria-labelledby="launch-title">
       <h2 class="section-title" id="launch-title">Куда уходят те, кто стартовал здесь</h2>
       <p>
-        Для 245 танцоров 4TH of July Convention стал первым событием с очками WSDC:
-        около 18% всех, кто когда-либо оставлял здесь очки Jack&amp;Jill по уровням.
+        Для 245 танцоров 4TH of July Convention стал первым событием с поинтами WSDC:
+        около 18% всех, кто когда-либо оставлял здесь поинты Jack&amp;Jill по уровням.
       </p>
       <p>
         Дальше карьера почти всегда уходит в остальной календарь. У тех, кто добрался до All-Star
-        и выше, медиана доли карьерных очков вне 4TH of July Convention около 87%.
-        Чаще вход, чем место, где копят основную массу очков.
+        и выше, медиана доли карьерных поинтов вне 4TH of July Convention около 87%.
+        Чаще вход, чем место, где копят основную массу поинтов.
       </p>
       <div class="insight-kpis" id="launchKpis"></div>
       <p>
@@ -740,7 +740,7 @@
       <div class="bar-chart" id="launchBars" aria-label="Высший дивизион стартовавших здесь"></div>
       <p class="footnote" id="launchFoot"></p>
       <p>
-        Из тех, кто взял первые очки именно здесь и потом набрал очки Champion за последние 20 лет
+        Из тех, кто взял первые поинты именно здесь и потом набрал поинты Champion за последние 20 лет
         (с 2007), есть и «старая школа», и более свежий пример:
       </p>
       <ul class="name-list">
@@ -748,7 +748,7 @@
         <li>Katie Schneider: старт в 2000</li>
         <li>Sharlot Bott: старт в 1992</li>
         <li>Christopher Hussey: старт в 1999</li>
-        <li>Mackenzie Keister: старт в 2022, уже с очками Champion</li>
+        <li>Mackenzie Keister: старт в 2022, уже с поинтами Champion</li>
       </ul>
       <p>
         Не фабрика чемпионов. Редкий след: из 245 стартов до Champion добрались 16 человек.
@@ -758,12 +758,12 @@
     <section class="section" aria-labelledby="ret-title">
       <h2 class="section-title" id="ret-title">Кто возвращается</h2>
       <p>
-        Большинство оставляет след один раз: 63% танцоров с очками на 4TH of July Convention были здесь
+        Большинство оставляет след один раз: 63% танцоров с поинтами на 4TH of July Convention были здесь
         только в одном проведении. Три и больше: около 15%.
         Линию держит относительно тонкое ядро регулярных.
       </p>
       <p>
-        Доля вернувшихся на следующий год (очки в Y и снова в Y+1) обычно между 13% и 41%.
+        Доля вернувшихся на следующий год (поинты в Y и снова в Y+1) обычно между 13% и 41%.
         Самый слабый недавний сезон: 2023→2024, 13%.
         После пропуска 2019→2022 вернулись около 21% из тех, кто был в 2019.
       </p>
@@ -774,16 +774,16 @@
     <section class="section" aria-labelledby="people-title">
       <h2 class="section-title" id="people-title">Кто оставлял след чаще всего</h2>
       <p>
-        Топ на этом событии не равен глобальному рейтингу. Здесь видно, кто чаще набирал очки,
+        Топ на этом событии не равен глобальному рейтингу. Здесь видно, кто чаще набирал поинты,
         возвращался или выигрывал именно в Финиксе.
       </p>
       <p>
-        По очкам: Robert Royston, Michael Kielbasa, Melissa Rutz.
+        По поинтам: Robert Royston, Michael Kielbasa, Melissa Rutz.
         По проведениям рядом Royston и Benji Schwimmer (по 11).
         По победам снова они (по 4), дальше Dayne Darden, Tom Jennings, Thomas Carter.
       </p>
       <div class="metric-toggles" id="peopleToggles" role="tablist" aria-label="Метрика топ-5">
-        <button type="button" role="tab" data-metric="points" class="is-active" aria-selected="true">Очки</button>
+        <button type="button" role="tab" data-metric="points" class="is-active" aria-selected="true">Поинты</button>
         <button type="button" role="tab" data-metric="editions" aria-selected="false">Проведения</button>
         <button type="button" role="tab" data-metric="wins" aria-selected="false">Победы</button>
       </div>
@@ -811,9 +811,9 @@
 
     <section class="section">
       <p class="closing">
-        4TH of July Convention держит самую длинную линию Jack&amp;Jill по уровням в реестре при среднем объёме очков,
+        4TH of July Convention держит самую длинную линию Jack&amp;Jill по уровням в реестре при среднем объёме поинтов,
         кормит в основном Novice, Intermediate и Advanced и регулярно выпускает стартовавших дальше по календарю.
-        Для части это первая запись в WSDC. Для большинства с очками здесь: одно проведение.
+        Для части это первая запись в WSDC. Для большинства с поинтами здесь: одно проведение.
         Портрет одного якоря, не рейтинг.
       </p>
     </section>
@@ -824,7 +824,7 @@
     <p class="sources-title">Данные из базы</p>
     <p class="data-note">
       Цифры, траектории, дивизионы, старты здесь, возвраты, топы и пары считаются по реестру
-      очков и результатов WSDC: танцоры с очками &gt; 0 в Jack&amp;Jill по уровням.
+      поинтов и результатов WSDC: танцоры с поинтами &gt; 0 в Jack&amp;Jill по уровням.
       Каталог событий: <code>event_catalog.csv</code> (в том числе <strong>номер события = 1</strong> для
       4TH of July Convention). Файл метрик этой статьи:
       <code>metrics/metrics.json</code>, собран 2026-07-17.
@@ -874,7 +874,7 @@
     </ul>
     <p class="data-note">
       Всё, что относится к истории клуба, именам события, площадке и правилам конкурсов,
-      взято из источников выше. Всё, что относится к очкам и сравнениям между событиями,
+      взято из источников выше. Всё, что относится к поинтам и сравнениям между событиями,
       взято из реестра / <code>metrics/metrics.json</code>.
     </p>
   </footer>
@@ -965,8 +965,8 @@
     const foot = document.getElementById("peerFoot");
     if (foot) {
       const what = key === "first_points_here"
-        ? "по числу танцоров, у которых первые очки WSDC вообще были Skill JJ на этом событии"
-        : "по числу танцоров с очками на событии";
+        ? "по числу танцоров, у которых первые поинты WSDC вообще были Skill JJ на этом событии"
+        : "по числу танцоров с поинтами на событии";
       foot.textContent =
         `Jack&Jill по уровням · среди всех ивентов · ${what}. ` +
         `Топ-${topN}, затем 4TH of July Convention: ${rank}-е место из ${pc.events_total_n || "…"}.`;
@@ -999,7 +999,7 @@
       const nov = e.share_pct.Novice != null ? `Nov ${String(e.share_pct.Novice).replace(".", ",")}%` : "";
       const adv = e.share_pct.Advanced != null ? `Adv ${String(e.share_pct.Advanced).replace(".", ",")}%` : "";
       const current = String(e.era) === lastEra ? " is-current" : "";
-      return `<div class="stack-era-row${current}"><div class="stack-era-label">${String(e.era).replace(/[–—]/g, "-")} · ${e.total_points} очк.${nov || adv ? ` · ${[nov, adv].filter(Boolean).join(" · ")}` : ""}</div><div class="stack-track">${segs}</div></div>`;
+      return `<div class="stack-era-row${current}"><div class="stack-era-label">${String(e.era).replace(/[–—]/g, "-")} · ${e.total_points} поинт.${nov || adv ? ` · ${[nov, adv].filter(Boolean).join(" · ")}` : ""}</div><div class="stack-track">${segs}</div></div>`;
     }).join("");
     document.getElementById("eraBars").innerHTML = `<div class="stack-era">${legend}${rows}</div>`;
   }
@@ -1007,7 +1007,7 @@
   function renderLaunch() {
     const L = M.insights.launchpad;
     document.getElementById("launchKpis").innerHTML = [
-      ["Стартов здесь", L.starters_n, "первые очки WSDC на 4TH of July Convention"],
+      ["Стартов здесь", L.starters_n, "первые поинты WSDC на 4TH of July Convention"],
       ["Дошли до All-Star+", `${String(L.reached_allstar_plus_pct).replace(".", ",")}%`, `${L.reached_allstar_plus_n} из ${L.starters_n}`],
       ["До Champion", `${String(L.reached_champion_pct).replace(".", ",")}%`, `${L.reached_champion_n} из ${L.starters_n}`]
     ].map(([lab, val, note]) =>
@@ -1023,7 +1023,7 @@
     document.getElementById("launchFoot").innerHTML =
       `Высший дивизион карьеры среди стартовавших здесь. Медиана до первого All-Star ≈ ${Math.round(L.median_months_to_allstar / 12)} лет, ` +
       `до Champion ≈ ${Math.round(L.median_months_to_champion / 12)} лет. ` +
-      `У All-Star и выше медиана доли карьерных очков вне 4TH of July Convention: ${String(L.as_plus_median_career_points_share_outside_pct).replace(".", ",")}%.`;
+      `У All-Star и выше медиана доли карьерных поинтов вне 4TH of July Convention: ${String(L.as_plus_median_career_points_share_outside_pct).replace(".", ",")}%.`;
   }
 
   function renderRetention() {
@@ -1044,8 +1044,8 @@
       return hbar(label, String(h.dancers), w, focus, h.editions === "5+");
     }).join("");
     document.getElementById("retFoot").textContent =
-      "Сколько разных лет танцор оставлял очки Jack&Jill по уровням именно на 4TH of July Convention. " +
-      `5+ проведений: ${R.five_plus_editions_n} человек и ${String(R.five_plus_points_share_pct).replace(".", ",")}% всех очков события.`;
+      "Сколько разных лет танцор оставлял поинты Jack&Jill по уровням именно на 4TH of July Convention. " +
+      `5+ проведений: ${R.five_plus_editions_n} человек и ${String(R.five_plus_points_share_pct).replace(".", ",")}% всех поинтов события.`;
   }
 
   function renderPeople(metric) {
@@ -1053,7 +1053,7 @@
     const rows = M.top5_by_metric[key];
     const valKey = key === "points" ? "points_here" : key;
     const max = Math.max(...rows.map((r) => r[valKey]));
-    const unit = key === "points" ? "очк." : key === "editions" ? "пр." : "побед";
+    const unit = key === "points" ? "поинт." : key === "editions" ? "пр." : "побед";
     document.getElementById("peopleBars").innerHTML = rows.map((r) => {
       const v = r[valKey];
       const w = ((100 * v) / max).toFixed(1);
@@ -1082,9 +1082,9 @@
     const tip = document.getElementById("trajTip");
     const series = buildSeries(metric);
     const labels = {
-      total_points: "Очки (Jack&Jill по уровням)",
-      unique_dancers: "Танцоры с очками",
-      new_dancers: "Новые (первые очки WSDC здесь)"
+      total_points: "Поинты (Jack&Jill по уровням)",
+      unique_dancers: "Танцоры с поинтами",
+      new_dancers: "Новые (первые поинты WSDC здесь)"
     };
     document.getElementById("trajCaption").textContent =
       labels[metric] + ". Наведите на точку: год и значение.";


### PR DESCRIPTION
## Summary
- Snapshot tooltips: Skill Level nominations (Newcomer–Champion)
- Article Russian copy: replace «очки» with «поинты» for WSDC scores

## Test plan
- [ ] Hover tooltips on Танцоры / Новые танцоры
- [ ] Scan body/toggles/captions: score language is «поинты», chart tip still says «точку»