### PR TITLE
fix(homepage): events total = occurred editions (2617→2637)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1342,15 +1342,15 @@
             const kpiTips = {
                 ru: {
                     label: 'О этих итогах',
-                    text: 'Счетчик основных метрик WSDC: количество событий, начисленных поинтов и танцоров, получивших хотя бы один поинт на ивентах WSDC. В детальной информации рост метрики за последнюю неделю, текущий месяц или год.'
+                    text: 'Счетчик основных метрик WSDC: число прошедших изданий (ивент × год/месяц с начисленными поинтами), сумма поинтов и танцоры с хотя бы одним поинтом. В деталях — рост за неделю, месяц или год.'
                 },
                 en: {
                     label: 'About these totals',
-                    text: 'A counter of core WSDC metrics: number of events, points awarded, and dancers who earned at least one point at WSDC events. In the details, metric growth for the latest week, current month, or year.'
+                    text: 'Core WSDC metrics: number of occurred event editions (event × year/month that awarded points), points awarded, and dancers who earned at least one point. Details show growth for the latest week, current month, or year.'
                 },
                 es: {
                     label: 'Sobre estos totales',
-                    text: 'Contador de las métricas principales de WSDC: número de eventos, puntos otorgados y bailarines que recibieron al menos un punto en eventos WSDC. En el detalle, el crecimiento de la métrica para la última semana, el mes actual o el año.'
+                    text: 'Métricas principales de WSDC: número de ediciones celebradas (evento × año/mes con puntos), puntos otorgados y bailarines con al menos un punto. En el detalle, el crecimiento de la última semana, mes o año.'
                 }
             };
             const kpiTipCopy = kpiTips[lang] || kpiTips.en;

--- a/scripts/build_homepage_kpis.py
+++ b/scripts/build_homepage_kpis.py
@@ -3,7 +3,9 @@
 
 Metrics
 -------
-- events (totals): count of rows in events_wsdc.csv
+- events (totals): count of occurred WSDC editions in event_editions.csv
+  (rows with result_rows > 0, or event_occurred). One row = one event
+  year/month that awarded points — not the stale events_wsdc registry dump.
 - points (totals): sum of event_points across all nominations in results
 - dancers (totals): count of unique dancer_id in results
 
@@ -130,12 +132,33 @@ def add_months(year: int, month: int, delta: int) -> tuple[int, int]:
     return idx // 12, idx % 12 + 1
 
 
-def count_catalog_events(source: Path) -> int | None:
-    path = source / "events_wsdc.csv"
+def count_occurred_editions(source: Path) -> int | None:
+    """Count WSDC editions that awarded points (not events_wsdc registry rows).
+
+    Includes editions even when start_date is missing — totals must move when
+    new results land, unlike the stale events_wsdc dump.
+    """
+    path = source / "event_editions.csv"
     if not path.exists():
         return None
+    count = 0
     with path.open("r", encoding="utf-8-sig", newline="") as f:
-        return sum(1 for _ in csv.DictReader(f))
+        for row in csv.DictReader(f):
+            name = (row.get("event_name") or "").strip()
+            if not name:
+                continue
+            try:
+                result_rows = int(float(row.get("result_rows") or 0))
+            except ValueError:
+                result_rows = 0
+            if truthy(row.get("event_occurred") or "") or result_rows > 0:
+                count += 1
+    return count
+
+
+def count_catalog_events(source: Path) -> int | None:
+    """Deprecated alias kept for callers; prefer count_occurred_editions."""
+    return count_occurred_editions(source)
 
 
 def load_editions(source: Path) -> list[Edition]:
@@ -418,7 +441,7 @@ def main() -> None:
     by_event, result_totals, first_points, first_wsdc_year, data_through = load_result_aggs(
         source, edition_starts
     )
-    catalog_events = count_catalog_events(source)
+    occurred_editions = count_occurred_editions(source)
 
     as_of = as_of_arg or date.today()
     if as_of > data_through:
