### PR TITLE
Publish Arizona event portrait on homepage

### DIFF
--- a/events/001-arizona-4th-of-july/article_en.html
+++ b/events/001-arizona-4th-of-july/article_en.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex,nofollow">
   <link rel="canonical" href="https://wsdc-analytics.github.io/events/001-arizona-4th-of-july/article_en.html" />
   <link rel="alternate" hreflang="ru" href="https://wsdc-analytics.github.io/events/001-arizona-4th-of-july/article_ru.html" />
   <link rel="alternate" hreflang="en" href="https://wsdc-analytics.github.io/events/001-arizona-4th-of-july/article_en.html" />

--- a/events/001-arizona-4th-of-july/article_es.html
+++ b/events/001-arizona-4th-of-july/article_es.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex,nofollow">
   <link rel="canonical" href="https://wsdc-analytics.github.io/events/001-arizona-4th-of-july/article_es.html" />
   <link rel="alternate" hreflang="ru" href="https://wsdc-analytics.github.io/events/001-arizona-4th-of-july/article_ru.html" />
   <link rel="alternate" hreflang="en" href="https://wsdc-analytics.github.io/events/001-arizona-4th-of-july/article_en.html" />

--- a/events/001-arizona-4th-of-july/article_ru.html
+++ b/events/001-arizona-4th-of-july/article_ru.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex,nofollow">
   <link rel="canonical" href="https://wsdc-analytics.github.io/events/001-arizona-4th-of-july/article_ru.html" />
   <link rel="alternate" hreflang="ru" href="https://wsdc-analytics.github.io/events/001-arizona-4th-of-july/article_ru.html" />
   <link rel="alternate" hreflang="en" href="https://wsdc-analytics.github.io/events/001-arizona-4th-of-july/article_en.html" />

--- a/events/001-arizona-4th-of-july/source_draft_ru.html
+++ b/events/001-arizona-4th-of-july/source_draft_ru.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex,nofollow">
   <meta name="description" content="4TH of July Convention (Финикс): портрет события через поинты Jack&Jill WSDC (черновик)">
   <title>4TH of July Convention: портрет события (черновик)</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/events/README.md
