### PR TITLE
Fix magazine articles: sticky site chrome like homepage

### DIFF
--- a/article_3year_rule.html
+++ b/article_3year_rule.html
@@ -561,6 +561,7 @@
   <a href="#main-content" class="skip-link">Перейти к содержимому</a>
     <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="ru"
     data-home-href="index.html"
@@ -569,7 +570,7 @@
     data-lang-en="article_3year_rule_en.html"
     data-lang-es="article_3year_rule_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
     <header class="header">
       <div class="article-header-top">
         <a class="wsdc-back is-on-hero" href="index.html?lang=ru" data-wsdc-back id="backLink">На главную</a>

--- a/article_3year_rule_en.html
+++ b/article_3year_rule_en.html
@@ -561,6 +561,7 @@
   <a href="#main-content" class="skip-link">Skip to content</a>
     <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="en"
     data-home-href="index.html"
@@ -569,7 +570,7 @@
     data-lang-en="article_3year_rule_en.html"
     data-lang-es="article_3year_rule_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
     <header class="header">
       <div class="article-header-top">
         <a class="wsdc-back is-on-hero" href="index.html?lang=en" data-wsdc-back id="backLink">Back to home</a>

--- a/article_3year_rule_es.html
+++ b/article_3year_rule_es.html
@@ -561,6 +561,7 @@
   <a href="#main-content" class="skip-link">Saltar al contenido</a>
     <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="es"
     data-home-href="index.html"
@@ -569,7 +570,7 @@
     data-lang-en="article_3year_rule_en.html"
     data-lang-es="article_3year_rule_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
     <header class="header">
       <div class="article-header-top">
         <a class="wsdc-back is-on-hero" href="index.html?lang=es" data-wsdc-back id="backLink">Volver al inicio</a>

--- a/article_division_transition_time.html
+++ b/article_division_transition_time.html
@@ -771,6 +771,7 @@
   <a href="#main-content" class="skip-link">Перейти к содержимому</a>
     <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="ru"
     data-home-href="index.html"
@@ -779,7 +780,7 @@
     data-lang-en="article_division_transition_time_en.html"
     data-lang-es="article_division_transition_time_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
     <header class="header">
       <div class="article-header-top">
         <a class="wsdc-back is-on-hero" href="index.html?lang=ru" data-wsdc-back id="backLink">На главную</a>

--- a/article_division_transition_time_en.html
+++ b/article_division_transition_time_en.html
@@ -771,6 +771,7 @@
   <a href="#main-content" class="skip-link">Skip to content</a>
   <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="en"
     data-home-href="index.html"
@@ -779,7 +780,7 @@
     data-lang-en="article_division_transition_time_en.html"
     data-lang-es="article_division_transition_time_es.html"
   ></div>
-  <div class="magazine-container">
+  <div class="wsdc-chrome-page-pad magazine-container">
     <header class="header">
             <div class="article-header-top">
         <a class="wsdc-back is-on-hero" href="index.html?lang=en" data-wsdc-back id="backLink">Back to home</a>

--- a/article_division_transition_time_es.html
+++ b/article_division_transition_time_es.html
@@ -771,6 +771,7 @@
   <a href="#main-content" class="skip-link">Saltar al contenido</a>
     <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="es"
     data-home-href="index.html"
@@ -779,7 +780,7 @@
     data-lang-en="article_division_transition_time_en.html"
     data-lang-es="article_division_transition_time_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
     <header class="header">
       <div class="article-header-top">
         <a class="wsdc-back is-on-hero" href="index.html?lang=es" data-wsdc-back id="backLink">Volver al inicio</a>

--- a/article_secondary_role.html
+++ b/article_secondary_role.html
@@ -718,6 +718,7 @@
   <a href="#main-content" class="skip-link">Перейти к содержимому</a>
     <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="ru"
     data-home-href="index.html"