@@ -430,7 +453,11 @@ def main() -> None:
         as_of = date.today()
 
     totals = {
-        "events": catalog_events if catalog_events is not None else len({ed.event_name for ed in editions}),
+        "events": (
+            occurred_editions
+            if occurred_editions is not None
+            else len({(ed.event_name, ed.event_year) for ed in editions if ed.occurred})
+        ),
         "points": result_totals["points"],
         "dancers": result_totals["dancers"],
     }
@@ -448,7 +475,10 @@ def main() -> None:
         "data_through": data_through.isoformat(),
         "source_dir": str(source),
         "methodology": {
-            "events_total": "count of rows in events_wsdc.csv",
+            "events_total": (
+                "count of occurred WSDC editions in event_editions.csv "
+                "(result_rows > 0 or event_occurred); one row per event year/month that awarded points"
+            ),
             "points_total": "sum of event_points across all nominations in dancers_results_info.csv",
             "dancers_total": "count of unique dancer_id in dancers_results_info.csv",
             "dancers_increment": (

--- a/static/data/homepage_kpis.json
+++ b/static/data/homepage_kpis.json
@@ -2,14 +2,14 @@
   "generated_at": "2026-07-20",
   "as_of": "2026-07-20",
   "data_through": "2026-07-31",
-  "source_dir": "/home/runner/work/wsdc-data-pipeline/wsdc-data-pipeline/data",
+  "source_dir": "/Users/ania/.cursor/projects/python/wsdc-data-pipeline/data",
   "methodology": {
-    "events_total": "count of rows in events_wsdc.csv",
+    "events_total": "count of occurred WSDC editions in event_editions.csv (result_rows > 0 or event_occurred); one row per event year/month that awarded points",
     "points_total": "sum of event_points across all nominations in dancers_results_info.csv",
     "dancers_total": "count of unique dancer_id in dancers_results_info.csv",
     "dancers_increment": "new dancers = unique dancer_id whose first WSDC points fall in the window (week/month: earliest edition start_date; year: event_year of that first event)",
     "edition_dates": "event_editions.csv start_date/end_date (edition_date remains YYYY-MM-01 for Tableau)",
-    "calendar_archive": "/home/runner/work/wsdc-data-pipeline/wsdc-data-pipeline/data/edition_calendar_dates.csv",
+    "calendar_archive": "/Users/ania/.cursor/projects/python/wsdc-data-pipeline/data/edition_calendar_dates.csv",
     "as_of_note": "as_of defaults to today.",
     "increment_note": "Events/points increments count activity in the window. Dancers increment counts new dancers (first WSDC points), not unique participants.",
     "week_note": "Week uses ISO week of edition start_date for occurred events. Never advances to a week with no occurred events (e.g. Jul 13-19 empty → keep Jul 6-12). Baseline since_previous_ended is end of previous calendar month.",
@@ -17,7 +17,7 @@
     "year_note": "Year increment uses WSDC event_year (not calendar start_date year), so late-December New Year events count toward the new year. Events = distinct event_name in results for that event_year; points = sum for those events; dancers = new dancers whose first points were at an event_year in this year."
   },
   "totals": {
-    "events": 2617,
+    "events": 2637,
     "points": 711119.0,
     "dancers": 27141
   },


### PR DESCRIPTION
## Summary
- Homepage **events** total now counts occurred editions in `event_editions.csv` (`result_rows > 0` / `event_occurred`), not rows in the stale `events_wsdc` registry
- Live total moves **2617 → 2637**; week/month increments unchanged
- Tip copy clarifies “editions that awarded points”

## Test plan
- [x] `build_homepage_kpis.py` → events=2637
- [x] `validate_site_data.py`
- [ ] After merge: https://wsdc-analytics.github.io/ shows 2637


Made with [Cursor](https://cursor.com)