### PR TITLE
Simplify dancers snapshot tooltip wording

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -674,7 +674,7 @@
           <span class="snapshot-info">
             <span class="info-icon" tabindex="0" role="img" aria-label="Пояснение: уникальные танцоры с поинтами на этом ивенте">
               <span aria-hidden="true">i</span>
-              <span class="info-tooltip">Количество уникальных танцоров, которые когда-либо получали поинты на этом ивенте в Skill Level номинациях (Newcomer–Champion).</span>
+              <span class="info-tooltip">Количество уникальных танцоров, которые когда-либо получали поинты на этом ивенте в Skill Level номинациях.</span>
             </span>
           </span>
         </div>


### PR DESCRIPTION
## Summary
- Removes `(Newcomer–Champion)` from the Танцоры info tooltip.

## Test plan
- [ ] Hover Танцоры `i` — tooltip has no division list


Made with [Cursor](https://cursor.com)