### PR TITLE
Arizona: restore teal bar-chart highlight

### DIFF
--- a/events/001-arizona-4th-of-july/article_en.html
+++ b/events/001-arizona-4th-of-july/article_en.html
@@ -734,6 +734,17 @@
       padding-left: 0;
       margin-left: 0;
     }
+    /* Keep series teal: shell remaps --accent to brand gray */
+    :root {
+      --accent: #0f766e;
+    }
+    .hbar.is-focus .hbar-fill {
+      background: #0f766e;
+    }
+    .hbar.is-focus .hbar-meta,
+    .hbar.is-focus .hbar-value {
+      color: #0f766e;
+    }
   </style>
 </head>
 <body>

--- a/events/001-arizona-4th-of-july/article_es.html
+++ b/events/001-arizona-4th-of-july/article_es.html
@@ -734,6 +734,17 @@
       padding-left: 0;
       margin-left: 0;
     }
+    /* Keep series teal: shell remaps --accent to brand gray */
+    :root {
+      --accent: #0f766e;
+    }
+    .hbar.is-focus .hbar-fill {
+      background: #0f766e;
+    }
+    .hbar.is-focus .hbar-meta,
+    .hbar.is-focus .hbar-value {
+      color: #0f766e;
+    }
   </style>
 </head>
 <body>

--- a/events/001-arizona-4th-of-july/article_ru.html
+++ b/events/001-arizona-4th-of-july/article_ru.html
@@ -734,6 +734,17 @@
       padding-left: 0;
       margin-left: 0;
     }
+    /* Keep series teal: shell remaps --accent to brand gray */
+    :root {
+      --accent: #0f766e;
+    }
+    .hbar.is-focus .hbar-fill {
+      background: #0f766e;
+    }
+    .hbar.is-focus .hbar-meta,
+    .hbar.is-focus .hbar-value {
+      color: #0f766e;
+    }
   </style>
 </head>
 <body>

--- a/scripts/build_arizona_event_articles.py
+++ b/scripts/build_arizona_event_articles.py
@@ -876,6 +876,17 @@ def build_one(lang: str, draft: str, i18n: dict) -> str:
       padding-left: 0;
       margin-left: 0;
     }}
+    /* Keep series teal: shell remaps --accent to brand gray */
+    :root {{
+      --accent: #0f766e;
+    }}
+    .hbar.is-focus .hbar-fill {{
+      background: #0f766e;
+    }}
+    .hbar.is-focus .hbar-meta,
+    .hbar.is-focus .hbar-value {{
+      color: #0f766e;
+    }}
   </style>
 </head>"""
 


### PR DESCRIPTION
## Summary
- Restore series teal (`#0f766e`) after article-shell remaps `--accent` to gray
- Focused bar-chart rows (this event / leaders) show green again
- Still not on the homepage

## Test plan
- [ ] Peer / people / retention bars: focused row is teal, not gray

Made with [Cursor](https://cursor.com)