### PR TITLE
Remove Arizona trajectory grey-band footnote

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -764,9 +764,6 @@
         <svg id="trajChart" viewBox="0 0 720 280" role="img" aria-label="Траектория метрики по годам"></svg>
         <p class="chart-caption" id="trajCaption">Наведите на точку: год, значение и изменение к предыдущему году.</p>
       </div>
-      <p class="footnote">
-        Серая полоса на графике: 2020-2021, событие не проводилось. Ранние годы в реестре покрыты тоньше.
-      </p>
     </section>
 
     <section class="section" aria-labelledby="era-title">


### PR DESCRIPTION
## Summary
- Removes the footnote under the trajectory chart about 2020-2021 and early registry coverage.

## Test plan
- [ ] Trajectory section has caption only, no grey-band footnote


Made with [Cursor](https://cursor.com)