### PR TITLE
Arizona: highlight all rank-1 dancers in people bars

### DIFF
--- a/events/001-arizona-4th-of-july/article_en.html
+++ b/events/001-arizona-4th-of-july/article_en.html
@@ -1298,7 +1298,7 @@
     document.getElementById("peopleBars").innerHTML = rows.map((r) => {
       const v = r[valKey];
       const w = ((100 * v) / max).toFixed(1);
-      const focus = r.dancer_name === "Robert Royston";
+      const focus = v === max;
       return hbar(r.dancer_name, String(v), w, focus, false);
     }).join("");
   }

--- a/events/001-arizona-4th-of-july/article_es.html
+++ b/events/001-arizona-4th-of-july/article_es.html
@@ -1298,7 +1298,7 @@
     document.getElementById("peopleBars").innerHTML = rows.map((r) => {
       const v = r[valKey];
       const w = ((100 * v) / max).toFixed(1);
-      const focus = r.dancer_name === "Robert Royston";
+      const focus = v === max;
       return hbar(r.dancer_name, String(v), w, focus, false);
     }).join("");
   }

--- a/events/001-arizona-4th-of-july/article_ru.html
+++ b/events/001-arizona-4th-of-july/article_ru.html
@@ -1298,7 +1298,7 @@
     document.getElementById("peopleBars").innerHTML = rows.map((r) => {
       const v = r[valKey];
       const w = ((100 * v) / max).toFixed(1);
-      const focus = r.dancer_name === "Robert Royston";
+      const focus = v === max;
       return hbar(r.dancer_name, String(v), w, focus, false);
     }).join("");
   }

--- a/events/001-arizona-4th-of-july/source_draft_ru.html
+++ b/events/001-arizona-4th-of-july/source_draft_ru.html
@@ -1100,7 +1100,7 @@
     document.getElementById("peopleBars").innerHTML = rows.map((r) => {
       const v = r[valKey];
       const w = ((100 * v) / max).toFixed(1);
-      const focus = r.dancer_name === "Robert Royston";
+      const focus = v === max;
       return hbar(r.dancer_name, String(v), w, focus, false);
     }).join("");
   }


### PR DESCRIPTION
## Summary
- People bar chart focus uses max value (rank 1), not a hard-coded name
- Benji Schwimmer is highlighted alongside Royston on editions/wins ties
- Still not on the homepage

## Test plan
- [ ] Points: only Royston teal
- [ ] Editions / Wins: Royston and Schwimmer both teal

Made with [Cursor](https://cursor.com)