### PR TITLE
Keep calendar day tooltips inside the viewport

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -455,10 +455,29 @@
 
   function moveTooltip(ev) {
     var tip = document.getElementById("tooltip");
-    var x = (ev.clientX || 0) + 12;
-    var y = (ev.clientY || 0) + 12;
-    tip.style.left = x + "px";
-    tip.style.top = y + "px";
+    if (!tip.classList.contains("is-visible")) return;
+    var pad = 8;
+    var gap = 12;
+    var vw = window.innerWidth || document.documentElement.clientWidth;
+    var vh = window.innerHeight || document.documentElement.clientHeight;
+    var cx = ev.clientX || 0;
+    var cy = ev.clientY || 0;
+    // Place off-screen first so layout size is measurable without flicker jump
+    tip.style.left = "0px";
+    tip.style.top = "0px";
+    var w = tip.offsetWidth;
+    var h = tip.offsetHeight;
+    var x = cx + gap;
+    var y = cy + gap;
+    if (x + w > vw - pad) x = cx - w - gap;
+    if (x < pad) x = pad;
+    if (x + w > vw - pad) x = Math.max(pad, vw - pad - w);
+    if (y + h > vh - pad) y = cy - h - gap;
+    if (y < pad) y = pad;
+    if (y + h > vh - pad) y = Math.max(pad, vh - pad - h);
+    tip.style.left = Math.round(x) + "px";
+    tip.style.top = Math.round(y) + "px";
+    tip.style.transformOrigin = (y < cy ? "bottom left" : "top left");
   }
 
   function hideTooltip() {

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -457,8 +457,10 @@ h1 {
 
 .tooltip {
   position: fixed;
-  z-index: 60;
-  max-width: 260px;
+  z-index: 80;
+  max-width: min(280px, calc(100vw - 16px));
+  max-height: min(50vh, calc(100dvh - 16px));
+  overflow: auto;
   background: #0B1221;
   color: #fff;
   font-size: 11px;


### PR DESCRIPTION
## Summary
- Flip day tooltips above/left of the cursor when bottom/right edges would clip the viewport
- Clamp tooltip position to padding so it stays fully visible

## Test plan
- [ ] Open events calendar and hover days near bottom/right edges of the viewport
- [ ] Confirm tooltip flips above/left instead of clipping
- [ ] Confirm tooltip stays within padded viewport on all edges
- [ ] Spot-check center/top-left days still show tooltips normally


Made with [Cursor](https://cursor.com)