### PR TITLE
Restore Arizona draft chart JavaScript

### DIFF
--- a/events/001-arizona-4th-of-july/draft_ru.html
+++ b/events/001-arizona-4th-of-july/draft_ru.html
@@ -889,3 +889,306 @@
 
 
 <script id="event-metrics" type="application/json">{"event_id":1,"generated":"2026-07-17","definitions":{"skill_jj":"West Coast Swing + Newcomer/Novice/Intermediate/Advanced/All-Star/Champion, points > 0","new_dancers":"dancers whose first-ever WSDC points row (any division, points>0) is Skill JJ at this event","wins":"result_standardized = '1' at this event (Skill JJ)","started_here_notable":"among starters who reached Champion: WSDC Hall of Fame inductees (Wayne Bott, Martin Parker), plus Katie Schneider, Heidi Groskreutz, Cameo Cross, and Mackenzie Keister","pairs":"All-Star/Champion place-matched Leader+Follower with same result_standardized in {1,2,3,4,5} same event_year+division (JJ finals convention; not stored partner_id)","peer_context":"Among all Skill JJ events; ranks by unique dancers / first-ever WSDC points at this event / total Skill JJ points / edition years","launchpad":"first-ever WSDC points (any skill JJ result) at this event; highest division and career points share outside this event","division_era_mix":"Share of Skill JJ points at this event by division, aggregated by era (COVID gap years excluded from 2022–2026 bucket)","retention":"Return = scored points at this event in year Y and again in Y+1; editions = distinct years with points here"},"catalog":{"canonical_name":"4TH of July Convention","url":"http://phoenix4thofjuly.com","typical_location":"Phoenix, AZ","typical_city":"Phoenix","typical_state":"Arizona","typical_country":"United States","first_edition_year":1991,"last_edition_year":2026,"edition_count":34,"unique_dancers_all_divisions":1556,"total_result_rows_all_divisions":3169},"skill_jj_kpi":{"unique_dancers":1364,"total_points":8284,"result_rows":2313,"editions_with_results":34,"first_points_here":245,"first_points_share_pct":18.0,"peak_year_dancers":2009,"peak_dancers":100,"peak_year_points":2014,"peak_points":380,"peak_year_new_dancers":1994,"peak_new_dancers":17},"year_gaps":[2020,2021],"champ_window_from_year":2007,"timeseries":[{"event_year":1991,"unique_dancers":1,"total_points":10,"new_dancers":1},{"event_year":1992,"unique_dancers":18,"total_points":88,"new_dancers":11},{"event_year":1993,"unique_dancers":22,"total_points":128,"new_dancers":13},{"event_year":1994,"unique_dancers":25,"total_points":139,"new_dancers":17},{"event_year":1995,"unique_dancers":28,"total_points":142,"new_dancers":9},{"event_year":1996,"unique_dancers":31,"total_points":151,"new_dancers":12},{"event_year":1997,"unique_dancers":37,"total_points":42,"new_dancers":13},{"event_year":1998,"unique_dancers":66,"total_points":186,"new_dancers":16},{"event_year":1999,"unique_dancers":70,"total_points":190,"new_dancers":15},{"event_year":2000,"unique_dancers":62,"total_points":182,"new_dancers":5},{"event_year":2001,"unique_dancers":64,"total_points":184,"new_dancers":6},{"event_year":2002,"unique_dancers":70,"total_points":190,"new_dancers":8},{"event_year":2003,"unique_dancers":80,"total_points":240,"new_dancers":2},{"event_year":2004,"unique_dancers":80,"total_points":240,"new_dancers":1},{"event_year":2005,"unique_dancers":80,"total_points":240,"new_dancers":5},{"event_year":2006,"unique_dancers":76,"total_points":236,"new_dancers":2},{"event_year":2007,"unique_dancers":94,"total_points":366,"new_dancers":6},{"event_year":2008,"unique_dancers":90,"total_points":342,"new_dancers":8},{"event_year":2009,"unique_dancers":100,"total_points":370,"new_dancers":14},{"event_year":2010,"unique_dancers":80,"total_points":312,"new_dancers":4},{"event_year":2011,"unique_dancers":64,"total_points":230,"new_dancers":7},{"event_year":2012,"unique_dancers":79,"total_points":296,"new_dancers":8},{"event_year":2013,"unique_dancers":90,"total_points":373,"new_dancers":3},{"event_year":2014,"unique_dancers":88,"total_points":380,"new_dancers":2},{"event_year":2015,"unique_dancers":81,"total_points":292,"new_dancers":8},{"event_year":2016,"unique_dancers":92,"total_points":333,"new_dancers":3},{"event_year":2017,"unique_dancers":88,"total_points":329,"new_dancers":3},{"event_year":2018,"unique_dancers":64,"total_points":219,"new_dancers":8},{"event_year":2019,"unique_dancers":68,"total_points":239,"new_dancers":7},{"event_year":2022,"unique_dancers":66,"total_points":236,"new_dancers":7},{"event_year":2023,"unique_dancers":92,"total_points":348,"new_dancers":5},{"event_year":2024,"unique_dancers":78,"total_points":308,"new_dancers":4},{"event_year":2025,"unique_dancers":88,"total_points":352,"new_dancers":5},{"event_year":2026,"unique_dancers":92,"total_points":371,"new_dancers":7}],"division_cuts":[{"division":"Newcomer","unique_dancers":53,"total_points":229},{"division":"Novice","unique_dancers":586,"total_points":2643},{"division":"Intermediate","unique_dancers":454,"total_points":1864},{"division":"Advanced","unique_dancers":425,"total_points":1921},{"division":"All-Star","unique_dancers":203,"total_points":1101},{"division":"Champion","unique_dancers":58,"total_points":526}],"top5_by_metric":{"points":[{"dancer_name":"Robert Royston","points_here":47,"editions":11,"wins":4},{"dancer_name":"Michael Kielbasa","points_here":45,"editions":7,"wins":2},{"dancer_name":"Melissa Rutz","points_here":43,"editions":10,"wins":2},{"dancer_name":"Hannah Coda","points_here":39,"editions":4,"wins":2},{"dancer_name":"Danya Svir","points_here":39,"editions":4,"wins":2}],"editions":[{"dancer_name":"Robert Royston","points_here":47,"editions":11,"wins":4},{"dancer_name":"Benji Schwimmer","points_here":35,"editions":11,"wins":4},{"dancer_name":"Melissa Rutz","points_here":43,"editions":10,"wins":2},{"dancer_name":"Tatiana Mollmann","points_here":35,"editions":10,"wins":2},{"dancer_name":"Tony Schubert","points_here":27,"editions":9,"wins":0}],"wins":[{"dancer_name":"Robert Royston","points_here":47,"editions":11,"wins":4},{"dancer_name":"Benji Schwimmer","points_here":35,"editions":11,"wins":4},{"dancer_name":"Dayne Darden","points_here":34,"editions":4,"wins":3},{"dancer_name":"Tom Jennings","points_here":33,"editions":4,"wins":3},{"dancer_name":"Thomas Carter","points_here":27,"editions":4,"wins":3}]},"pairs_as_champ":{"method_note":"Place-matched Leader+Follower (same place 1–5) in All-Star/Champion at this event","by_wins":[{"leader_name":"Robert Royston","follower_name":"Torri Zzaoui","placed_together":3,"wins_together":1,"years":3},{"leader_name":"Robert Royston","follower_name":"Brandi Tobias","placed_together":2,"wins_together":1,"years":2},{"leader_name":"Kyle Redd","follower_name":"Deborah Szekely","placed_together":2,"wins_together":1,"years":2},{"leader_name":"Benji Schwimmer","follower_name":"Laureen Baldovi","placed_together":2,"wins_together":1,"years":2}],"by_placements":[{"leader_name":"Robert Royston","follower_name":"Torri Zzaoui","placed_together":3,"wins_together":1,"years":3},{"leader_name":"Kyle Redd","follower_name":"Deborah Szekely","placed_together":2,"wins_together":1,"years":2},{"leader_name":"Robert Royston","follower_name":"Brandi Tobias","placed_together":2,"wins_together":1,"years":2},{"leader_name":"Benji Schwimmer","follower_name":"Laureen Baldovi","placed_together":2,"wins_together":1,"years":2},{"leader_name":"PJ Turner","follower_name":"Melissa Rutz","placed_together":2,"wins_together":0,"years":2}]},"other_divisions_present":["Invitational","Juniors","Master","Professional","Teacher"],"header_candidates":["assets/hero_fullwidth.png","assets/logo_website.png","assets/logo_estd_1982.png"],"started_here_notable_examples":[{"dancer_name":"Wayne Bott","event_year":1992,"champ_pts":24,"wsdc_hof_year":2009,"hof_url":"https://worldsdc.com/hall-of-fame/wayne-bott-2009/"},{"dancer_name":"Martin Parker","event_year":1993,"champ_pts":29,"wsdc_hof_year":2015,"hof_url":"https://worldsdc.com/hall-of-fame/martin-parker-2015/"},{"dancer_name":"Katie Schneider","event_year":2000,"champ_pts":51,"wsdc_hof_year":null,"hof_url":null},{"dancer_name":"Heidi Groskreutz","event_year":2000,"champ_pts":21,"wsdc_hof_year":null,"hof_url":null},{"dancer_name":"Cameo Cross","event_year":2007,"champ_pts":316,"wsdc_hof_year":null,"hof_url":null},{"dancer_name":"Mackenzie Keister","event_year":2022,"champ_pts":5,"wsdc_hof_year":null,"hof_url":null}],"insights":{"peer_context":{"definition":"Among all Skill JJ events; ranks by unique dancers / first-ever WSDC points at this event / total Skill JJ points / edition years","this_event":"4TH of July Convention","editions":34,"unique_dancers":1364,"rank_by_editions":1,"rank_by_unique_among_long":6,"long_events_n":27,"events_total_n":344,"peers_top12_by_unique":[{"event_name":"MADjam","editions":21,"unique_dancers":1652,"first_points_here":367,"total_points":11367,"is_this_event":false},{"event_name":"Capital Swing Dance Convention","editions":30,"unique_dancers":1518,"first_points_here":329,"total_points":9210,"is_this_event":false},{"event_name":"Boogie By The Bay","editions":31,"unique_dancers":1476,"first_points_here":184,"total_points":10682,"is_this_event":false},{"event_name":"Liberty Swing Dance Championships","editions":21,"unique_dancers":1418,"first_points_here":243,"total_points":8356,"is_this_event":false},{"event_name":"Summer Hummer","editions":25,"unique_dancers":1413,"first_points_here":337,"total_points":8468,"is_this_event":false},{"event_name":"4TH of July Convention","editions":34,"unique_dancers":1364,"first_points_here":245,"total_points":8284,"is_this_event":true},{"event_name":"Easter Swing","editions":30,"unique_dancers":1359,"first_points_here":258,"total_points":9226,"is_this_event":false},{"event_name":"Swing Fling","editions":29,"unique_dancers":1336,"first_points_here":402,"total_points":8138,"is_this_event":false},{"event_name":"Boston Tea Party","editions":26,"unique_dancers":1281,"first_points_here":402,"total_points":7796,"is_this_event":false},{"event_name":"J&J O'Rama","editions":28,"unique_dancers":1279,"first_points_here":141,"total_points":8554,"is_this_event":false},{"event_name":"SwingTime","editions":31,"unique_dancers":1265,"first_points_here":250,"total_points":7535,"is_this_event":false},{"event_name":"Monterey Swing Fest","editions":31,"unique_dancers":1154,"first_points_here":200,"total_points":7804,"is_this_event":false}],"peers_top12_by_first_points":[{"event_name":"Swing Fling","editions":29,"unique_dancers":1336,"first_points_here":402,"total_points":8138,"is_this_event":false},{"event_name":"Boston Tea Party","editions":26,"unique_dancers":1281,"first_points_here":402,"total_points":7796,"is_this_event":false},{"event_name":"MADjam","editions":21,"unique_dancers":1652,"first_points_here":367,"total_points":11367,"is_this_event":false},{"event_name":"BudaFest","editions":14,"unique_dancers":1112,"first_points_here":345,"total_points":7753,"is_this_event":false},{"event_name":"Summer Hummer","editions":25,"unique_dancers":1413,"first_points_here":337,"total_points":8468,"is_this_event":false},{"event_name":"Capital Swing Dance Convention","editions":30,"unique_dancers":1518,"first_points_here":329,"total_points":9210,"is_this_event":false},{"event_name":"West in Lyon","editions":13,"unique_dancers":746,"first_points_here":321,"total_points":5104,"is_this_event":false},{"event_name":"Countdown Swing Boston","editions":22,"unique_dancers":937,"first_points_here":304,"total_points":5463,"is_this_event":false},{"event_name":"D-Town Swing","editions":11,"unique_dancers":698,"first_points_here":271,"total_points":3785,"is_this_event":false},{"event_name":"French Open","editions":14,"unique_dancers":840,"first_points_here":263,"total_points":5724,"is_this_event":false},{"event_name":"Easter Swing","editions":30,"unique_dancers":1359,"first_points_here":258,"total_points":9226,"is_this_event":false},{"event_name":"SwingTime","editions":31,"unique_dancers":1265,"first_points_here":250,"total_points":7535,"is_this_event":false},{"event_name":"4TH of July Convention","editions":34,"unique_dancers":1364,"first_points_here":245,"total_points":8284,"is_this_event":true}],"rank_by_first_points_among_long":9,"rank_by_unique_all":6,"rank_by_first_points_all":13,"peers_top15_by_first_points":[{"event_name":"Swing Fling","editions":29,"unique_dancers":1336,"first_points_here":402,"total_points":8138,"is_this_event":false},{"event_name":"Boston Tea Party","editions":26,"unique_dancers":1281,"first_points_here":402,"total_points":7796,"is_this_event":false},{"event_name":"MADjam","editions":21,"unique_dancers":1652,"first_points_here":367,"total_points":11367,"is_this_event":false},{"event_name":"BudaFest","editions":14,"unique_dancers":1112,"first_points_here":345,"total_points":7753,"is_this_event":false},{"event_name":"Summer Hummer","editions":25,"unique_dancers":1413,"first_points_here":337,"total_points":8468,"is_this_event":false},{"event_name":"Capital Swing Dance Convention","editions":30,"unique_dancers":1518,"first_points_here":329,"total_points":9210,"is_this_event":false},{"event_name":"West in Lyon","editions":13,"unique_dancers":746,"first_points_here":321,"total_points":5104,"is_this_event":false},{"event_name":"Countdown Swing Boston","editions":22,"unique_dancers":937,"first_points_here":304,"total_points":5463,"is_this_event":false},{"event_name":"D-Town Swing","editions":11,"unique_dancers":698,"first_points_here":271,"total_points":3785,"is_this_event":false},{"event_name":"French Open","editions":14,"unique_dancers":840,"first_points_here":263,"total_points":5724,"is_this_event":false},{"event_name":"Easter Swing","editions":30,"unique_dancers":1359,"first_points_here":258,"total_points":9226,"is_this_event":false},{"event_name":"SwingTime","editions":31,"unique_dancers":1265,"first_points_here":250,"total_points":7535,"is_this_event":false},{"event_name":"4TH of July Convention","editions":34,"unique_dancers":1364,"first_points_here":245,"total_points":8284,"is_this_event":true},{"event_name":"Liberty Swing Dance Championships","editions":21,"unique_dancers":1418,"first_points_here":243,"total_points":8356,"is_this_event":false},{"event_name":"Asia West Coast Swing Open","editions":11,"unique_dancers":528,"first_points_here":222,"total_points":3598,"is_this_event":false}],"peers_top12_by_total_points":[{"event_name":"MADjam","editions":21,"unique_dancers":1652,"first_points_here":367,"total_points":11367,"is_this_event":false},{"event_name":"Boogie By The Bay","editions":31,"unique_dancers":1476,"first_points_here":184,"total_points":10682,"is_this_event":false},{"event_name":"Easter Swing","editions":30,"unique_dancers":1359,"first_points_here":258,"total_points":9226,"is_this_event":false},{"event_name":"Capital Swing Dance Convention","editions":30,"unique_dancers":1518,"first_points_here":329,"total_points":9210,"is_this_event":false},{"event_name":"J&J O'Rama","editions":28,"unique_dancers":1279,"first_points_here":141,"total_points":8554,"is_this_event":false},{"event_name":"Summer Hummer","editions":25,"unique_dancers":1413,"first_points_here":337,"total_points":8468,"is_this_event":false},{"event_name":"Liberty Swing Dance Championships","editions":21,"unique_dancers":1418,"first_points_here":243,"total_points":8356,"is_this_event":false},{"event_name":"4TH of July Convention","editions":34,"unique_dancers":1364,"first_points_here":245,"total_points":8284,"is_this_event":true},{"event_name":"Swing Fling","editions":29,"unique_dancers":1336,"first_points_here":402,"total_points":8138,"is_this_event":false},{"event_name":"Monterey Swing Fest","editions":31,"unique_dancers":1154,"first_points_here":200,"total_points":7804,"is_this_event":false},{"event_name":"Boston Tea Party","editions":26,"unique_dancers":1281,"first_points_here":402,"total_points":7796,"is_this_event":false},{"event_name":"BudaFest","editions":14,"unique_dancers":1112,"first_points_here":345,"total_points":7753,"is_this_event":false}],"rank_by_total_points_all":8,"total_points":8284},"launchpad":{"definition":"first-ever WSDC points (any skill JJ result) at this event; highest division and career points share outside this event","starters_n":245,"reached_allstar_plus_n":31,"reached_allstar_plus_pct":12.7,"reached_champion_n":16,"reached_champion_pct":6.5,"median_months_to_allstar":76.0,"median_months_to_champion":69.0,"median_career_points_share_outside_pct":66.7,"as_plus_median_career_points_share_outside_pct":87.3,"highest_division_counts":[{"division":"Newcomer","n":14},{"division":"Novice","n":79},{"division":"Intermediate","n":59},{"division":"Advanced","n":62},{"division":"All-Star","n":15},{"division":"Champion","n":16}]},"division_era_mix":{"definition":"Share of Skill JJ points at this event by division, aggregated by era (COVID gap years excluded from 2022–2026 bucket)","eras":[{"era":"1991–1999","total_points":1076,"share_pct":{"Newcomer":18.5,"Novice":35.5,"Intermediate":11.5,"Advanced":34.5},"points":{"Newcomer":199,"Novice":382,"Intermediate":124,"Advanced":371}},{"era":"2000–2009","total_points":2590,"share_pct":{"Newcomer":1.2,"Novice":26.4,"Intermediate":24.9,"Advanced":24.7,"All-Star":17.3,"Champion":5.6},"points":{"Newcomer":30,"Novice":684,"Intermediate":644,"Advanced":640,"All-Star":448,"Champion":144}},{"era":"2010–2019","total_points":3003,"share_pct":{"Novice":33.8,"Intermediate":23.3,"Advanced":18.5,"All-Star":14.6,"Champion":9.8},"points":{"Novice":1016,"Intermediate":700,"Advanced":556,"All-Star":437,"Champion":294}},{"era":"2022–2026","total_points":1615,"share_pct":{"Novice":34.7,"Intermediate":24.5,"Advanced":21.9,"All-Star":13.4,"Champion":5.4},"points":{"Novice":561,"Intermediate":396,"Advanced":354,"All-Star":216,"Champion":88}}]},"retention":{"definition":"Return = scored points at this event in year Y and again in Y+1; editions = distinct years with points here","unique_dancers":1364,"one_edition_n":865,"one_edition_pct":63.4,"three_plus_editions_n":209,"three_plus_editions_pct":15.3,"five_plus_editions_n":55,"one_edition_points_share_pct":39.4,"five_plus_points_share_pct":13.8,"edition_histogram":[{"editions":1,"dancers":865},{"editions":2,"dancers":290},{"editions":3,"dancers":99},{"editions":4,"dancers":55},{"editions":5,"dancers":27},{"editions":6,"dancers":10},{"editions":7,"dancers":8},{"editions":8,"dancers":5},{"editions":9,"dancers":1},{"editions":10,"dancers":2},{"editions":11,"dancers":2}],"next_year_return":[{"from_year":2014,"to_year":2015,"base":88,"returned":20,"rate_pct":22.7},{"from_year":2015,"to_year":2016,"base":81,"returned":33,"rate_pct":40.7},{"from_year":2016,"to_year":2017,"base":92,"returned":22,"rate_pct":23.9},{"from_year":2017,"to_year":2018,"base":88,"returned":17,"rate_pct":19.3},{"from_year":2018,"to_year":2019,"base":64,"returned":18,"rate_pct":28.1},{"from_year":2022,"to_year":2023,"base":66,"returned":16,"rate_pct":24.2},{"from_year":2023,"to_year":2024,"base":92,"returned":12,"rate_pct":13.0},{"from_year":2024,"to_year":2025,"base":78,"returned":27,"rate_pct":34.6},{"from_year":2025,"to_year":2026,"base":88,"returned":27,"rate_pct":30.7}],"return_after_gap":{"from_year":2019,"to_year":2022,"base":68,"returned":14,"rate_pct":20.6,"note":"after COVID gap"},"recent_return_rate_range_pct":[13.0,40.7]}}}</script>
