### PR TITLE
Add points KPI and side info tooltips on Arizona draft

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -199,7 +199,7 @@
 
     .snapshot {
       display: grid;
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(4, minmax(0, 1fr));
       gap: 0;
       margin: 1.5rem 0 0.25rem;
       border-top: 1px solid var(--line);
@@ -207,16 +207,16 @@
       overflow: visible;
     }
     .snapshot-item {
-      padding: 1.1rem 0.85rem 1rem 0;
+      padding: 1.1rem 0.7rem 1rem 0;
       border-right: 1px solid var(--line);
       overflow: visible;
     }
     .snapshot-item:last-child { border-right: 0; padding-right: 0; }
-    .snapshot-item:not(:first-child) { padding-left: 0.85rem; }
+    .snapshot-item:not(:first-child) { padding-left: 0.7rem; }
     .snapshot-label {
       display: flex;
       align-items: center;
-      gap: 0.4rem;
+      gap: 0.35rem;
       font-size: 11px;
       text-transform: uppercase;
       letter-spacing: 0.1em;
@@ -266,9 +266,9 @@
     }
     .snapshot-info .info-tooltip {
       position: absolute;
-      left: 50%;
-      bottom: calc(100% + 8px);
-      transform: translateX(-50%);
+      left: calc(100% + 8px);
+      top: 50%;
+      transform: translateY(-50%);
       min-width: 12.5rem;
       max-width: min(15.5rem, 70vw);
       padding: 0.55rem 0.7rem;
@@ -288,10 +288,11 @@
       z-index: 20;
       white-space: normal;
     }
+    /* Last column: open left so tooltip stays in the article width */
     .snapshot-item:last-child .snapshot-info .info-tooltip {
       left: auto;
-      right: 0;
-      transform: none;
+      right: calc(100% + 8px);
+      transform: translateY(-50%);
     }
     .snapshot-info .info-icon:hover .info-tooltip,
     .snapshot-info .info-icon:focus-visible .info-tooltip {
@@ -571,6 +572,16 @@
     }
     .chart-wrap { position: relative; }
 
+    @media (max-width: 900px) {
+      .snapshot { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .snapshot-item:nth-child(2n) { border-right: 0; padding-right: 0; }
+      .snapshot-item:nth-child(2n) .snapshot-info .info-tooltip {
+        left: auto;
+        right: calc(100% + 8px);
+        transform: translateY(-50%);
+      }
+    }
+
     @media (max-width: 768px) {
       .article-header { padding: 72px var(--pad-x) 48px; min-height: 320px; }
       .article-content { padding: 2.25rem var(--pad-x) 1.5rem; }
@@ -586,6 +597,12 @@
       .insight-kpis .snapshot-item:last-child { border-bottom: 0; }
       .snapshot-item:not(:first-child),
       .insight-kpis .snapshot-item:not(:first-child) { padding-left: 0; }
+      .snapshot-item:nth-child(2n) .snapshot-info .info-tooltip,
+      .snapshot-item:last-child .snapshot-info .info-tooltip {
+        left: calc(100% + 8px);
+        right: auto;
+        transform: translateY(-50%);
+      }
     }
 
     @media (prefers-reduced-motion: reduce) {
@@ -689,6 +706,19 @@
         </div>
         <div class="snapshot-value">245</div>
         <div class="snapshot-note">топ-13 среди всех ивентов</div>
+      </div>
+      <div class="snapshot-item">
+        <div class="snapshot-label">
+          Поинты
+          <span class="snapshot-info">
+            <span class="info-icon" tabindex="0" role="img" aria-label="Пояснение: сумма Skill-Level поинтов на этом ивенте">
+              <span aria-hidden="true">i</span>
+              <span class="info-tooltip">Количество поинтов, набранных на ивенте всеми танцорами в Skill-Level номинациях.</span>
+            </span>
+          </span>
+        </div>
+        <div class="snapshot-value">8284</div>
+        <div class="snapshot-note">топ-8 среди всех ивентов</div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Adds a fourth snapshot metric: Поинты (8284, top-8) with an info tooltip.
- Moves snapshot `i` tooltips from above the icon to the right (last column opens left to stay in frame).

## Test plan
- [ ] Snapshot shows 4 columns: Издания / Танцоры / Новые танцоры / Поинты
- [ ] Hover `i` on Танцоры and Новые — tooltip appears to the right
- [ ] Hover `i` on Поинты — tooltip appears to the left of the icon
- [ ] Mobile stacks to one column


Made with [Cursor](https://cursor.com)