### PR TITLE
Add New Champions nav button + SEO/sitemap

### DIFF
--- a/champion-news.html
+++ b/champion-news.html
@@ -5,17 +5,41 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="canonical" href="https://wsdc-analytics.github.io/champion-news.html">
     <meta name="description" content="New Champions - chronology of dancers who reached Allowed or Required to Champions (All-Stars / Champions thresholds).">
+    <meta name="keywords" content="WSDC, New Champions, Allowed Champions, Required Champions, All-Stars, Champions, West Coast Swing, thresholds, transitions">
+    <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://wsdc-analytics.github.io/champion-news.html">
     <meta property="og:title" content="New Champions | WSDC Analytics">
     <meta property="og:description" content="Chronology of Allowed and Required Champions transitions with Champion Path details.">
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://wsdc-analytics.github.io/champion-news.html">
+    <meta property="twitter:title" content="New Champions | WSDC Analytics">
+    <meta property="twitter:description" content="Chronology of Allowed and Required Champions transitions with Champion Path details.">
     <title>New Champions | WSDC Analytics</title>
+    <!-- Structured Data (Schema.org) -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "name": "New Champions | WSDC Analytics",
+      "url": "https://wsdc-analytics.github.io/champion-news.html",
+      "description": "Chronology of Allowed and Required Champions transitions with Champion Path details.",
+      "publisher": {
+        "@type": "Organization",
+        "name": "WSDC Analytics"
+      }
+    }
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://www.googletagmanager.com">
+    <link rel="dns-prefetch" href="https://www.googletagmanager.com">
     <link rel="stylesheet" href="static/css/tokens.css">
     <link rel="stylesheet" href="static/css/site-chrome.css">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="preload" href="static/data/champion_news.json" as="fetch" crossorigin>
+    <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMLCY5PE8Z"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -576,7 +600,7 @@
 </head>
 <body>
     <a href="#catalog" class="skip-link">Skip to New Champions catalog</a>
-    <div data-site-chrome data-active="home" data-lang="en" data-home-href="index.html"></div>
+    <div data-site-chrome data-active="champions" data-lang="en" data-home-href="index.html"></div>
 
     <div class="container">
         <a class="wsdc-back" href="index.html?lang=en" data-wsdc-back id="backLink">Back to home</a>

--- a/champion-news.html
+++ b/champion-news.html
@@ -605,7 +605,7 @@
     <div class="container">
         <a class="wsdc-back" href="index.html?lang=en" data-wsdc-back id="backLink">Back to home</a>
         <h1>New Champions</h1>
-        <p class="subtitle">Threshold crossings toward Champions, organized by publication date.</p>
+        <p class="subtitle">Dancers who crossed the threshold for transitioning into Champions.</p>
 
         <div class="page-search">
             <div class="search-help">

--- a/docs/DESIGN_SYSTEM_MINI.md
+++ b/docs/DESIGN_SYSTEM_MINI.md
@@ -14,7 +14,7 @@ Core tokens:
 Source of truth: `static/css/site-chrome.css` + `static/js/site-chrome.js`  
 Usage notes: `docs/SITE_CHROME.md`
 
-Mount with `<div data-site-chrome …>` — brand · Dashboards · Summary Points · quiet contact · RU/EN/ES.
+Mount with `<div data-site-chrome …>` — brand · Dashboards · Summary Points · New Champions · quiet contact · RU/EN/ES.
 
 ## Component primitives
 Use these shared patterns across pages:

--- a/docs/SITE_CHROME.md
+++ b/docs/SITE_CHROME.md
@@ -30,7 +30,7 @@ Mount point:
 
 | Attribute | Values | Notes |
 | --- | --- | --- |
-| `data-active` | `home` \| `dashboards` \| `points` | Highlights nav pill |
+| `data-active` | `home` \| `dashboards` \| `points` \| `champions` | Highlights nav pill |
 | `data-lang` | `ru` \| `en` \| `es` | Initial language pills |
 | `data-fixed` | `true` | Fixed floating bar (homepage **and magazine articles**) |
 | `data-brand` | `logo` (default) \| `text` | WSDC logo links home |
@@ -39,7 +39,7 @@ Mount point:
 | `data-lang-ru/en/es` | URL | Used with `data-lang-mode=navigate` |
 | `data-current-dash` | filename | Marks current Dashboards item |
 
-Includes quiet `i` tips for Dashboards and Summary Points (hover/focus).
+Includes quiet `i` tips for Dashboards, Summary Points, and New Champions (hover/focus).
 
 ### Back to home
 

--- a/scripts/smoke_check_site_files.py
+++ b/scripts/smoke_check_site_files.py
@@ -62,10 +62,12 @@ def main() -> None:
     check_exists(
         "index.html",
         "points-summary.html",
+        "champion-news.html",
         "sitemap.xml",
         "robots.txt",
         "static/data/articles.json",
         "static/data/points_summaries.json",
+        "static/data/champion_news.json",
     )
     check_sitemap_links()
     check_index_data_references()

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -37,6 +37,12 @@
     <priority>0.9</priority>
   </url>
 <url>
