### PR TITLE
SEO: canonical tags + remove duplicate homepage from sitemap

### DIFF
--- a/dancer-profile.html
+++ b/dancer-profile.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://wsdc-analytics.github.io/dancer-profile.html">
     <meta name="description" content="Dancer Profile - профиль танцора WSDC">
     <title>Dancer Profile | WSDC Analytics</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/dashboard.html
+++ b/dashboard.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://wsdc-analytics.github.io/dashboard.html">
     <meta name="description" content="WSDC KPI Dashboard - interactive West Coast Swing analytics">
     <title>WSDC KPI Dashboard | WSDC Analytics</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://wsdc-analytics.github.io/">
     <meta name="google-site-verification" content="QVff8NSySSaK5zqCIPAbTF1zyv6IX5zGoDT4xq-Qs2w" />
     <meta name="description" content="WSDC Analytics - Data-driven insights and analysis on the West Coast Swing competitive scene. WSDC events rankings, statistics, and trends for 2025.">
     <meta name="keywords" content="WSDC Analytics, WSDC, West Coast Swing, swing dance, competitive dance, dance analytics, WCS events, WSDC statistics, WSDC rankings">

--- a/navigator.html
+++ b/navigator.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://wsdc-analytics.github.io/navigator.html">
     <meta name="description" content="WSDC Navigator - карта событий West Coast Swing">
     <title>WSDC Navigator | WSDC Analytics</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/points-summary.html
+++ b/points-summary.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://wsdc-analytics.github.io/points-summary.html">
     <meta name="description" content="WSDC Points Summary - Registry points awarded by event and division. Not full competition results.">
     <meta name="keywords" content="WSDC, Points Summary, registry points, events, divisions, WCS, West Coast Swing, placements">
     <!-- Open Graph / Facebook -->

--- a/rankings.html
+++ b/rankings.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="canonical" href="https://wsdc-analytics.github.io/rankings.html">
     <meta name="description" content="Dancer's Rankings Combinator - рейтинги WSDC">
     <title>Dancer's Rankings Combinator | WSDC Analytics</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,13 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://wsdc-analytics.github.io/</loc>
-    <lastmod>2026-02-13</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-<url>
-    <loc>https://wsdc-analytics.github.io/index.html</loc>
-    <lastmod>2026-02-13</lastmod>
+    <lastmod>2026-07-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- Remove `index.html` from `sitemap.xml` (duplicate of `/`).
- Add `<link rel="canonical">` to homepage and all dashboard pages listed in sitemap.

## Test plan
- [ ] `sitemap.xml` has `/` but not `index.html`
- [ ] View source on index + dashboards shows canonical URLs
- [ ] Re-submit `sitemap.xml` in Search Console after deploy

Made with [Cursor](https://cursor.com)