### PR TITLE
Arizona: flush section titles left

### DIFF
--- a/events/001-arizona-4th-of-july/article_en.html
+++ b/events/001-arizona-4th-of-july/article_en.html
@@ -725,6 +725,15 @@
     .article-rail .article-feedback {
       text-align: left;
     }
+    /* Drop magazine H2 rail — flush left with body column */
+    .article-rail .section-title,
+    .article-rail h2.section-title,
+    .article-content .section-title,
+    .article-feedback-title {
+      border-left: none;
+      padding-left: 0;
+      margin-left: 0;
+    }
   </style>
 </head>
 <body>

--- a/events/001-arizona-4th-of-july/article_es.html
+++ b/events/001-arizona-4th-of-july/article_es.html
@@ -725,6 +725,15 @@
     .article-rail .article-feedback {
       text-align: left;
     }
+    /* Drop magazine H2 rail — flush left with body column */
+    .article-rail .section-title,
+    .article-rail h2.section-title,
+    .article-content .section-title,
+    .article-feedback-title {
+      border-left: none;
+      padding-left: 0;
+      margin-left: 0;
+    }
   </style>
 </head>
 <body>

--- a/events/001-arizona-4th-of-july/article_ru.html
+++ b/events/001-arizona-4th-of-july/article_ru.html
@@ -725,6 +725,15 @@
     .article-rail .article-feedback {
       text-align: left;
     }
+    /* Drop magazine H2 rail — flush left with body column */
+    .article-rail .section-title,
+    .article-rail h2.section-title,
+    .article-content .section-title,
+    .article-feedback-title {
+      border-left: none;
+      padding-left: 0;
+      margin-left: 0;
+    }
   </style>
 </head>
 <body>

--- a/scripts/build_arizona_event_articles.py
+++ b/scripts/build_arizona_event_articles.py
@@ -867,6 +867,15 @@ def build_one(lang: str, draft: str, i18n: dict) -> str:
     .article-rail .article-feedback {{
       text-align: left;
     }}
+    /* Drop magazine H2 rail — flush left with body column */
+    .article-rail .section-title,
+    .article-rail h2.section-title,
+    .article-content .section-title,
+    .article-feedback-title {{
+      border-left: none;
+      padding-left: 0;
+      margin-left: 0;
+    }}
   </style>
 </head>"""
 


### PR DESCRIPTION
## Summary
- Override article-shell left border/padding on `.section-title` so headings align with the body column
- Still not on the homepage

## Test plan
- [ ] H2 titles flush left with paragraphs (no indent rail)

Made with [Cursor](https://cursor.com)