### PR TITLE
Fix lang-redirect: honor ?lang= without auto-redirect

### DIFF
--- a/static/js/lang-redirect.js
+++ b/static/js/lang-redirect.js
@@ -57,13 +57,17 @@
     if (!current) return;
 
     var params = new URLSearchParams(window.location.search);
-    var forced = params.get("setlang");
+    // Treat both setlang and lang as explicit user choice.
+    // If present, do not run auto language detection redirect.
+    var forced = params.get("setlang") || params.get("lang");
     if (forced && ["ru", "en", "es"].indexOf(forced) !== -1) {
       localStorage.setItem("wsdc-lang", forced);
       params.delete("setlang");
+      params.delete("lang");
       var cleanQuery = params.toString();
       var forcedTarget = buildTarget(current.base, forced);
       var forcedUrl = forcedTarget + (cleanQuery ? "?" + cleanQuery : "") + window.location.hash;
+      if (forcedTarget === current.file && !cleanQuery) return;
       window.location.replace(forcedUrl);
       return;
     }


### PR DESCRIPTION
## Summary
- Treat `?lang=` the same as `?setlang=` as an explicit language choice in `static/js/lang-redirect.js`.
- Skip self-redirect when the page already matches the forced language and the query is clean.
- Prevents Google Search Console from classifying URLs like `/dancers_2025.html?lang=ru` as redirect pages when JS auto-detection would otherwise send crawlers elsewhere.

## Test plan
- [ ] Open `https://wsdc-analytics.github.io/dancers_2025.html?lang=ru` after deploy → stays on RU page (no jump to `_en`/`_es`)
- [ ] Open `...?lang=en` from RU file → lands on `dancers_2025_en.html` (clean URL preferred)
- [ ] Open `...?lang=es` → lands on `dancers_2025_es.html`
- [ ] Without `lang`/`setlang`, existing auto preference redirect still works
- [ ] Hard-refresh / cache-bust `static/js/lang-redirect.js` if CDN serves old file


Made with [Cursor](https://cursor.com)