### PR TITLE
Restyle Events Calendar to Tableau-like year grid

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -51,7 +51,7 @@
             <div class="head-top">
                 <h1 data-i18n="title">Events Calendar</h1>
             </div>
-            <p class="how-to" data-i18n="howTo">Dots mark Thu-Sun weekends with events. Click a marked Thursday to open the map and cards.</p>
+            <p class="how-to" data-i18n="howTo">Blue blocks mark Thu-Sun weekends with events. Click a highlighted day to open the map and cards.</p>
             <p class="disclaimer" id="disclaimer"></p>
             <div class="filters" role="toolbar" aria-label="Filters">
                 <div class="filter-field">
@@ -109,7 +109,7 @@
   var I18N = {
     en: {
       title: "Events Calendar",
-      howTo: "Dots mark Thu-Sun weekends with events. Click a marked Thursday to open the map and cards.",
+      howTo: "Blue blocks mark Thu-Sun weekends with events. Click a highlighted day to open the map and cards.",
       year: "Year",
       region: "Region",
       status: "Status",
@@ -137,7 +137,7 @@
     },
     ru: {
       title: "Календарь ивентов",
-      howTo: "Точки - выходные чт-вс с ивентами. Клик по отмеченному четвергу открывает карту и карточки.",
+      howTo: "Синие блоки - выходные чт-вс с ивентами. Клик по выделенному дню открывает карту и карточки.",
       year: "Год",
       region: "Регион",
       status: "Статус",
@@ -165,7 +165,7 @@
     },
     es: {
       title: "Calendario de eventos",
-      howTo: "Los puntos marcan fines de semana (jue-dom). Haz clic en un jueves marcado para el mapa y las fichas.",
+      howTo: "Los bloques azules marcan fines de semana (jue-dom). Haz clic en un dia marcado para el mapa y las fichas.",
       year: "Año",
       region: "Región",
       status: "Estado",
@@ -263,6 +263,11 @@
     });
   }
 
