### PR TITLE
Left-align Arizona trajectory tooltips

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -563,7 +563,7 @@
       transition: opacity 140ms var(--ease-out), transform 140ms var(--ease-out);
       white-space: nowrap;
       z-index: 5;
-      text-align: center;
+      text-align: left;
       line-height: 1.35;
     }
     .line-tip.is-on {


### PR DESCRIPTION
## Summary
- Aligns trajectory tooltip content to the left instead of center.

## Test plan
- [ ] Hover a trajectory point and confirm year/value and YoY lines are left-aligned


Made with [Cursor](https://cursor.com)