+<script>
+
+(function () {
+  const M = JSON.parse(document.getElementById("event-metrics").textContent);
+  const gaps = new Set(M.year_gaps || []);
+
+  function bindToggles(rootId, onChange) {
+    const root = document.getElementById(rootId);
+    root.addEventListener("click", (e) => {
+      const btn = e.target.closest("button[data-metric]");
+      if (!btn) return;
+      root.querySelectorAll("button").forEach((b) => {
+        const on = b === btn;
+        b.classList.toggle("is-active", on);
+        b.setAttribute("aria-selected", on ? "true" : "false");
+      });
+      onChange(btn.dataset.metric);
+    });
+  }
+
+  function shortEventName(name) {
+    if (!name) return "";
+    if (name === "Phoenix 4th of July" || name === "4TH of July Convention") {
+      return "4TH of July Convention";
+    }
+    return String(name)
+      .replace("Mid-Atlantic Dance Jam", "MADjam")
+      .replace(" Dance Championships", "")
+      .replace(" Championships", "")
+      .replace(" Dance Convention", "")
+      .replace(" Convention", "")
+      .trim();
+  }
+
+  function hbar(label, valueText, pct, focus, muted) {
+    const cls = focus ? " is-focus" : muted ? " is-muted" : "";
+    return (
+      `<div class="hbar${cls}">` +
+      `<div class="hbar-meta"><span class="hbar-label">${label}</span>` +
+      (valueText ? ` · <span class="hbar-value">${valueText}</span>` : "") +
+      `</div>` +
+      `<div class="hbar-track"><div class="hbar-fill" style="width:${pct}%"></div></div>` +
+      `</div>`
+    );
+  }
+
+  function renderPeerBars(metric) {
+    const key = metric === "first_points_here"
+      ? "first_points_here"
+      : metric === "total_points"
+        ? "total_points"
+        : "unique_dancers";
+    const pc = M.insights.peer_context;
+    const all = key === "first_points_here"
+      ? (pc.peers_top12_by_first_points || [])
+      : key === "total_points"
+        ? (pc.peers_top12_by_total_points || [])
+        : (pc.peers_top12_by_unique || []);
+    const rank = key === "first_points_here"
+      ? (pc.rank_by_first_points_all || 13)
+      : key === "total_points"
+        ? (pc.rank_by_total_points_all || 8)
+        : (pc.rank_by_unique_all || 6);
+    const self = all.find((r) => r.is_this_event) || {
+      event_name: "4TH of July Convention",
+      editions: pc.editions,
+      unique_dancers: pc.unique_dancers,
+      first_points_here: M.skill_jj_kpi.first_points_here,
+      total_points: pc.total_points || M.skill_jj_kpi.total_points,
+      is_this_event: true
+    };
+    const topN = 5;
+    const leaders = all.filter((r) => !r.is_this_event).slice(0, topN);
+    const selfInTop = rank <= topN;
+    const rows = selfInTop
+      ? all.slice(0, topN).map((r, i) => ({ ...r, _rank: i + 1 }))
+      : leaders.map((r, i) => ({ ...r, _rank: i + 1 })).concat([{ ...self, _rank: rank }]);
+    const max = Math.max(...rows.map((r) => r[key] || 0), 1);
+    const showGap = !selfInTop && rank > topN + 1;
+    const parts = [];
+    rows.forEach((r, idx) => {
+      if (showGap && idx === topN) {
+        parts.push(`<div class="peer-gap" aria-hidden="true">···</div>`);
+      }
+      const v = r[key] || 0;
+      const w = ((100 * v) / max).toFixed(1);
+      const label = `#${r._rank} ${shortEventName(r.event_name)}`;
+      parts.push(hbar(label, String(v), w, !!r.is_this_event, false));
+    });
+    document.getElementById("peerBars").innerHTML = parts.join("");
+  }
+
+  function renderLaunch() {
+    const L = M.insights.launchpad;
+    document.getElementById("launchKpis").innerHTML = [
+      ["Новые танцоры", L.starters_n, ""],
+      ["Дошли до All-Star+", `${String(L.reached_allstar_plus_pct).replace(".", ",")}%`, `${L.reached_allstar_plus_n} из ${L.starters_n}`],
+      ["Дошли до Champion", `${String(L.reached_champion_pct).replace(".", ",")}%`, `${L.reached_champion_n} из ${L.starters_n}`]
+    ].map(([lab, val, note]) =>
+      `<div class="snapshot-item"><div class="snapshot-label">${lab}</div><div class="snapshot-value">${val}</div>` +
+      (note ? `<div class="snapshot-note">${note}</div>` : "") +
+      `</div>`
+    ).join("");
+
+    const ladder = L.highest_division_counts.slice();
+    const base = L.starters_n || ladder.reduce((s, d) => s + d.n, 0) || 1;
+    const max = Math.max(...ladder.map((d) => d.n), 1);
+    document.getElementById("launchBars").innerHTML = ladder.map((d) => {
+      const w = ((100 * d.n) / max).toFixed(1);
+      const pct = (Math.round((1000 * d.n) / base) / 10).toFixed(1).replace(".", ",");
+      return hbar(d.division, `${d.n} · ${pct}%`, w, false);
+    }).join("");
+    document.getElementById("launchFoot").innerHTML =
+      `Высший дивизион карьеры среди ${base} стартовавших здесь: число танцоров и доля от всех стартов. ` +
+      `Медиана до первого All-Star ≈ ${Math.round(L.median_months_to_allstar / 12)} лет, ` +
+      `до Champion ≈ ${Math.round(L.median_months_to_champion / 12)} лет.`;
+  }
+
+  function renderRetention() {
+    const R = M.insights.retention;
+    const hist = R.edition_histogram;
+    const low = [];
+    let fivePlus = 0;
+    hist.forEach((h) => {
+      if (Number(h.editions) >= 5) fivePlus += h.dancers;
+      else low.push(h);
+    });
+    if (fivePlus > 0) low.push({ editions: "5+", dancers: fivePlus });
+    const max = Math.max(...low.map((h) => h.dancers));
+    document.getElementById("retBars").innerHTML = low.map((h) => {
+      const w = ((100 * h.dancers) / max).toFixed(1);
+      const label = h.editions === 1 ? "1 издание" : h.editions === "5+" ? "5+ изданий" : String(h.editions);
+      const focus = h.editions === 1;
+      return hbar(label, String(h.dancers), w, focus, h.editions === "5+");
+    }).join("");
+    document.getElementById("retFoot").textContent =
+      "Сколько разных лет танцор оставлял поинты Jack&Jill по уровням именно на 4TH of July Convention. " +
+      `5+ изданий: ${R.five_plus_editions_n} человек и ${String(R.five_plus_points_share_pct).replace(".", ",")}% всех поинтов события.`;
+  }
+
+  function renderPeople(metric) {
+    const key = metric === "editions" ? "editions" : metric === "wins" ? "wins" : "points";
+    const rows = M.top5_by_metric[key];
+    const valKey = key === "points" ? "points_here" : key;
+    const max = Math.max(...rows.map((r) => r[valKey]));
+    const unit = key === "points" ? "поинт." : key === "editions" ? "изд." : "побед";
+    document.getElementById("peopleBars").innerHTML = rows.map((r) => {
+      const v = r[valKey];
+      const w = ((100 * v) / max).toFixed(1);
+      return hbar(r.dancer_name, `${v} ${unit}`, w, false);
+    }).join("");
+  }
+
+  function buildSeries(metric) {
+    const byYear = Object.fromEntries(M.timeseries.map((t) => [t.event_year, t]));
+    const y0 = M.catalog.first_edition_year;
+    const y1 = M.catalog.last_edition_year;
+    const series = [];
+    for (let y = y0; y <= y1; y++) {
+      if (gaps.has(y)) {
+        series.push({ year: y, value: null, gap: true });
+        continue;
+      }
+      const row = byYear[y];
+      series.push({ year: y, value: row ? row[metric] : null, gap: false });
+    }
+    return series;
+  }
+
+  function yoyChange(series, index) {
+    const cur = series[index];
+    if (cur == null || cur.value == null) return null;
+    let prev = null;
+    for (let j = index - 1; j >= 0; j--) {
+      if (series[j].value != null) {
+        prev = series[j];
+        break;
+      }
+    }
+    if (!prev || prev.value === 0) return null;
+    return ((cur.value - prev.value) / prev.value) * 100;
+  }
+
+  function formatYoy(pct) {
+    if (pct == null || !Number.isFinite(pct)) return null;
+    const rounded = Math.round(pct);
+    if (rounded === 0) return { text: "0% год к году", cls: "is-flat" };
+    const sign = rounded > 0 ? "+" : "−";
+    return { text: `${sign}${Math.abs(rounded)}% год к году`, cls: rounded > 0 ? "is-up" : "is-down" };
+  }
+
+  /** Year ticks: always endpoints; evenly spaced intermediates that do not crowd the ends. */
+  function pickYearTicks(y0, y1, maxLabels) {
+    const span = y1 - y0;
+    if (span <= 0) return [y0];
+    const steps = [5, 10, 4, 8, 2];
+    let best = [y0, y1];
+    for (const step of steps) {
+      const mid = [];
+      const first = Math.ceil((y0 + 1) / step) * step;
+      for (let y = first; y < y1; y += step) mid.push(y);
+      const minEdge = Math.max(3, Math.ceil(step * 0.75));
+      const kept = mid.filter((y) => y - y0 >= minEdge && y1 - y >= minEdge);
+      const ticks = [y0, ...kept, y1];
+      if (ticks.length <= maxLabels && ticks.length >= best.length) best = ticks;
+    }
+    return best;
+  }
+
+  function renderTraj(metric) {
+    const svg = document.getElementById("trajChart");
+    const tip = document.getElementById("trajTip");
+    const series = buildSeries(metric);
+
+    const W = 720, H = 280;
+    const pad = { t: 16, r: 16, b: 36, l: 36 };
+    const iw = W - pad.l - pad.r;
+    const ih = H - pad.t - pad.b;
+    const vals = series.map((s) => s.value).filter((v) => v != null);
+    const vmax = Math.max(...vals, 1);
+    const n = series.length;
+    const xAt = (i) => pad.l + (n === 1 ? iw / 2 : (i / (n - 1)) * iw);
+    const yAt = (v) => pad.t + ih - (v / vmax) * ih;
+
+    let path = "";
+    let started = false;
+    series.forEach((s, i) => {
+      if (s.value == null) {
+        started = false;
+        return;
+      }
+      const cmd = started ? "L" : "M";
+      path += `${cmd}${xAt(i).toFixed(1)},${yAt(s.value).toFixed(1)} `;
+      started = true;
+    });
+
+    const yTicks = 4;
+    let grid = "";
+    for (let i = 0; i <= yTicks; i++) {
+      const v = Math.round((vmax * i) / yTicks);
+      const y = yAt(v);
+      grid += `<line x1="${pad.l}" y1="${y}" x2="${W - pad.r}" y2="${y}" stroke="#dde1e8" stroke-width="1"/>`;
+      grid += `<text x="${pad.l - 8}" y="${y + 4}" text-anchor="end" font-size="11" fill="#6b7280">${v}</text>`;
+    }
+
+    let gapRects = "";
+    series.forEach((s, i) => {
+      if (!s.gap) return;
+      const x0 = i === 0 ? xAt(0) : (xAt(i - 1) + xAt(i)) / 2;
+      const x1 = i === n - 1 ? xAt(i) : (xAt(i) + xAt(i + 1)) / 2;
+      gapRects += `<rect x="${x0}" y="${pad.t}" width="${Math.max(x1 - x0, 2)}" height="${ih}" fill="#e8ebf0"/>`;
+    });
+
+    const y0 = series[0].year;
+    const y1 = series[n - 1].year;
+    const yearTicks = new Set(pickYearTicks(y0, y1, 8));
+    let xLabels = "";
+    series.forEach((s, i) => {
+      if (!yearTicks.has(s.year)) return;
+      const anchor = i === 0 ? "start" : i === n - 1 ? "end" : "middle";
+      xLabels += `<text x="${xAt(i)}" y="${H - 14}" text-anchor="${anchor}" font-size="11" fill="#6b7280">${s.year}</text>`;
+    });
+
+    const dots = series.map((s, i) => {
+      if (s.value == null) return "";
+      return `<circle class="traj-dot" data-i="${i}" cx="${xAt(i)}" cy="${yAt(s.value)}" r="4" fill="#1a1f2e" stroke="#fff" stroke-width="1.5" style="cursor:pointer"/>`;
+    }).join("");
+
+    svg.innerHTML = `${gapRects}${grid}<path d="${path.trim()}" fill="none" stroke="#0f766e" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>${dots}${xLabels}`;
+
+    svg.querySelectorAll(".traj-dot").forEach((dot) => {
+      dot.addEventListener("mouseenter", () => {
+        const i = +dot.dataset.i;
+        const s = series[i];
+        const rect = svg.getBoundingClientRect();
+        const cx = +dot.getAttribute("cx");
+        const cy = +dot.getAttribute("cy");
+        const yoy = formatYoy(yoyChange(series, i));
+        tip.innerHTML =
+          `<span class="line-tip-main">${s.year}: ${s.value}</span>` +
+          (yoy ? `<span class="line-tip-yoy ${yoy.cls}">${yoy.text}</span>` : "");
+        tip.style.left = (cx / W) * rect.width + "px";
+        tip.style.top = (cy / H) * rect.height + "px";
+        tip.classList.add("is-on");
+      });
+      dot.addEventListener("mouseleave", () => tip.classList.remove("is-on"));
+    });
+  }
+
+  bindToggles("peerToggles", renderPeerBars);
+  bindToggles("trajToggles", renderTraj);
+  bindToggles("peopleToggles", renderPeople);
+
+  renderPeerBars("unique_dancers");
+  renderLaunch();
+  renderRetention();
+  renderTraj("unique_dancers");
+  renderPeople("points");
+})();
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Restores the rendering script that was accidentally truncated when regenerating the embedded metrics JSON.
- Keeps the Hall of Fame / notable name list and metrics content from #53.

## Test plan
- [ ] Peer, trajectory, launchpad, retention, and people charts render
- [ ] Notable name list still shows Wayne, Martin, Katie, Heidi, Cameo, Mackenzie


Made with [Cursor](https://cursor.com)