### PR TITLE
Mobile chrome: hide Dashboards, center Points + Champions

### DIFF
--- a/docs/SITE_CHROME.md
+++ b/docs/SITE_CHROME.md
@@ -39,7 +39,7 @@ Mount point:
 | `data-lang-ru/en/es` | URL | Used with `data-lang-mode=navigate` |
 | `data-current-dash` | filename | Marks current Dashboards item |
 
-Includes quiet `i` tips for Dashboards, Summary Points, and New Champions (hover/focus).
+Includes quiet `i` tips for Dashboards, Summary Points, and New Champions (hover/focus). On mobile (≤720px) Dashboards is hidden; Summary Points and New Champions are centered on the second chrome row.
 
 ### Back to home
 

--- a/static/css/site-chrome.css
+++ b/static/css/site-chrome.css
@@ -474,7 +474,7 @@ a.back-link.is-on-hero:focus-visible {
   /*
    * Mobile chrome layout:
    *  Row 1 — logo (far left) | envelope + language pills (far right)
-   *  Row 2 — Dashboards + Summary Points + New Champions (symmetric tip+pill clusters)
+   *  Row 2 — Summary Points + New Champions centered (Dashboards hidden)
    */
   .wsdc-chrome {
     display: flex;
@@ -513,8 +513,22 @@ a.back-link.is-on-hero:focus-visible {
     padding: 0;
   }
 
-  .wsdc-chrome__cluster {
+  .wsdc-chrome__cluster[data-chrome-nav="dashboards"] {
+    display: none;
+  }
+
+  .wsdc-chrome__cluster[data-chrome-nav="points"],
+  .wsdc-chrome__cluster[data-chrome-nav="champions"] {
     order: 5;
+  }
+
+  /* Center the two visible nav clusters as a pair on row 2 */
+  .wsdc-chrome__cluster[data-chrome-nav="points"] {
+    margin-left: auto;
+  }
+
+  .wsdc-chrome__cluster[data-chrome-nav="champions"] {
+    margin-right: auto;
   }
 
   .wsdc-chrome__tip-bubble {


### PR DESCRIPTION
## Summary
- Hide Dashboards cluster on mobile (≤720px)
- Keep Summary Points and New Champions on the second chrome row, centered as a pair

## Test plan
- [ ] Mobile / narrow viewport: row 1 = logo | contact + langs
- [ ] Mobile row 2 = Summary Points + New Champions centered, no Dashboards
- [ ] Desktop unchanged: Dashboards + Summary Points + New Champions visible


Made with [Cursor](https://cursor.com)