@@ -726,7 +727,7 @@
     data-lang-en="article_secondary_role_en.html"
     data-lang-es="article_secondary_role_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
     <header class="article-header">
       <div class="article-header-top">
         <a class="wsdc-back is-on-hero" href="index.html?lang=ru" data-wsdc-back id="backLink">На главную</a>

--- a/article_secondary_role_en.html
+++ b/article_secondary_role_en.html
@@ -602,6 +602,7 @@
   <a href="#main-content" class="skip-link">Skip to content</a>
     <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="en"
     data-home-href="index.html"
@@ -610,7 +611,7 @@
     data-lang-en="article_secondary_role_en.html"
     data-lang-es="article_secondary_role_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
     <header class="article-header">
       <div class="article-header-top">
         <a class="wsdc-back is-on-hero" href="index.html?lang=en" data-wsdc-back id="backLink">Back to home</a>

--- a/article_secondary_role_es.html
+++ b/article_secondary_role_es.html
@@ -574,6 +574,7 @@
   <a href="#main-content" class="skip-link">Ir al contenido</a>
     <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="es"
     data-home-href="index.html"
@@ -582,7 +583,7 @@
     data-lang-en="article_secondary_role_en.html"
     data-lang-es="article_secondary_role_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
     <header class="article-header">
       <div class="article-header-top">
         <a class="wsdc-back is-on-hero" href="index.html?lang=es" data-wsdc-back id="backLink">Volver al inicio</a>

--- a/dancers_2025.html
+++ b/dancers_2025.html
@@ -886,6 +886,7 @@
     
       <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="ru"
     data-home-href="index.html"
@@ -894,7 +895,7 @@
     data-lang-en="dancers_2025_en.html"
     data-lang-es="dancers_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
         <header class="article-header">
             <div class="article-header-top">
                 <a class="wsdc-back is-on-hero" href="index.html?lang=ru" data-wsdc-back id="backLink">На главную</a>

--- a/dancers_2025_en.html
+++ b/dancers_2025_en.html
@@ -883,6 +883,7 @@
     
   <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="en"
     data-home-href="index.html"
@@ -891,7 +892,7 @@
     data-lang-en="dancers_2025_en.html"
     data-lang-es="dancers_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
 <header class="article-header">
 <div class="article-header-top">
                 <a class="wsdc-back is-on-hero" href="index.html?lang=en" data-wsdc-back id="backLink">Back to home</a>

--- a/dancers_2025_es.html
+++ b/dancers_2025_es.html
@@ -886,6 +886,7 @@
     
       <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="es"
     data-home-href="index.html"
@@ -894,7 +895,7 @@
     data-lang-en="dancers_2025_en.html"
     data-lang-es="dancers_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
         <header class="article-header">
             <div class="article-header-top">
                 <a class="wsdc-back is-on-hero" href="index.html?lang=es" data-wsdc-back id="backLink">Volver al inicio</a>

--- a/docs/SITE_CHROME.md
+++ b/docs/SITE_CHROME.md
@@ -32,7 +32,7 @@ Mount point:
 | --- | --- | --- |
 | `data-active` | `home` \| `dashboards` \| `points` | Highlights nav pill |
 | `data-lang` | `ru` \| `en` \| `es` | Initial language pills |
-| `data-fixed` | `true` | Fixed floating bar (homepage) |
+| `data-fixed` | `true` | Fixed floating bar (homepage **and magazine articles**) |
 | `data-brand` | `logo` (default) \| `text` | WSDC logo links home |
 | `data-home-href` | URL | Logo → home (default `index.html`) |
 | `data-lang-mode` | `callback` \| `navigate` | Per-lang navigation or callback |