+++ b/events/README.md
@@ -12,6 +12,8 @@ Series editorial guide (conclusion-first sections, charts after insight, Summary
 
 Drafts under `events/` are **not** linked from the homepage or `static/data/articles.json` until ready to publish.
 
+**Published:** [`001-arizona-4th-of-july/`](001-arizona-4th-of-july/) (RU/EN/ES) — on homepage and in `articles.json` since 2026-07-22.
+
 ## Naming
 
 `NNN-<region-or-state>-<event-slug>/`
@@ -37,4 +39,4 @@ Stack (bottom → top), same brightness family as other article heroes (`#2d3748
 - [`001-arizona-4th-of-july/article_ru.html`](001-arizona-4th-of-july/article_ru.html) · [`article_en.html`](001-arizona-4th-of-july/article_en.html) · [`article_es.html`](001-arizona-4th-of-july/article_es.html)
 - Rebuild from `source_draft_ru.html` + `i18n.json`: `python3 scripts/build_arizona_event_articles.py`
 - `draft_ru.html` redirects to `article_ru.html` (old URL)
-- Still **not** on the homepage until explicit publish
+- **Published** on homepage (`static/data/articles.json`) since 2026-07-22

--- a/scripts/build_arizona_event_articles.py
+++ b/scripts/build_arizona_event_articles.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-"""Build production article_ru/en/es from draft_ru.html + i18n.json.
-
-Does NOT link from homepage / articles.json (publish is a separate step).
-Keeps noindex until official publish.
-"""
+"""Build production article_ru/en/es from source_draft_ru.html + i18n.json."""
 from __future__ import annotations
 
 import json
@@ -103,8 +99,7 @@ def head_extras(t: dict) -> str:
     lang = t["lang"]
     page = f"article_{lang}.html"
     url = f"{BASE}/{page}"
-    return f"""  <meta name="robots" content="noindex,nofollow">
-  <link rel="canonical" href="{url}" />
+    return f"""  <link rel="canonical" href="{url}" />
   <link rel="alternate" hreflang="ru" href="{BASE}/article_ru.html" />
   <link rel="alternate" hreflang="en" href="{BASE}/article_en.html" />
   <link rel="alternate" hreflang="es" href="{BASE}/article_es.html" />

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -204,4 +204,22 @@
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
+<url>
+    <loc>https://wsdc-analytics.github.io/events/001-arizona-4th-of-july/article_ru.html</loc>
+    <lastmod>2026-07-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+<url>
+    <loc>https://wsdc-analytics.github.io/events/001-arizona-4th-of-july/article_en.html</loc>
+    <lastmod>2026-07-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+<url>
+    <loc>https://wsdc-analytics.github.io/events/001-arizona-4th-of-july/article_es.html</loc>
+    <lastmod>2026-07-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
 </urlset>

--- a/static/data/articles.json
+++ b/static/data/articles.json
@@ -1,6 +1,15 @@
 {
   "ru": [
     {
+      "title": "4TH of July Convention: портрет события",
+      "language": "RU",
+      "description": "34 издания с 1991 года, 1364 танцора с поинтами Skill Level и 245, кто начал путь в WSDC именно здесь.",
+      "url": "events/001-arizona-4th-of-july/article_ru.html",
+      "keywords": "WSDC, 4TH of July Convention, Финикс, West Coast Swing, реестр поинтов, Jack and Jill, Skill Level, портрет ивента",
+      "datePublished": "2026-07-22",
+      "category": "Ивенты"
+    },
+    {
       "title": "WSDC 2025: Континентальные различия в динамике развития",
       "language": "RU",
       "description": "По итогам 2025 года: Америка сохраняет стабильность, пока Европа бьет рекорды роста.",
@@ -75,6 +84,15 @@
   ],
   "en": [
     {
+      "title": "4TH of July Convention: An Event Portrait",
+      "language": "EN",
+      "description": "34 editions since 1991, 1,364 dancers with Skill Level points, and 245 who earned their first WSDC points in Phoenix.",
+      "url": "events/001-arizona-4th-of-july/article_en.html",
+      "keywords": "WSDC, 4TH of July Convention, Phoenix Arizona, West Coast Swing, points registry, Jack and Jill, Skill Level, event portrait",
+      "datePublished": "2026-07-22",
+      "category": "Events"
+    },
+    {
       "title": "WSDC 2025: Continental Differences in Development Dynamics",
       "language": "EN",
       "description": "Fresh data from 2025 reveals a community at a crossroads: a mature American heartland and a European frontier expanding at breakneck speed.",
@@ -148,6 +166,15 @@
     }
   ],
   "es": [
+    {
+      "title": "4TH of July Convention: retrato de un evento",
+      "language": "ES",
+      "description": "34 ediciones desde 1991, 1364 bailarines con puntos Skill Level y 245 que obtuvieron sus primeros puntos WSDC en Phoenix.",
+      "url": "events/001-arizona-4th-of-july/article_es.html",
+      "keywords": "WSDC, 4TH of July Convention, Phoenix Arizona, West Coast Swing, registro de puntos, Jack and Jill, Skill Level, retrato de evento",
+      "datePublished": "2026-07-22",
+      "category": "Eventos"
+    },
     {
       "title": "WSDC 2025: diferencias continentales en la dinámica de desarrollo",
       "language": "ES",


### PR DESCRIPTION
## Summary
- Add 4TH of July Convention (RU/EN/ES) to `static/data/articles.json` with `datePublished: 2026-07-22` so it appears as the featured **Latest** card on the homepage.
- Add article URLs to `sitemap.xml`.
- Remove `noindex` from Arizona production pages and the build script.

## Test plan
- [ ] Homepage RU/EN/ES: Arizona card is first, highlighted as Latest
- [ ] Card links open `events/001-arizona-4th-of-july/article_*.html`
- [ ] Articles are indexable (no `noindex` in `<head>`)

Made with [Cursor](https://cursor.com)