### PR TITLE
Always show Hiatus in Confirm status filter

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -390,21 +390,9 @@
       t("allCountries")
     );
 
-    var statusPool = yearEvents.filter(function (e) {
-      if (state.country && e.country !== state.country) return false;
-      if (state.kind && e.kind !== state.kind) return false;
-      return true;
-    });
-    var statusPresent = {};
-    statusPool.forEach(function (e) {
-      if (e.status) statusPresent[e.status] = true;
-    });
-    var statusOpts = STATUSES.filter(function (s) { return statusPresent[s]; }).map(function (s) {
+    var statusOpts = STATUSES.map(function (s) {
       return { value: s, label: statusLabel(s) };
     });
-    if (state.status && statusPresent[state.status] !== true) {
-      state.status = "";
-    }
     fillDropdown(
       document.getElementById("statusFilterMenu"),
       document.getElementById("statusFilterValue"),


### PR DESCRIPTION
## Summary
- Confirm status dropdown always includes Confirmed / Expected / Cancelled / Hiatus.
- Hiatus no longer disappears in years (or filter cascades) with no hiatus editions.

## Test plan
- [ ] Open Events Calendar → Confirm status → Hiatus is listed for 2025–2028
- [ ] Selecting Hiatus in 2025/2026 shows hiatus events; in 2027+ may be empty


Made with [Cursor](https://cursor.com)