@@ -61,4 +61,17 @@ window.WsdcChrome.onLangChange = function (lang) {
 };
 ```
 
-Add `wsdc-chrome-page-pad` when using `data-fixed="true"`.
+Add `wsdc-chrome-page-pad` when using `data-fixed="true"` (homepage and magazine articles).
+
+```html
+<div
+  data-site-chrome
+  data-fixed="true"
+  data-active="home"
+  data-lang="en"
+  data-home-href="index.html"
+></div>
+<div class="wsdc-chrome-page-pad magazine-container">
+  …
+</div>
+```

--- a/events/001-arizona-4th-of-july/article_en.html
+++ b/events/001-arizona-4th-of-july/article_en.html
@@ -751,6 +751,7 @@
   <a href="#main-content" class="skip-link">Skip to content</a>
   <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="en"
     data-home-href="../../index.html"
@@ -761,7 +762,7 @@
     data-lang-es="article_es.html"
   ></div>
 
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
   <header class="article-header">
     <div class="article-header-top">
       <a class="wsdc-back is-on-hero" href="../../index.html?lang=en" data-wsdc-back id="backLink">Back to home</a>

--- a/events/001-arizona-4th-of-july/article_es.html
+++ b/events/001-arizona-4th-of-july/article_es.html
@@ -751,6 +751,7 @@
   <a href="#main-content" class="skip-link">Saltar al contenido</a>
   <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="es"
     data-home-href="../../index.html"
@@ -761,7 +762,7 @@
     data-lang-es="article_es.html"
   ></div>
 
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
   <header class="article-header">
     <div class="article-header-top">
       <a class="wsdc-back is-on-hero" href="../../index.html?lang=es" data-wsdc-back id="backLink">Volver al inicio</a>

--- a/events/001-arizona-4th-of-july/article_ru.html
+++ b/events/001-arizona-4th-of-july/article_ru.html
@@ -751,6 +751,7 @@
   <a href="#main-content" class="skip-link">Перейти к содержимому</a>
   <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="ru"
     data-home-href="../../index.html"
@@ -761,7 +762,7 @@
     data-lang-es="article_es.html"
   ></div>
 
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
   <header class="article-header">
     <div class="article-header-top">
       <a class="wsdc-back is-on-hero" href="../../index.html?lang=ru" data-wsdc-back id="backLink">На главную</a>

--- a/events_2025.html
+++ b/events_2025.html
@@ -786,6 +786,7 @@
     
   <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="ru"
     data-home-href="index.html"
@@ -794,7 +795,7 @@
     data-lang-en="events_2025_en.html"
     data-lang-es="events_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
 <header class="article-header">
 <div class="article-header-top">
 <a class="wsdc-back is-on-hero" href="index.html?lang=ru" data-wsdc-back id="backLink">На главную</a>

--- a/events_2025_en.html
+++ b/events_2025_en.html
@@ -786,6 +786,7 @@
     
   <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="en"
     data-home-href="index.html"
@@ -794,7 +795,7 @@
     data-lang-en="events_2025_en.html"
     data-lang-es="events_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
 <header class="article-header">
 <div class="article-header-top">
 <a class="wsdc-back is-on-hero" href="index.html?lang=en" data-wsdc-back id="backLink">Back to home</a>

--- a/events_2025_es.html
+++ b/events_2025_es.html
@@ -786,6 +786,7 @@
     
   <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="es"
     data-home-href="index.html"
@@ -794,7 +795,7 @@
     data-lang-en="events_2025_en.html"
     data-lang-es="events_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
 <header class="article-header">
 <div class="article-header-top">
 <a class="wsdc-back is-on-hero" href="index.html?lang=es" data-wsdc-back id="backLink">Volver al inicio</a>

--- a/geo_2025.html
+++ b/geo_2025.html
@@ -684,6 +684,7 @@
     
   <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="ru"
     data-home-href="index.html"
@@ -692,7 +693,7 @@
     data-lang-en="geo_2025_en.html"
     data-lang-es="geo_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
 <header class="article-header">
 <div class="article-header-top">
 <a class="wsdc-back is-on-hero" href="index.html?lang=ru" data-wsdc-back id="backLink">На главную</a>

--- a/geo_2025_en.html
+++ b/geo_2025_en.html
@@ -684,6 +684,7 @@
     
   <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="en"
     data-home-href="index.html"
@@ -692,7 +693,7 @@
     data-lang-en="geo_2025_en.html"
     data-lang-es="geo_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
 <header class="article-header">
 <div class="article-header-top">
 <a class="wsdc-back is-on-hero" href="index.html?lang=en" data-wsdc-back id="backLink">Back to home</a>

--- a/geo_2025_es.html
+++ b/geo_2025_es.html
@@ -684,6 +684,7 @@
     
   <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="es"
     data-home-href="index.html"
@@ -692,7 +693,7 @@
     data-lang-en="geo_2025_en.html"
     data-lang-es="geo_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
 <header class="article-header">
 <div class="article-header-top">
 <a class="wsdc-back is-on-hero" href="index.html?lang=es" data-wsdc-back id="backLink">Volver al inicio</a>

--- a/overview_2025.html
+++ b/overview_2025.html
@@ -1184,6 +1184,7 @@
     <a href="#main-content" class="skip-link">Перейти к содержимому</a>
       <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="ru"
     data-home-href="index.html"
@@ -1192,7 +1193,7 @@
     data-lang-en="overview_2025_en.html"
     data-lang-es="overview_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
         <!-- Article Header -->
         <header class="article-header">
             <div class="article-header-top">

--- a/overview_2025_en.html
+++ b/overview_2025_en.html
@@ -1124,6 +1124,7 @@
     
       <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="en"
     data-home-href="index.html"
@@ -1132,7 +1133,7 @@
     data-lang-en="overview_2025_en.html"
     data-lang-es="overview_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
         <!-- Article Header -->
         <header class="article-header">
             <div class="article-header-top">

--- a/overview_2025_es.html
+++ b/overview_2025_es.html
@@ -1122,6 +1122,7 @@
     
       <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="es"
     data-home-href="index.html"
@@ -1130,7 +1131,7 @@
     data-lang-en="overview_2025_en.html"
     data-lang-es="overview_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
         <!-- Article Header -->
         <header class="article-header">
             <div class="article-header-top">

--- a/rules_catalog.html
+++ b/rules_catalog.html
@@ -150,6 +150,7 @@
 <body>
       <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="ru"
     data-home-href="index.html"
@@ -158,7 +159,7 @@
     data-lang-en="rules_catalog_en.html"
     data-lang-es="rules_catalog_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
         <header class="article-header">
             <div class="article-header-top">
                 <a class="wsdc-back is-on-hero" href="index.html?lang=ru" data-wsdc-back id="backLink">На главную</a>

--- a/rules_catalog_en.html
+++ b/rules_catalog_en.html
@@ -150,6 +150,7 @@
 <body>
       <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="en"
     data-home-href="index.html"
@@ -158,7 +159,7 @@
     data-lang-en="rules_catalog_en.html"
     data-lang-es="rules_catalog_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
         <header class="article-header">
             <div class="article-header-top">
                 <a class="wsdc-back is-on-hero" href="index.html?lang=en" data-wsdc-back id="backLink">Back to home</a>

--- a/rules_catalog_es.html
+++ b/rules_catalog_es.html
@@ -150,6 +150,7 @@
 <body>
       <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="es"
     data-home-href="index.html"
@@ -158,7 +159,7 @@
     data-lang-en="rules_catalog_en.html"
     data-lang-es="rules_catalog_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
         <header class="article-header">
             <div class="article-header-top">
                 <a class="wsdc-back is-on-hero" href="index.html?lang=es" data-wsdc-back id="backLink">Volver al inicio</a>

--- a/rules_evolution_2025.html
+++ b/rules_evolution_2025.html
@@ -959,6 +959,7 @@
     <a href="#main-content" class="skip-link">Перейти к содержимому</a>
       <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="ru"
     data-home-href="index.html"
@@ -967,7 +968,7 @@
     data-lang-en="rules_evolution_2025_en.html"
     data-lang-es="rules_evolution_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
         <header class="article-header">
             <div class="article-header-top">
                 <a class="wsdc-back is-on-hero" href="index.html?lang=ru" data-wsdc-back id="backLink">На главную</a>

--- a/rules_evolution_2025_en.html
+++ b/rules_evolution_2025_en.html
@@ -956,6 +956,7 @@
     <a href="#main-content" class="skip-link">Skip to content</a>
       <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="en"
     data-home-href="index.html"
@@ -964,7 +965,7 @@
     data-lang-en="rules_evolution_2025_en.html"
     data-lang-es="rules_evolution_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
         <header class="article-header">
             <div class="article-header-top">
                 <a class="wsdc-back is-on-hero" href="index.html?lang=en" data-wsdc-back id="backLink">Back to home</a>

--- a/rules_evolution_2025_es.html
+++ b/rules_evolution_2025_es.html
@@ -942,6 +942,7 @@
     <a href="#main-content" class="skip-link">Saltar al contenido</a>
       <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="es"
     data-home-href="index.html"
@@ -950,7 +951,7 @@
     data-lang-en="rules_evolution_2025_en.html"
     data-lang-es="rules_evolution_2025_es.html"
   ></div>
-<div class="magazine-container">
+<div class="wsdc-chrome-page-pad magazine-container">
         <header class="article-header">
             <div class="article-header-top">
                 <a class="wsdc-back is-on-hero" href="index.html?lang=es" data-wsdc-back id="backLink">Volver al inicio</a>

--- a/scripts/build_arizona_event_articles.py
+++ b/scripts/build_arizona_event_articles.py
@@ -177,6 +177,7 @@ def chrome_mount(t: dict) -> str:
     return f"""  <a href="#main-content" class="skip-link">{esc_html(t['skip_link'])}</a>
   <div
     data-site-chrome
+    data-fixed="true"
     data-active="home"
     data-lang="{lang}"
     data-home-href="../../index.html"
@@ -898,7 +899,11 @@ def build_one(lang: str, draft: str, i18n: dict) -> str:
     )
 
     # Body: chrome + back link
-    html = html.replace("<body>\n\n<div class=\"magazine-container\">", "<body>\n" + chrome_mount(t) + "\n<div class=\"magazine-container\">", 1)
+    html = html.replace(
+        "<body>\n\n<div class=\"magazine-container\">",
+        "<body>\n" + chrome_mount(t) + "\n<div class=\"wsdc-chrome-page-pad magazine-container\">",
+        1,
+    )
     html = html.replace(
         '  <header class="article-header">\n    <div class="article-header-media"',
         f'  <header class="article-header">\n    <div class="article-header-top">\n      <a class="wsdc-back is-on-hero" href="../../index.html?lang={lang}" data-wsdc-back id="backLink">{esc_html(t["back_home"])}</a>\n    </div>\n    <div class="article-header-media"',

--- a/static/js/site-chrome.js
+++ b/static/js/site-chrome.js
@@ -4,7 +4,7 @@
  * Attributes:
  *   data-active          home | dashboards | points
  *   data-lang            ru | en | es
- *   data-fixed           "true" for position:fixed (homepage)
+ *   data-fixed           "true" for position:fixed (homepage + magazine articles)
  *   data-brand           "logo" (default) | "text"
  *   data-home-href       brand logo link (default index.html) — return home
  *   data-path-prefix     prefix for dashboard / points-summary hrefs (e.g. "../../" from nested pages)


### PR DESCRIPTION
## Summary
- Enable `data-fixed="true"` on all magazine article chrome mounts (same as homepage).
- Add `wsdc-chrome-page-pad` on `magazine-container` so content clears the floating bar.
- Keep Arizona rebuild script / SITE_CHROME docs in sync.

## Test plan
- [ ] Open any article (e.g. 3-year rule, Arizona EN) and scroll — chrome bar stays fixed.
- [ ] Confirm hero / “Back to home” are not covered by the bar.
- [ ] Spot-check mobile width (two-row chrome) still has enough top padding.

Made with [Cursor](https://cursor.com)