### PR TITLE
Publish UK WCS Championships article on homepage

### DIFF
--- a/static/data/articles.json
+++ b/static/data/articles.json
@@ -1,6 +1,15 @@
 {
   "ru": [
     {
+      "title": "UK WCS Championships: портрет события",
+      "language": "RU",
+      "description": "13 изданий с 2009 года, 752 танцора, 211 первых поинтов в Лондоне.",
+      "url": "events/002-uk-wcs-championships/article_ru.html",
+      "keywords": "WSDC, UK WCS Championships, Лондон, West Coast Swing, реестр поинтов, Jack and Jill, Skill Level, Европа",
+      "datePublished": "2026-07-27",
+      "category": "Ивенты"
+    },
+    {
       "title": "Портрет ивента: 4TH of July Convention",
       "language": "RU",
       "description": "Статья об ивенте с самой долгой историей проведения на основании реестра поинтов WSDC",
@@ -84,6 +93,15 @@
   ],
   "en": [
     {
+      "title": "UK WCS Championships: An Event Portrait",
+      "language": "EN",
+      "description": "13 editions since 2009, 752 dancers with Skill Level points, and 211 who earned their first WSDC points in London.",
+      "url": "events/002-uk-wcs-championships/article_en.html",
+      "keywords": "WSDC, UK WCS Championships, London, West Coast Swing, points registry, Jack and Jill, Skill Level, Europe",
+      "datePublished": "2026-07-27",
+      "category": "Events"
+    },
+    {
       "title": "Event portrait: 4TH of July Convention",
       "language": "EN",
       "description": "Article on the longest-running event in the WSDC points registry",
@@ -166,6 +184,15 @@
     }
   ],
   "es": [
+    {
+      "title": "UK WCS Championships: retrato de un evento",
+      "language": "ES",
+      "description": "13 ediciones desde 2009, 752 bailarines con puntos Skill Level y 211 que obtuvieron sus primeros puntos WSDC en Londres.",
+      "url": "events/002-uk-wcs-championships/article_es.html",
+      "keywords": "WSDC, UK WCS Championships, Londres, West Coast Swing, registro de puntos, Jack and Jill, Skill Level, Europa",
+      "datePublished": "2026-07-27",
+      "category": "Eventos"
+    },
     {
       "title": "Retrato de evento: 4TH of July Convention",
       "language": "ES",


### PR DESCRIPTION
## Summary
- add RU/EN/ES homepage cards for `events/002-uk-wcs-championships/article_{ru,en,es}.html`
- reuse the exact localized SEO card copy (title/description/keywords) from published article metadata
- set `datePublished` to `2026-07-27` so UK appears as the newest featured article on index

## Test plan
- [x] Validate JSON contracts: `python3 scripts/validate_site_data.py`
- [x] Confirm UK URLs present in all language arrays of `static/data/articles.json`
- [ ] Open homepage in RU/EN/ES and verify UK card is the first featured item


Made with [Cursor](https://cursor.com)