+  function isWeekendDay(iso) {
+    var wd = new Date(iso + "T12:00:00").getDay();
+    return wd === 0 || wd >= 4; // Thu-Sun
+  }
+
   function renderCalendar() {
     var root = document.getElementById("calendarRoot");
     var events = eventsForYear(state.year);
@@ -276,27 +281,45 @@
     var html = '<div class="year-grid">';
     for (var m = 0; m < 12; m++) {
       html += '<section class="month"><h2>' + months[m] + "</h2>";
-      html += '<div class="dow">' + dow.map(function (d) { return "<span>" + d + "</span>"; }).join("") + "</div>";
+      html += '<div class="dow" aria-hidden="true">' + dow.map(function (d) { return "<span>" + d + "</span>"; }).join("") + "</div>";
       html += '<div class="days">';
       var first = new Date(state.year, m, 1);
       var startPad = (first.getDay() + 6) % 7; // Mon-first
       var daysInMonth = new Date(state.year, m + 1, 0).getDate();
+      var cells = [];
       var i;
       for (i = 0; i < startPad; i++) {
-        html += '<div class="day is-other" aria-hidden="true"></div>';
+        cells.push({ empty: true });
       }
       for (var day = 1; day <= daysInMonth; day++) {
         var iso = state.year + "-" + String(m + 1).padStart(2, "0") + "-" + String(day).padStart(2, "0");
         var wb = weekendBounds(iso);
-        // Marker only on Thursday = weekend anchor (less calendar noise)
-        var isAnchor = iso === wb.key;
-        var list = isAnchor ? (state.byWeekend[wb.key] || []) : [];
-        var has = list.length > 0;
-        var selected = state.selectedWeekend === wb.key && isAnchor ? " is-selected" : "";
-        html += '<button type="button" class="day' + (has ? " has-events" : "") + selected + '" data-date="' + iso + '" data-weekend="' + wb.key + '"' +
-          (has ? "" : " disabled") + ' aria-label="' + iso + (has ? ", " + list.length + " events" : "") + '">';
-        html += "<span>" + day + "</span>";
-        if (has) html += '<span class="day-dot" aria-hidden="true"></span>';
+        var list = state.byWeekend[wb.key] || [];
+        var occupied = isWeekendDay(iso) && list.length > 0;
+        cells.push({
+          empty: false,
+          day: day,
+          iso: iso,
+          weekend: wb.key,
+          occupied: occupied,
+          count: list.length,
+          selected: occupied && state.selectedWeekend === wb.key
+        });
+      }
+      while (cells.length < 42) {
+        cells.push({ empty: true });
+      }
+      for (i = 0; i < cells.length; i++) {
+        var c = cells[i];
+        if (c.empty) {
+          html += '<div class="day is-empty" aria-hidden="true"></div>';
+          continue;
+        }
+        var cls = "day" + (c.occupied ? " has-events is-occupied" : "") + (c.selected ? " is-selected" : "");
+        html += '<button type="button" class="' + cls + '" data-date="' + c.iso + '" data-weekend="' + c.weekend + '"' +
+          (c.occupied ? "" : " disabled") +
+          ' aria-label="' + c.iso + (c.occupied ? ", " + c.count + " events" : "") + '">';
+        html += "<span>" + c.day + "</span>";
         html += "</button>";
       }
       html += "</div></section>";

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -182,50 +182,61 @@ h1 {
 .swatch.expected { background: var(--status-expected); }
 .swatch.cancelled { background: var(--status-cancelled); }
 .swatch.hiatus { background: var(--status-hiatus); }
-.swatch.occupied { background: #64748b; }
+.swatch.occupied { background: #1e3a5f; }
 
-/* —— Year grid: denser —— */
+/* —— Year grid: Tableau-style compact 4×3 —— */
 #calendarRoot {
   flex: 1;
   min-height: 0;
   display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  overflow: auto;
+  padding-top: 2px;
 }
 
 .year-grid {
-  flex: 1;
-  min-height: 0;
+  flex: 0 0 auto;
+  width: min(100%, 820px);
+  max-width: 820px;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  grid-template-rows: repeat(3, minmax(0, 1fr));
-  gap: 4px;
-  width: 100%;
+  grid-template-rows: repeat(3, auto);
+  gap: 0;
+  border-top: 1px solid #e8eaed;
+  border-left: 1px solid #e8eaed;
+  background: #fff;
 }
 
 .month {
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius);
-  padding: 3px 4px 4px;
+  border-right: 1px solid #e8eaed;
+  border-bottom: 1px solid #e8eaed;
+  border-radius: 0;
+  padding: 4px 6px 6px;
   background: #fff;
   min-height: 0;
+  min-width: 0;
   display: flex;
   flex-direction: column;
 }
 
 .month h2 {
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
-  margin-bottom: 1px;
+  margin: 0 0 3px;
   color: var(--text-primary);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
   line-height: 1.2;
+  text-align: center;
 }
 
 .dow {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   gap: 0;
-  margin-bottom: 0;
+  margin-bottom: 2px;
   font-size: 8px;
+  font-weight: 500;
   color: var(--text-tertiary);
   text-align: center;
   flex: 0 0 auto;
@@ -233,63 +244,78 @@ h1 {
 }
 
 .days {
-  flex: 1;
-  min-height: 0;
+  flex: 0 0 auto;
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  grid-template-rows: repeat(6, minmax(0, 1fr));
+  grid-template-rows: repeat(6, auto);
   gap: 0;
+  border-top: 1px solid #eceef1;
+  border-left: 1px solid #eceef1;
 }
 
 .day {
   border: none;
-  background: transparent;
-  border-radius: 3px;
+  border-right: 1px solid #eceef1;
+  border-bottom: 1px solid #eceef1;
+  background: #fff;
+  border-radius: 0;
   font: inherit;
   font-size: 9px;
   color: var(--text-secondary);
   position: relative;
   cursor: default;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0;
+  aspect-ratio: 1;
+  width: 100%;
   min-height: 0;
+  min-width: 0;
   padding: 0;
   line-height: 1;
-  transition: background 120ms var(--ease-out), transform 120ms var(--ease-out);
+  transition: background 120ms var(--ease-out), color 120ms var(--ease-out);
 }
 
-.day.is-other { color: #d1d5db; }
+.day.is-empty {
+  background: #fff;
+  pointer-events: none;
+}
+
+.day:disabled {
+  cursor: default;
+  opacity: 1;
+}
 
 .day.has-events {
   cursor: pointer;
-  color: var(--text-primary);
+}
+
+.day.is-occupied {
+  background: #1e3a5f;
+  color: #fff;
   font-weight: 600;
 }
 
-.day.has-events:focus-visible {
-  background: rgba(37, 99, 235, 0.12);
-  outline: none;
+.day.is-occupied:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+  z-index: 1;
+}
+
+.day.is-occupied.is-selected {
+  background: #152a45;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
 }
 
 .day.has-events:active {
-  transform: scale(0.96);
+  transform: none;
+  filter: brightness(0.92);
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .day.has-events:hover {
-    background: rgba(37, 99, 235, 0.1);
+  .day.is-occupied:hover {
+    background: #274866;
   }
-}
-
-.day.is-selected { background: rgba(37, 99, 235, 0.16); }
-
-.day-dot {
-  width: 3px; height: 3px; border-radius: 50%;
-  background: #64748b;
-  margin-top: 1px;
 }
 
 /* —— Weekend overlay panel —— */
@@ -474,7 +500,9 @@ h1 {
 @media (max-width: 960px) {
   .year-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    grid-template-rows: repeat(4, minmax(0, 1fr));
+    grid-template-rows: repeat(4, auto);
+    width: min(100%, 680px);
+    max-width: 680px;
   }
   .panel-inner { grid-template-columns: 1fr; }
   #weekendMap { height: 26vh; }
@@ -495,13 +523,12 @@ h1 {
   .year-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     grid-template-rows: none;
-    height: auto;
-    gap: 6px;
+    width: 100%;
+    max-width: 100%;
   }
-  .month { min-height: 140px; padding: 5px 6px 6px; }
+  .month { padding: 5px 5px 6px; }
   .month h2 { font-size: 11px; }
-  .day { min-height: 20px; font-size: 10px; }
-  .day-dot { width: 4px; height: 4px; }
+  .day { font-size: 10px; }
   .panel { position: fixed; inset: 0; }
   .filter-soon { display: none; }
 }


### PR DESCRIPTION
## Summary
- Switch the year view to a compact centered 4x3 cell grid (max ~820px, not full-bleed).
- Use subtle hairline month/day dividers and fill Thu-Sun weekend blocks when occupied.
- Drop day-dot markers; click any highlighted weekend day to open the map panel.

## Test plan
- [ ] Desktop: calendar is 4 columns x 3 rows, centered, not stretched full width
- [ ] Occupied weekends show as continuous Thu-Sun blue blocks
- [ ] Empty leading/trailing cells keep borders with no numbers
- [ ] Clicking a highlighted day opens weekend map/cards
- [ ] Mobile still stacks and remains usable


Made with [Cursor](https://cursor.com)