### PR TITLE
Rewrite Arizona peer ranking section copy

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -714,17 +714,17 @@
     </div>
 
     <section class="section" aria-labelledby="peer-title">
-      <h2 class="section-title" id="peer-title">Самая длинная, не самая большая</h2>
+      <h2 class="section-title" id="peer-title">Место среди других ивентов</h2>
       <p>
-        Среди всех ивентов с Jack&amp;Jill по уровням
-        <strong>4TH of July Convention</strong> первый по числу лет
-        и только шестой по числу танцоров с поинтами. Впереди MADjam, Capital Swing, Boogie By The Bay,
-        Liberty Swing, Summer Hummer. Рядом по объёму Easter Swing.
+        Несмотря на то, что ивент проводился чаще остальных, по остальным метрикам он немного
+        уступает другим ивентам. <strong>4TH of July Convention</strong> находится на 6 месте
+        среди всех ивентов по количеству уникальных танцоров, которые получали поинты на этом
+        ивенте (1364), на 13 месте по количеству танцоров, которые получили свои первые поинты (245)
+        и на 8 месте по количеству поинтов, полученных танцорами в Skill Level номинациях.
       </p>
       <p>
-        Переключатель ниже показывает три среза по всем ивентам: кто вообще брал поинты
-        на ивенте, кто взял здесь свои первые поинты WSDC, и сколько Skill-Level поинтов
-        начислили на ивенте за всё время.
+        Основная причина таких показателей: сознательный отказ ивента от проведения номинации
+        Newcomer с 1998 года (в 2009 номинация возвращалась на 1 год).
       </p>
       <div class="metric-toggles" id="peerToggles" role="tablist" aria-label="Метрика сравнения ивентов">
         <button type="button" role="tab" data-metric="unique_dancers" class="is-active" aria-selected="true">Танцоры</button>


### PR DESCRIPTION
## Summary
- Renames the first chart section to «Место среди других ивентов».
- Replaces the lead copy with ranks (6 / 13 / 8) and the Newcomer-from-1998 explanation.

## Test plan
- [ ] Read section above the peer bar chart
- [ ] Confirm toggles still work


Made with [Cursor](https://cursor.com)