### PR TITLE
Fix calendar stats position: gutter overlay, restore layout

### DIFF
--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -320,28 +320,37 @@ h1 {
   border: 1.5px solid var(--color-accent);
 }
 
-/* —— Year grid + left filter stats —— */
+/* —— Year grid (restored centering) + gutter stats —— */
 .calendar-stage {
+  position: relative;
   flex: 1;
   min-height: 0;
   display: flex;
+  justify-content: center;
   align-items: stretch;
-  gap: 10px;
   overflow: hidden;
   padding: 2px 0 8px;
 }
 
+/* Float in the empty gutter left of the centered 820px grid — does not shift the calendar */
 .cal-stats {
-  flex: 0 0 92px;
-  width: 92px;
-  max-width: 92px;
-  align-self: center;
+  position: absolute;
+  top: 50%;
+  left: max(4px, calc(50% - 410px - 96px));
+  transform: translateY(-50%);
+  z-index: 2;
+  width: 84px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 4px 2px 4px 0;
-  min-height: 0;
-  overflow: visible;
+  gap: 8px;
+  padding: 0;
+  pointer-events: none;
+}
+
+.cal-stats__head,
+.cal-stats__tip,
+.cal-stats__item {
+  pointer-events: auto;
 }
 
 .cal-stats__head {
@@ -457,7 +466,7 @@ h1 {
 }
 
 .cal-stats__value {
-  font-size: 1.25rem;
+  font-size: 18px;
   font-weight: 700;
   letter-spacing: -0.02em;
   line-height: 1.1;
@@ -466,8 +475,9 @@ h1 {
 }
 
 #calendarRoot {
-  flex: 1;
-  min-width: 0;
+  flex: 1 1 auto;
+  width: min(100%, 820px);
+  max-width: 820px;
   min-height: 0;
   display: flex;
   justify-content: center;
@@ -805,13 +815,8 @@ h1 {
 }
 
 @media (max-width: 960px) {
-  .calendar-stage {
-    overflow: auto;
-    align-items: flex-start;
-  }
   .cal-stats {
-    align-self: flex-start;
-    padding-top: 8px;
+    left: max(4px, calc(50% - 340px - 96px));
   }
   #calendarRoot {
     overflow-y: auto;
@@ -864,19 +869,20 @@ h1 {
   }
   .cal-dd__btn { width: 100%; }
   .calendar-stage {
-    flex-direction: column;
-    gap: 8px;
     overflow: visible;
   }
   .cal-stats {
-    flex: 0 0 auto;
+    position: static;
+    transform: none;
+    left: auto;
+    top: auto;
     width: 100%;
-    max-width: none;
+    margin: 0 0 4px;
     flex-direction: row;
     flex-wrap: wrap;
     align-items: flex-end;
     gap: 8px 14px;
-    padding: 0;
+    pointer-events: auto;
   }
   .cal-stats__head {
     width: 100%;
@@ -888,15 +894,26 @@ h1 {
     transform: translateY(-4px) scale(0.96);
     transform-origin: top left;
   }
-  .cal-stats__tip:focus-visible .cal-stats__tip-bubble,
-  .cal-stats__tip:hover .cal-stats__tip-bubble {
+  .cal-stats__tip:focus-visible .cal-stats__tip-bubble {
     transform: translateY(0) scale(1);
+  }
+  @media (hover: hover) and (pointer: fine) {
+    .cal-stats__tip:hover .cal-stats__tip-bubble {
+      transform: translateY(0) scale(1);
+    }
   }
   .cal-stats__item {
     min-width: 4.5rem;
   }
   .cal-stats__value {
-    font-size: 1.1rem;
+    font-size: 16px;
+  }
+  .calendar-stage {
+    flex-direction: column;
+  }
+  #calendarRoot {
+    width: 100%;
+    max-width: 100%;
   }
   .year-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
- Restore the previous centered calendar layout (stats no longer squeeze the grid).
- Position the counter in the empty gutter immediately left of the year grid.
- Reduce metric number size by 2px (20→18).

## Test plan
- [ ] Desktop: calendar/legend alignment matches pre-counter layout
- [ ] Stats sit in the circled left gutter beside Jan/May/Sep, not far left of the page
- [ ] Numbers look slightly smaller; filters still update counts


Made with [Cursor](https://cursor.com)