### PR TITLE
Fix calendar filter widths

### DIFF
--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -147,14 +147,24 @@ h1 {
 .cal-dd {
   position: relative;
   display: inline-flex;
+  width: var(--cal-dd-width, 9rem);
+  flex-shrink: 0;
 }
+
+#yearSelectDd { --cal-dd-width: 5.25rem; }
+#continentFilterDd { --cal-dd-width: 9.5rem; }
+#countryFilterDd { --cal-dd-width: 10.5rem; }
+#statusFilterDd { --cal-dd-width: 13.5rem; }
+#kindFilterDd { --cal-dd-width: 8.75rem; }
 
 .cal-dd__btn {
   appearance: none;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   gap: 4px;
+  box-sizing: border-box;
+  width: 100%;
   height: 28px;
   padding: 0 10px;
   border-radius: 999px;
@@ -167,7 +177,6 @@ h1 {
   line-height: 1;
   cursor: pointer;
   white-space: nowrap;
-  max-width: 14rem;
   transition:
     transform 140ms var(--ease-out),
     background-color 160ms ease,
@@ -200,8 +209,11 @@ h1 {
 }
 
 .cal-dd__value {
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-align: center;
 }
 
 .cal-dd__btn svg {
@@ -216,9 +228,11 @@ h1 {
 .cal-dd__menu {
   position: absolute;
   top: calc(100% + 6px);
-  left: 50%;
+  left: 0;
+  right: 0;
   z-index: 20;
-  min-width: max(100%, 160px);
+  min-width: 100%;
+  width: max-content;
   max-width: min(280px, calc(100vw - 32px));
   max-height: min(280px, 50vh);
   overflow-y: auto;
@@ -228,9 +242,9 @@ h1 {
   border-radius: 10px;
   border: 1px solid var(--border-color);
   background: #fff;
-  transform-origin: top center;
+  transform-origin: top left;
   opacity: 0;
-  transform: translateX(-50%) scale(0.96);
+  transform: scale(0.96);
   pointer-events: none;
   transition:
     opacity 120ms var(--ease-out),
@@ -239,7 +253,7 @@ h1 {
 
 .cal-dd.is-open .cal-dd__menu {
   opacity: 1;
-  transform: translateX(-50%) scale(1);
+  transform: scale(1);
   pointer-events: auto;
   transition-duration: 180ms;
 }
@@ -692,8 +706,11 @@ h1 {
   h1 { font-size: 1.25rem; }
   .subtitle { font-size: 13px; }
   .filter-field { flex: 1 1 42%; }
-  .cal-dd { width: 100%; }
-  .cal-dd__btn { width: 100%; max-width: none; }
+  .cal-dd {
+    width: 100%;
+    --cal-dd-width: 100%;
+  }
+  .cal-dd__btn { width: 100%; }
   .year-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     grid-template-rows: none;


### PR DESCRIPTION
## Summary
- Lock each calendar filter pill to a fixed width so changing the selected label no longer shifts neighbors.
- Ellipsis long values; menus still expand to content when needed.

## Test plan
- [ ] Switch Year / Continent / Country / Confirm status / Event type — filter row stays put
- [ ] RU/ES long “all …” labels truncate with ellipsis inside the pill
- [ ] Mobile wrap still uses full-width filters


Made with [Cursor](https://cursor.com)