### PR TITLE
Update Arizona homepage card copy

### DIFF
--- a/static/data/articles.json
+++ b/static/data/articles.json
@@ -1,9 +1,9 @@
 {
   "ru": [
     {
-      "title": "4TH of July Convention: портрет события",
+      "title": "Портрет ивента - 4TH of July Convention",
       "language": "RU",
-      "description": "34 издания с 1991 года, 1364 танцора с поинтами Skill Level и 245, кто начал путь в WSDC именно здесь.",
+      "description": "Портрет ивента с самой долгой историей проведения на основании реестра поинтов WSDC.",
       "url": "events/001-arizona-4th-of-july/article_ru.html",
       "keywords": "WSDC, 4TH of July Convention, Финикс, West Coast Swing, реестр поинтов, Jack and Jill, Skill Level, портрет ивента",
       "datePublished": "2026-07-22",
@@ -84,9 +84,9 @@
   ],
   "en": [
     {
-      "title": "4TH of July Convention: An Event Portrait",
+      "title": "Event portrait - 4TH of July Convention",
       "language": "EN",
-      "description": "34 editions since 1991, 1,364 dancers with Skill Level points, and 245 who earned their first WSDC points in Phoenix.",
+      "description": "Portrait of the longest-running event in the WSDC points registry.",
       "url": "events/001-arizona-4th-of-july/article_en.html",
       "keywords": "WSDC, 4TH of July Convention, Phoenix Arizona, West Coast Swing, points registry, Jack and Jill, Skill Level, event portrait",
       "datePublished": "2026-07-22",
@@ -167,9 +167,9 @@
   ],
   "es": [
     {
-      "title": "4TH of July Convention: retrato de un evento",
+      "title": "Retrato de evento - 4TH of July Convention",
       "language": "ES",
-      "description": "34 ediciones desde 1991, 1364 bailarines con puntos Skill Level y 245 que obtuvieron sus primeros puntos WSDC en Phoenix.",
+      "description": "Retrato del evento con la historia más larga del registro de puntos WSDC.",
       "url": "events/001-arizona-4th-of-july/article_es.html",
       "keywords": "WSDC, 4TH of July Convention, Phoenix Arizona, West Coast Swing, registro de puntos, Jack and Jill, Skill Level, retrato de evento",
       "datePublished": "2026-07-22",


### PR DESCRIPTION
## Summary
- RU card: **Портрет ивента - 4TH of July Convention** + new description about the longest-running event in the WSDC points registry.
- EN/ES: matching adapted title and description.

## Test plan
- [ ] Homepage RU: featured card shows new title and subtitle

Made with [Cursor](https://cursor.com)