### PR TITLE
Calendar stats polish + stale-expected data refresh

### DIFF
--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -335,9 +335,9 @@ h1 {
 /* Float in the empty gutter left of the centered 820px grid — does not shift the calendar */
 .cal-stats {
   position: absolute;
-  top: 50%;
+  top: 8px;
   left: max(4px, calc(50% - 410px - 96px));
-  transform: translateY(-50%);
+  transform: none;
   z-index: 2;
   width: 84px;
   display: flex;
@@ -466,9 +466,9 @@ h1 {
 }
 
 .cal-stats__value {
-  font-size: 18px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-size: 16px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
   line-height: 1.1;
   color: var(--color-primary-dark);
   font-variant-numeric: tabular-nums;
@@ -906,7 +906,7 @@ h1 {
     min-width: 4.5rem;
   }
   .cal-stats__value {
-    font-size: 16px;
+    font-size: 14px;
   }
   .calendar-stage {
     flex-direction: column;

--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-03",
-  "generated_at": "2026-08-03T20:33:52Z",
+  "generated_at": "2026-08-03T20:42:05Z",
   "years": [
     2025,
     2026,
@@ -21,8 +21,8 @@
     "end_weekday": "sun"
   },
   "counts_by_year": {
-    "2025": 177,
-    "2026": 193,
+    "2025": 176,
+    "2026": 192,
     "2027": 187,
     "2028": 183
   },
@@ -749,26 +749,6 @@
       "lat": 51.5072178,
       "lon": -0.1275862,
       "url": "http://www.ukwcschamps.com",
-      "year": 2025,
-      "source": "edition_calendar_dates"
-    },
-    {
-      "id": "expected:217:2025-03-28",
-      "event_id": 217,
-      "name": "San Diego Dance Festival (Unconfirmed)",
-      "start_date": "2025-03-28",
-      "end_date": "2025-03-30",
-      "weekend_start": "2025-03-27",
-      "weekend_end": "2025-03-30",
-      "weekend_key": "2025-03-27",
-      "status": "expected",
-      "kind": "registry",
-      "city": "San Diego",
-      "country": "United States",
-      "continent": "America",
-      "lat": 32.715738,
-      "lon": -117.1610838,
-      "url": "https://sandiegodancefestival.com",
       "year": 2025,
       "source": "edition_calendar_dates"
     },
@@ -4991,28 +4971,6 @@
       "url": "http://www.nanaimodancefusion.ca",
       "year": 2026,
       "source": "edition_calendar_dates"
-    },
-    {
-      "id": "expected:368:2026-05-30",
-      "event_id": 368,
-      "name": "Next Level Swing",
-      "start_date": "2026-05-30",
-      "end_date": "2026-06-01",
-      "weekend_start": "2026-05-28",
-      "weekend_end": "2026-05-31",
-      "weekend_key": "2026-05-28",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Gothenburg",
-      "country": "Sweden",
-      "continent": "Europe",
-      "lat": 57.70887,
-      "lon": 11.97456,
-      "url": "http://www.next-level.dance",
-      "year": 2026,
-      "source": "expected_yoy",
-      "projected_from_year": 2025,
-      "projected_from_start": "2025-05-30"
     },
     {
       "id": "confirmed:25:2026-06-04",


### PR DESCRIPTION
## Summary
- Top-align the left counter with the year grid (no vertical centering).
- Metric values: 16px, normal weight (less visual pull).
- Refresh `events_year_calendar.json` from pipeline #81 (stale expected pruned).

## Test plan
- [ ] Stats sit at top-left of the calendar gutter; numbers quieter
- [ ] Past year / past weekends: no lingering expected; hiatus/cancelled remain


Made with [Cursor](https://cursor.com)