### PR TITLE
Add filter-aware calendar event counter

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -116,7 +116,37 @@
                 </div>
             </div>
         </header>
-        <div id="calendarRoot"></div>
+        <div class="calendar-stage">
+            <aside class="cal-stats" id="calStats" aria-label="Selection counts">
+                <div class="cal-stats__head">
+                    <button type="button" class="cal-stats__tip" id="calStatsTip" aria-label="About these counts">
+                        <span class="cal-stats__tip-mark" aria-hidden="true">i</span>
+                        <span class="cal-stats__tip-bubble" id="calStatsTipText" role="tooltip" data-i18n="statTip">Counts for the current year after filters: confirm status and event type breakdown of the visible selection.</span>
+                    </button>
+                </div>
+                <div class="cal-stats__item">
+                    <span class="cal-stats__label" data-i18n="statConfirmed">Confirmed</span>
+                    <span class="cal-stats__value" data-stat="confirmed">0</span>
+                </div>
+                <div class="cal-stats__item">
+                    <span class="cal-stats__label" data-i18n="statExpected">Expected</span>
+                    <span class="cal-stats__value" data-stat="expected">0</span>
+                </div>
+                <div class="cal-stats__item">
+                    <span class="cal-stats__label" data-i18n="statPaused">Hiatus / Cancelled</span>
+                    <span class="cal-stats__value" data-stat="paused">0</span>
+                </div>
+                <div class="cal-stats__item">
+                    <span class="cal-stats__label" data-i18n="statRegistry">Registry</span>
+                    <span class="cal-stats__value" data-stat="registry">0</span>
+                </div>
+                <div class="cal-stats__item">
+                    <span class="cal-stats__label" data-i18n="statTrial">Trial</span>
+                    <span class="cal-stats__value" data-stat="trial">0</span>
+                </div>
+            </aside>
+            <div id="calendarRoot"></div>
+        </div>
         <section class="panel" id="weekendPanel" aria-live="polite">
             <div class="panel-inner">
             <div class="panel-head">
@@ -162,6 +192,13 @@
       legDensity: "events/day",
       legEmpty: "Empty day",
       legToday: "Today",
+      statConfirmed: "Confirmed",
+      statExpected: "Expected",
+      statPaused: "Hiatus / Cancelled",
+      statRegistry: "Registry",
+      statTrial: "Trial",
+      statTip: "Live counts for the selected year after all filters. Confirm status and event type of the events currently shown on the calendar.",
+      statAria: "Selection counts",
       empty: "No day-precision events for this year yet.",
       day: "Day",
       noGeo: "Some events have no coordinates - listed below only.",
@@ -196,6 +233,13 @@
       legDensity: "ивентов/день",
       legEmpty: "Пустой день",
       legToday: "Сегодня",
+      statConfirmed: "Confirmed",
+      statExpected: "Expected",
+      statPaused: "Hiatus / Cancelled",
+      statRegistry: "Registry",
+      statTrial: "Trial",
+      statTip: "Живые цифры за выбранный год после всех фильтров: confirm status и тип ивента в текущей выборке на календаре.",
+      statAria: "Счётчики выборки",
       empty: "Для этого года пока нет дат с точностью до дня.",
       day: "День",
       noGeo: "У части ивентов нет координат - только список.",
@@ -230,6 +274,13 @@
       legDensity: "eventos/día",
       legEmpty: "Dia vacío",
       legToday: "Hoy",
+      statConfirmed: "Confirmed",
+      statExpected: "Expected",
+      statPaused: "Hiatus / Cancelled",
+      statRegistry: "Registry",
+      statTrial: "Trial",
+      statTip: "Conteos en vivo del año seleccionado tras los filtros: estado de confirmación y tipo de evento de la selección visible.",
+      statAria: "Conteos de la selección",
       empty: "Aún no hay eventos con fecha exacta para este año.",
       day: "Dia",
       noGeo: "Algunos eventos no tienen coordenadas - solo en la lista.",
@@ -280,6 +331,36 @@
       document.getElementById("disclaimer").textContent =
         state.data.disclaimer[state.lang] || state.data.disclaimer.en || "";
     }