+    <loc>https://wsdc-analytics.github.io/champion-news.html</loc>
+    <lastmod>2026-08-01</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+<url>
     <loc>https://wsdc-analytics.github.io/overview_2025.html</loc>
     <lastmod>2026-01-28</lastmod>
     <changefreq>monthly</changefreq>

--- a/static/css/site-chrome.css
+++ b/static/css/site-chrome.css
@@ -1,6 +1,6 @@
 /**
  * Shared Evolved C site chrome - floating nav across homepage, Points Summary,
- * dashboards, and magazine articles.
+ * New Champions, dashboards, and magazine articles.
  */
 :root {
   --wsdc-chrome-ease-out: cubic-bezier(0.23, 1, 0.32, 1);
@@ -472,54 +472,47 @@ a.back-link.is-on-hero:focus-visible {
   /*
    * Mobile chrome layout:
    *  Row 1 — logo (far left) | envelope + language pills (far right)
-   *  Row 2 — Dashboards + Summary Points
+   *  Row 2 — Dashboards + Summary Points + New Champions (symmetric tip+pill clusters)
    */
   .wsdc-chrome {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto auto;
-    grid-template-rows: auto auto;
+    display: flex;
+    flex-wrap: wrap;
     align-items: center;
     column-gap: 4px;
     row-gap: 8px;
-    flex-wrap: nowrap;
   }
 
   .wsdc-chrome__brand {
-    grid-column: 1;
-    grid-row: 1;
+    order: 1;
     justify-self: start;
   }
 
-  .wsdc-chrome__spacer {
-    display: none;
+  .wsdc-chrome__brand + .wsdc-chrome__cluster {
+    margin-left: 0;
   }
 
   .wsdc-chrome__contact {
-    grid-column: 3;
-    grid-row: 1;
-    justify-self: end;
+    order: 2;
+    margin-left: auto;
   }
 
   .wsdc-chrome__langs {
-    grid-column: 4;
-    grid-row: 1;
-    justify-self: end;
+    order: 3;
     margin-left: 0;
   }
 
-  /* Dashboards cluster */
-  .wsdc-chrome__brand + .wsdc-chrome__cluster {
-    margin-left: 0;
-    grid-column: 1;
-    grid-row: 2;
-    justify-self: start;
+  /* Flex line break between top row and nav clusters */
+  .wsdc-chrome__spacer {
+    order: 4;
+    flex: 1 0 100%;
+    height: 0;
+    min-width: 100%;
+    margin: 0;
+    padding: 0;
   }
 
-  /* Summary Points cluster — sits next to Dashboards on row 2 */
-  .wsdc-chrome__brand + .wsdc-chrome__cluster + .wsdc-chrome__cluster {
-    grid-column: 2 / 5;
-    grid-row: 2;
-    justify-self: start;
+  .wsdc-chrome__cluster {
+    order: 5;
   }
 
   .wsdc-chrome__tip-bubble {

--- a/static/js/site-chrome.js
+++ b/static/js/site-chrome.js
@@ -2,12 +2,12 @@
  * Mount Evolved C site chrome into [data-site-chrome] placeholders.
  *
  * Attributes:
- *   data-active          home | dashboards | points
+ *   data-active          home | dashboards | points | champions
  *   data-lang            ru | en | es
  *   data-fixed           "true" for position:fixed (homepage + magazine articles)
  *   data-brand           "logo" (default) | "text"
  *   data-home-href       brand logo link (default index.html) — return home
- *   data-path-prefix     prefix for dashboard / points-summary hrefs (e.g. "../../" from nested pages)
+ *   data-path-prefix     prefix for dashboard / points-summary / champion-news hrefs (e.g. "../../" from nested pages)
  *   data-lang-mode       callback | navigate (default callback)
  *   data-lang-ru/en/es   URLs when data-lang-mode=navigate
  *   data-current-dash    filename to mark current dashboard link
@@ -34,6 +34,7 @@
   var LABELS = {
     dashboards: { ru: "Дашборды", en: "Dashboards", es: "Paneles" },
     points: { ru: "Summary Points", en: "Summary Points", es: "Summary Points" },
+    champions: { ru: "New Champions", en: "New Champions", es: "New Champions" },
     contact: { ru: "Контакты", en: "Contacts", es: "Contacto" },
     email: { ru: "Написать на email", en: "Send email", es: "Enviar email" },
     facebook: { ru: "Написать в Facebook", en: "Message on Facebook", es: "Escribir en Facebook" },
@@ -47,6 +48,11 @@
       ru: "Очки, начисленные по ивентам",
       en: "Points awarded by event",
       es: "Puntos otorgados por evento",
+    },
+    championsTip: {
+      ru: "Хронология переходов Allowed и Required Champions",
+      en: "Chronology of Allowed and Required Champions transitions",
+      es: "Cronología de transiciones Allowed y Required Champions",
     },
   };
 
@@ -114,9 +120,11 @@
     var wrapClass = "wsdc-chrome-wrap" + (fixed ? " is-fixed" : "");
     var dashActive = active === "dashboards" ? " is-active" : "";
     var pointsActive = active === "points" ? " is-active" : "";
+    var championsActive = active === "champions" ? " is-active" : "";
     var homeLabel = LABELS.home[lang] || LABELS.home.en;
     var dashTip = LABELS.dashTip[lang] || LABELS.dashTip.en;
     var pointsTip = LABELS.pointsTip[lang] || LABELS.pointsTip.en;
+    var championsTip = LABELS.championsTip[lang] || LABELS.championsTip.en;
 
     var brandHtml;
     if (brandMode === "text") {
@@ -182,7 +190,7 @@
       '">' +
       '<nav class="wsdc-chrome" aria-label="Site">' +
       brandHtml +
-      '<div class="wsdc-chrome__cluster">' +
+      '<div class="wsdc-chrome__cluster" data-chrome-nav="dashboards">' +
       tipHtml(dashTip, 'data-chrome-dash-tip') +
       '<div class="wsdc-chrome__dd" data-chrome-dd>' +
       '<button type="button" class="wsdc-chrome__pill' +
@@ -198,14 +206,28 @@
       "</ul>" +
       "</div>" +
       "</div>" +
-      '<div class="wsdc-chrome__cluster">' +
+      '<div class="wsdc-chrome__cluster" data-chrome-nav="points">' +
       tipHtml(pointsTip, 'data-chrome-points-tip') +
       '<a class="wsdc-chrome__pill' +
       pointsActive +
       '" href="' +
       esc(withPathPrefix(root, "points-summary.html")) +
       '" id="pointsSummaryBtn">' +
+      '<span data-chrome-points-label>' +
       esc(LABELS.points[lang] || LABELS.points.en) +
+      "</span>" +
+      "</a>" +
+      "</div>" +
+      '<div class="wsdc-chrome__cluster" data-chrome-nav="champions">' +
+      tipHtml(championsTip, 'data-chrome-champions-tip') +
+      '<a class="wsdc-chrome__pill' +
+      championsActive +
+      '" href="' +
+      esc(withPathPrefix(root, "champion-news.html")) +
+      '" id="championNewsBtn">' +
+      '<span data-chrome-champions-label>' +
+      esc(LABELS.champions[lang] || LABELS.champions.en) +
+      "</span>" +
       "</a>" +
       "</div>" +
       '<div class="wsdc-chrome__spacer" aria-hidden="true"></div>' +
@@ -254,9 +276,14 @@
     var homeHref = withLangQuery(root.getAttribute("data-home-href") || "index.html", lang);
     var dashTip = LABELS.dashTip[lang] || LABELS.dashTip.en;
     var pointsTip = LABELS.pointsTip[lang] || LABELS.pointsTip.en;
+    var championsTip = LABELS.championsTip[lang] || LABELS.championsTip.en;
 
     var dashLabel = root.querySelector("[data-chrome-dash-label]");
     if (dashLabel) dashLabel.textContent = LABELS.dashboards[lang] || LABELS.dashboards.en;
+    var pointsLabel = root.querySelector("[data-chrome-points-label]");
+    if (pointsLabel) pointsLabel.textContent = LABELS.points[lang] || LABELS.points.en;
+    var championsLabel = root.querySelector("[data-chrome-champions-label]");
+    if (championsLabel) championsLabel.textContent = LABELS.champions[lang] || LABELS.champions.en;
     var contactBtn = root.querySelector("[data-chrome-contact-btn]");
     if (contactBtn) contactBtn.setAttribute("aria-label", LABELS.contact[lang] || LABELS.contact.en);
     var email = root.querySelector("[data-chrome-email]");
@@ -283,6 +310,12 @@
       pointsTipEl.textContent = pointsTip;
       var tipWrap2 = pointsTipEl.closest(".wsdc-chrome__tip");
       if (tipWrap2) tipWrap2.setAttribute("aria-label", pointsTip);
+    }
+    var championsTipEl = root.querySelector("[data-chrome-champions-tip]");
+    if (championsTipEl) {
+      championsTipEl.textContent = championsTip;
+      var tipWrap3 = championsTipEl.closest(".wsdc-chrome__tip");
+      if (tipWrap3) tipWrap3.setAttribute("aria-label", championsTip);
     }
 
     root.querySelectorAll(".lang-btn").forEach(function (btn) {


### PR DESCRIPTION
## Summary
- Add **New Champions** chrome button (with info tooltip) next to Summary Points on all pages using shared site chrome
- Keep tip+pill clusters symmetric; update mobile row layout for three nav clusters
- Align `champion-news.html` SEO with Points Summary: keywords, Twitter cards, Schema.org WebPage, GTM preconnect
- Set `data-active="champions"` on the target page
- Add `champion-news.html` to `sitemap.xml`
- Document chrome change and extend smoke checks

## Test plan
- [x] `python3 scripts/smoke_check_site_files.py`
- [x] `python3 scripts/validate_site_data.py`
- [ ] Homepage chrome shows Dashboards · Summary Points · New Champions with matching `i` tips
- [ ] New Champions opens `/champion-news.html` and highlights active pill
- [ ] Mobile: tip+button clusters remain readable and aligned
- [ ] View source on champion-news: canonical, og, twitter, ld+json present


Made with [Cursor](https://cursor.com)