### PR TITLE
chore(data): July homepage KPI events 9→10

### DIFF
--- a/static/data/homepage_kpis.json
+++ b/static/data/homepage_kpis.json
@@ -1,15 +1,15 @@
 {
-  "generated_at": "2026-07-17",
-  "as_of": "2026-07-17",
+  "generated_at": "2026-07-19",
+  "as_of": "2026-07-19",
   "data_through": "2026-07-31",
-  "source_dir": "/home/runner/work/wsdc-data-pipeline/wsdc-data-pipeline/data",
+  "source_dir": "/Users/ania/.cursor/projects/python/wsdc-data-pipeline/data",
   "methodology": {
     "events_total": "count of rows in events_wsdc.csv",
     "points_total": "sum of event_points across all nominations in dancers_results_info.csv",
     "dancers_total": "count of unique dancer_id in dancers_results_info.csv",
     "dancers_increment": "new dancers = unique dancer_id whose first WSDC points fall in the window (week/month: earliest edition start_date; year: event_year of that first event)",
     "edition_dates": "event_editions.csv start_date/end_date (edition_date remains YYYY-MM-01 for Tableau)",
-    "calendar_archive": "/home/runner/work/wsdc-data-pipeline/wsdc-data-pipeline/data/edition_calendar_dates.csv",
+    "calendar_archive": "/Users/ania/.cursor/projects/python/wsdc-data-pipeline/data/edition_calendar_dates.csv",
     "as_of_note": "as_of defaults to today.",
     "increment_note": "Events/points increments count activity in the window. Dancers increment counts new dancers (first WSDC points), not unique participants.",
     "week_note": "Week uses ISO week of edition start_date for occurred events. Never advances to a week with no occurred events (e.g. Jul 13-19 empty → keep Jul 6-12). Baseline since_previous_ended is end of previous calendar month.",
@@ -30,25 +30,25 @@
         "since_previous_ended": "2026-06-30",
         "iso_week": "2026-W28",
         "bucket": "edition_start_date",
-        "event_names": "Big Apple Dance Festival, Carolina Summer Swing, MY Swing, Mediterranean Open WCS"
+        "event_names": "Big Apple Dance Festival, Carolina Summer Swing, MY Swing, Mediterranean Open WCS, SwingLab Berlin"
       },
       "increment": {
-        "events": 4,
-        "points": 1536.0,
-        "dancers": 62
+        "events": 5,
+        "points": 2048.0,
+        "dancers": 79
       }
     },
     "month": {
       "label": "Month",
       "period": {
         "start": "2026-07-01",
-        "end": "2026-07-17",
+        "end": "2026-07-19",
         "since_previous_ended": "2026-06-30",
         "bucket": "edition_start_date"
       },
       "increment": {
-        "events": 9,
-        "points": 3737.0,
+        "events": 10,
+        "points": 4249.0,
         "dancers": 147
       }
     },
@@ -56,7 +56,7 @@
       "label": "Year",
       "period": {
         "start": "2026-01-01",
-        "end": "2026-07-17",
+        "end": "2026-07-19",
         "since_previous_ended": "2025-12-31",
         "bucket": "event_year"
       },


### PR DESCRIPTION
## Summary
- Rebuild `homepage_kpis.json` after SwingLab Berlin got `start_date` (calendar event_id remap in pipeline)
- Month increment: **9 → 10** events (as of 2026-07-19)

## Test plan
- [x] Local build shows Month +events=10
- [ ] After merge: https://wsdc-analytics.github.io/ — month counter shows 10


Made with [Cursor](https://cursor.com)