+    var stats = document.getElementById("calStats");
+    if (stats) stats.setAttribute("aria-label", t("statAria"));
+    var tip = document.getElementById("calStatsTip");
+    if (tip) tip.setAttribute("aria-label", t("statTip"));
+  }
+
+  function countFilterStats(events) {
+    var out = {
+      confirmed: 0,
+      expected: 0,
+      paused: 0,
+      registry: 0,
+      trial: 0
+    };
+    (events || []).forEach(function (e) {
+      if (e.status === "confirmed") out.confirmed += 1;
+      else if (e.status === "expected") out.expected += 1;
+      else if (e.status === "hiatus" || e.status === "cancelled") out.paused += 1;
+      if (e.kind === "trial") out.trial += 1;
+      else out.registry += 1;
+    });
+    return out;
+  }
+
+  function renderFilterStats(events) {
+    var counts = countFilterStats(events);
+    document.querySelectorAll("[data-stat]").forEach(function (el) {
+      var key = el.getAttribute("data-stat");
+      el.textContent = String(counts[key] || 0);
+    });
   }
 
   function eventsForYear(year) {
@@ -474,6 +555,7 @@
     var root = document.getElementById("calendarRoot");
     var events = eventsForYear(state.year);
     state.byDay = indexByDay(events, state.year);
+    renderFilterStats(events);
     if (!events.length) {
       root.innerHTML = '<div class="empty-year">' + t("empty") + "</div>";
       return;

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -320,15 +320,159 @@ h1 {
   border: 1.5px solid var(--color-accent);
 }
 
-/* —— Year grid: Tableau-style compact 4×3 (fits remaining viewport) —— */
+/* —— Year grid + left filter stats —— */
+.calendar-stage {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: stretch;
+  gap: 10px;
+  overflow: hidden;
+  padding: 2px 0 8px;
+}
+
+.cal-stats {
+  flex: 0 0 92px;
+  width: 92px;
+  max-width: 92px;
+  align-self: center;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 4px 2px 4px 0;
+  min-height: 0;
+  overflow: visible;
+}
+
+.cal-stats__head {
+  display: flex;
+  justify-content: flex-start;
+  min-height: 18px;
+}
+
+.cal-stats__tip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 1.5px solid var(--border-color);
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-weight: 600;
+  font-style: normal;
+  line-height: 1;
+  cursor: help;
+  background: #fff;
+  box-sizing: border-box;
+  padding: 0;
+  font-family: inherit;
+}
+
+.cal-stats__tip-mark {
+  display: block;
+  line-height: 1;
+  transform: translateY(-0.5px);
+}
+
+.cal-stats__tip:focus {
+  outline: none;
+}
+
+.cal-stats__tip:focus-visible {
+  outline: 2px solid var(--color-primary-dark);
+  outline-offset: 2px;
+  border-color: var(--color-primary-dark);
+  color: var(--text-primary);
+}
+
+.cal-stats__tip-bubble {
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%) scale(0.96);
+  transform-origin: left center;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  background: var(--color-primary-dark);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.35;
+  border-radius: 8px;
+  width: max-content;
+  max-width: min(260px, calc(100vw - 48px));
+  white-space: normal;
+  text-align: left;
+  text-transform: none;
+  letter-spacing: normal;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  z-index: 30;
+  transition:
+    opacity 120ms var(--ease-out),
+    transform 120ms var(--ease-out),
+    visibility 120ms var(--ease-out);
+}
+
+.cal-stats__tip:focus-visible .cal-stats__tip-bubble {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(-50%) scale(1);
+  transition-duration: 180ms;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .cal-stats__tip:hover {
+    border-color: var(--color-primary-dark);
+    color: var(--text-primary);
+  }
+  .cal-stats__tip:hover .cal-stats__tip-bubble {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(-50%) scale(1);
+    transition-duration: 180ms;
+  }
+}
+
+.cal-stats__item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.cal-stats__label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.2;
+  color: var(--text-tertiary);
+  text-wrap: balance;
+}
+
+.cal-stats__value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  color: var(--color-primary-dark);
+  font-variant-numeric: tabular-nums;
+}
+
 #calendarRoot {
   flex: 1;
+  min-width: 0;
   min-height: 0;
   display: flex;
   justify-content: center;
   align-items: stretch;
   overflow: hidden;
-  padding: 2px 0 8px;
 }
 
 .year-grid {
@@ -661,6 +805,14 @@ h1 {
 }
 
 @media (max-width: 960px) {
+  .calendar-stage {
+    overflow: auto;
+    align-items: flex-start;
+  }
+  .cal-stats {
+    align-self: flex-start;
+    padding-top: 8px;
+  }
   #calendarRoot {
     overflow-y: auto;
     align-items: flex-start;
@@ -711,6 +863,41 @@ h1 {
     --cal-dd-width: 100%;
   }
   .cal-dd__btn { width: 100%; }
+  .calendar-stage {
+    flex-direction: column;
+    gap: 8px;
+    overflow: visible;
+  }
+  .cal-stats {
+    flex: 0 0 auto;
+    width: 100%;
+    max-width: none;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 8px 14px;
+    padding: 0;
+  }
+  .cal-stats__head {
+    width: 100%;
+    min-height: 0;
+  }
+  .cal-stats__tip-bubble {
+    left: 0;
+    top: calc(100% + 8px);
+    transform: translateY(-4px) scale(0.96);
+    transform-origin: top left;
+  }
+  .cal-stats__tip:focus-visible .cal-stats__tip-bubble,
+  .cal-stats__tip:hover .cal-stats__tip-bubble {
+    transform: translateY(0) scale(1);
+  }
+  .cal-stats__item {
+    min-width: 4.5rem;
+  }
+  .cal-stats__value {
+    font-size: 1.1rem;
+  }
   .year-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     grid-template-rows: none;
@@ -736,7 +923,8 @@ h1 {
   .panel-close,
   .tooltip,
   .cal-dd__btn,
-  .cal-dd__menu {
+  .cal-dd__menu,
+  .cal-stats__tip-bubble {
     transition: none;
   }
   .tooltip.is-visible {


### PR DESCRIPTION
## Summary
- Add a compact left-rail counter next to the year grid: Confirmed, Expected, Hiatus/Cancelled, Registry, Trial.
- Counts update with year + all filters (same selection as the calendar).
- Info tip explains the counter; mobile stacks metrics above the grid.

## Test plan
- [ ] 2025 no filters: status buckets sum to total; registry+trial = total
- [ ] Continent America changes all five numbers
- [ ] Confirm status / Event type filters update counts to the visible subset
- [ ] Tip hover/focus shows explanation; layout stays within the page on desktop


Made with [Cursor](https://cursor.com)