### PR TITLE
Widen chrome info tips (fix tall skinny bubbles)

### DIFF
--- a/static/css/site-chrome.css
+++ b/static/css/site-chrome.css
@@ -151,12 +151,12 @@
 
 .wsdc-chrome__tip-bubble {
   position: absolute;
-  /* Below the tip: grow taller via wrap instead of spilling past the chrome bar */
-  top: calc(100% + 8px);
-  left: 0;
+  /* Wide horizontal bubble beside the tip — avoid a tall skinny column */
+  left: calc(100% + 8px);
   right: auto;
-  transform: translateY(-2px) scale(0.96);
-  transform-origin: top left;
+  top: 50%;
+  transform: translateY(-50%) scale(0.96);
+  transform-origin: left center;
   min-height: 32px;
   display: flex;
   align-items: center;
@@ -168,7 +168,7 @@
   line-height: 1.35;
   border-radius: 8px;
   width: max-content;
-  max-width: min(200px, calc(100vw - 48px));
+  max-width: min(340px, calc(100vw - 48px));
   white-space: normal;
   opacity: 0;
   visibility: hidden;
@@ -180,18 +180,18 @@
     visibility var(--wsdc-chrome-exit) var(--wsdc-chrome-ease-out);
 }
 
-/* Keep later tips inside the bar: grow left toward the center */
+/* Later tips open left into the bar so a wide bubble stays inside */
 .wsdc-chrome__cluster[data-chrome-nav="points"] .wsdc-chrome__tip-bubble,
 .wsdc-chrome__cluster[data-chrome-nav="champions"] .wsdc-chrome__tip-bubble {
   left: auto;
-  right: 0;
-  transform-origin: top right;
+  right: calc(100% + 8px);
+  transform-origin: right center;
 }
 
 .wsdc-chrome__tip:focus-visible .wsdc-chrome__tip-bubble {
   opacity: 1;
   visibility: visible;
-  transform: translateY(0) scale(1);
+  transform: translateY(-50%) scale(1);
   transition-duration: var(--wsdc-chrome-enter);
 }
 
@@ -204,7 +204,7 @@
   .wsdc-chrome__tip:hover .wsdc-chrome__tip-bubble {
     opacity: 1;
     visibility: visible;
-    transform: translateY(0) scale(1);
+    transform: translateY(-50%) scale(1);
     transition-duration: var(--wsdc-chrome-enter);
   }
 }
@@ -526,28 +526,28 @@ a.back-link.is-on-hero:focus-visible {
   }
 
   .wsdc-chrome__tip-bubble {
-    top: calc(100% + 8px);
-    left: 0;
+    left: calc(100% + 8px);
     right: auto;
-    transform: translateY(-2px) scale(0.96);
-    transform-origin: top left;
-    max-width: min(180px, calc(100vw - 48px));
+    top: 50%;
+    transform: translateY(-50%) scale(0.96);
+    transform-origin: left center;
+    max-width: min(280px, calc(100vw - 48px));
   }
 
   .wsdc-chrome__cluster[data-chrome-nav="points"] .wsdc-chrome__tip-bubble,
   .wsdc-chrome__cluster[data-chrome-nav="champions"] .wsdc-chrome__tip-bubble {
     left: auto;
-    right: 0;
-    transform-origin: top right;
+    right: calc(100% + 8px);
+    transform-origin: right center;
   }
 
   .wsdc-chrome__tip:focus-visible .wsdc-chrome__tip-bubble {
-    transform: translateY(0) scale(1);
+    transform: translateY(-50%) scale(1);
   }
 
   @media (hover: hover) and (pointer: fine) {
     .wsdc-chrome__tip:hover .wsdc-chrome__tip-bubble {
-      transform: translateY(0) scale(1);
+      transform: translateY(-50%) scale(1);
     }
   }
 


### PR DESCRIPTION
## Summary
- Revert the narrow below-the-icon tip layout that made Champions tip a tall column
- Open tips beside the icon again, with max-width ~340px so text stays short and wide
- Points / New Champions tips open to the left into the bar so a wide bubble does not spill past the right edge

## Test plan
- [ ] Hover New Champions tip — wide horizontal bubble, not a vertical column
- [ ] Hover Dashboards / Summary Points tips — same horizontal style
- [ ] Confirm tips stay visually attached to the chrome row height


Made with [Cursor](https://cursor.com)