### PR TITLE
Move calendar legend to the right gutter

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -104,16 +104,6 @@
                         </div>
                     </div>
                 </div>
-                <div class="legend" aria-label="Calendar legend">
-                    <span class="legend-density" title="Events overlapping that calendar day">
-                        <span class="legend-dens-item"><i class="swatch dens-1"></i><span data-i18n="legDens1">1–2</span></span>
-                        <span class="legend-dens-item"><i class="swatch dens-2"></i><span data-i18n="legDens2">3–4</span></span>
-                        <span class="legend-dens-item"><i class="swatch dens-3"></i><span data-i18n="legDens3">5+</span></span>
-                        <span class="legend-dens-label" data-i18n="legDensity">events/day</span>
-                    </span>
-                    <span><i class="swatch empty-day"></i> <span data-i18n="legEmpty">Empty day</span></span>
-                    <span><i class="swatch today"></i> <span data-i18n="legToday">Today</span></span>
-                </div>
             </div>
         </header>
         <div class="calendar-stage">
@@ -146,6 +136,29 @@
                 </div>
             </aside>
             <div id="calendarRoot"></div>
+            <aside class="cal-legend" aria-label="Calendar legend">
+                <div class="cal-legend__item" title="Events overlapping that calendar day">
+                    <i class="swatch dens-1"></i>
+                    <span data-i18n="legDens1">1–2</span>
+                </div>
+                <div class="cal-legend__item" title="Events overlapping that calendar day">
+                    <i class="swatch dens-2"></i>
+                    <span data-i18n="legDens2">3–4</span>
+                </div>
+                <div class="cal-legend__item" title="Events overlapping that calendar day">
+                    <i class="swatch dens-3"></i>
+                    <span data-i18n="legDens3">5+</span>
+                </div>
+                <div class="cal-legend__note" data-i18n="legDensity">events/day</div>
+                <div class="cal-legend__item">
+                    <i class="swatch empty-day"></i>
+                    <span data-i18n="legEmpty">Empty day</span>
+                </div>
+                <div class="cal-legend__item">
+                    <i class="swatch today"></i>
+                    <span data-i18n="legToday">Today</span>
+                </div>
+            </aside>
         </div>
         <section class="panel" id="weekendPanel" aria-live="polite">
             <div class="panel-inner">

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -109,7 +109,7 @@ h1 {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 10px 16px;
   padding-top: 4px;
   min-width: 0;
@@ -290,26 +290,11 @@ h1 {
   font-weight: 600;
 }
 
-.legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 14px;
-  font-size: 12px;
-  color: var(--text-secondary);
-  align-items: center;
-  padding-bottom: 4px;
-}
-
-.legend span { display: inline-flex; align-items: center; gap: 6px; }
-
-.legend-density { gap: 8px; }
-.legend-dens-item { display: inline-flex; align-items: center; gap: 4px; }
-.legend-dens-label { color: var(--text-tertiary); font-size: 11px; }
-
 .swatch {
   width: 10px; height: 10px; border-radius: 2px;
   display: inline-block;
   box-sizing: border-box;
+  flex-shrink: 0;
 }
 .swatch.dens-1 { background: #eef2f6; border: 1px solid #d5dde8; }
 .swatch.dens-2 { background: #d5dee9; border: 1px solid #b7c4d4; }
@@ -472,6 +457,41 @@ h1 {
   line-height: 1.1;
   color: var(--color-primary-dark);
   font-variant-numeric: tabular-nums;
+}
+
+/* Right gutter: density / empty / today legend (vertical) */
+.cal-legend {
+  position: absolute;
+  top: 8px;
+  left: calc(50% + 410px + 12px);
+  z-index: 2;
+  width: 104px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0;
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.25;
+}
+
+.cal-legend__item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.cal-legend__item span {
+  min-width: 0;
+}
+
+.cal-legend__note {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text-tertiary);
+  margin: -2px 0 2px 16px;
 }
 
 #calendarRoot {
@@ -818,6 +838,10 @@ h1 {
   .cal-stats {
     left: max(4px, calc(50% - 340px - 96px));
   }
+  .cal-legend {
+    left: calc(50% + 340px + 12px);
+    width: 96px;
+  }
   #calendarRoot {
     overflow-y: auto;
     align-items: flex-start;
@@ -844,7 +868,6 @@ h1 {
   .panel-inner { grid-template-columns: 1fr; }
   #weekendMap { height: 26vh; }
   .event-list { max-height: none; }
-  .legend { width: 100%; }
 }
 
 @media (max-width: 700px) {
@@ -907,6 +930,21 @@ h1 {
   }
   .cal-stats__value {
     font-size: 14px;
+  }
+  .cal-legend {
+    position: static;
+    left: auto;
+    top: auto;
+    width: 100%;
+    margin: 8px 0 0;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px 12px;
+  }
+  .cal-legend__note {
+    margin: 0;
+    width: 100%;
   }
   .calendar-stage {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Move density / empty day / today legend from the header into the empty right gutter beside the year grid (vertical stack).
- Header toolbar keeps filters only.

## Test plan
- [ ] Desktop: legend sits in the right gutter; filters-only header
- [ ] Same swatches and labels as before (1–2 / 3–4 / 5+ / events/day / Empty / Today)
- [ ] Mobile: legend wraps under the calendar without overlapping


Made with [Cursor](https://cursor.com)