### PR TITLE
Simplify Arizona peer bar chart labels

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -1019,7 +1019,7 @@
       const v = r[key] || 0;
       const w = ((100 * v) / max).toFixed(1);
       const label = `#${r._rank} ${shortEventName(r.event_name)}`;
-      parts.push(hbar(label, `${v} · ${r.editions} изд.`, w, !!r.is_this_event, false));
+      parts.push(hbar(label, String(v), w, !!r.is_this_event, false));
     });
     document.getElementById("peerBars").innerHTML = parts.join("");
     const foot = document.getElementById("peerFoot");


### PR DESCRIPTION
## Summary
- Peer ranking bars now show `#rank Event · metric` only (no editions suffix).

## Test plan
- [ ] Open peer chart on Arizona draft
- [ ] Confirm labels like `#1 MADjam · 1652` without `· N изд.`


Made with [Cursor](https://cursor.com)