### PR TITLE
Fit year calendar grid into remaining viewport height

### DIFF
--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -57,10 +57,10 @@ body {
   width: 100%;
   max-width: 1280px;
   margin: 0 auto;
-  padding: 16px 20px 12px;
+  padding: 12px 20px 8px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 /* —— Header: title + subtitle + filters + occupancy legend —— */
@@ -173,36 +173,40 @@ h1 {
 .swatch.occupied { background: #e4eaf2; border: 1px solid #c5d0de; }
 .swatch.empty-day { background: #fff; border: 1px solid #d1d5db; }
 
-/* —— Year grid: Tableau-style compact 4×3 —— */
+/* —— Year grid: Tableau-style compact 4×3 (fits remaining viewport) —— */
 #calendarRoot {
   flex: 1;
   min-height: 0;
   display: flex;
   justify-content: center;
-  align-items: flex-start;
+  align-items: stretch;
   overflow: hidden;
-  padding-top: 2px;
+  padding: 2px 0 8px;
 }
 
 .year-grid {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
   width: min(100%, 820px);
   max-width: 820px;
+  max-height: 100%;
+  min-height: 0;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  grid-template-rows: repeat(3, auto);
-  gap: 6px 8px;
+  grid-template-rows: repeat(3, minmax(0, 1fr));
+  gap: 4px 8px;
   border: none;
   background: transparent;
+  align-self: stretch;
 }
 
 .month {
   border: none;
   border-radius: 0;
-  padding: 4px 6px 6px;
+  padding: 2px 4px 4px;
   background: #fff;
   min-height: 0;
   min-width: 0;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }
@@ -210,18 +214,19 @@ h1 {
 .month h2 {
   font-size: 11px;
   font-weight: 600;
-  margin: 0 0 3px;
+  margin: 0 0 2px;
   color: var(--text-primary);
   letter-spacing: 0.01em;
   line-height: 1.2;
   text-align: center;
+  flex: 0 0 auto;
 }
 
 .dow {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   gap: 0;
-  margin-bottom: 2px;
+  margin-bottom: 1px;
   font-size: 8px;
   font-weight: 500;
   color: var(--text-tertiary);
@@ -231,10 +236,11 @@ h1 {
 }
 
 .days {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
+  min-height: 0;
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  grid-template-rows: repeat(6, auto);
+  grid-template-rows: repeat(6, minmax(0, 1fr));
   gap: 0;
   border: none;
 }
@@ -244,15 +250,15 @@ h1 {
   background: #fff;
   border-radius: 0;
   font: inherit;
-  font-size: 9px;
+  font-size: clamp(8px, 1.05vh, 11px);
   color: var(--text-secondary);
   position: relative;
   cursor: default;
   display: flex;
   align-items: center;
   justify-content: center;
-  aspect-ratio: 1;
   width: 100%;
+  height: 100%;
   min-height: 0;
   min-width: 0;
   padding: 0;
@@ -482,11 +488,28 @@ h1 {
 }
 
 @media (max-width: 960px) {
+  #calendarRoot {
+    overflow-y: auto;
+    align-items: flex-start;
+  }
   .year-grid {
+    flex: 0 0 auto;
+    height: auto;
+    max-height: none;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     grid-template-rows: repeat(4, auto);
     width: min(100%, 680px);
     max-width: 680px;
+  }
+  .month { height: auto; }
+  .days {
+    flex: 0 0 auto;
+    grid-template-rows: repeat(6, auto);
+  }
+  .day {
+    aspect-ratio: 1;
+    height: auto;
+    font-size: 9px;
   }
   .panel-inner { grid-template-columns: 1fr; }
   #weekendMap { height: 26vh; }


### PR DESCRIPTION
## Summary
- Fit the year calendar grid into leftover viewport height so December rows stay visible under the taller header (square day cells no longer force clip/overflow).

## Test plan
- [ ] Desktop: all 12 months visible without clipping at the bottom
- [ ] Asia filter still works as before

Made with [Cursor](https://cursor.com)