### PR TITLE
Nudge calendar legend 50px from the grid

### DIFF
--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -463,7 +463,7 @@ h1 {
 .cal-legend {
   position: absolute;
   top: 8px;
-  left: calc(50% + 410px + 12px);
+  left: calc(50% + 410px + 112px);
   z-index: 2;
   width: 104px;
   display: flex;
@@ -839,7 +839,7 @@ h1 {
     left: max(4px, calc(50% - 340px - 96px));
   }
   .cal-legend {
-    left: calc(50% + 340px + 12px);
+    left: calc(50% + 340px + 112px);
     width: 96px;
   }
   #calendarRoot {

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -463,7 +463,7 @@ h1 {
 .cal-legend {
   position: absolute;
   top: 8px;
-  left: calc(50% + 410px + 112px);
+  left: calc(50% + 410px + 62px);
   z-index: 2;
   width: 104px;
   display: flex;
@@ -839,7 +839,7 @@ h1 {
     left: max(4px, calc(50% - 340px - 96px));
   }
   .cal-legend {
-    left: calc(50% + 340px + 112px);
+    left: calc(50% + 340px + 62px);
     width: 96px;
   }
   #calendarRoot {


### PR DESCRIPTION
## Summary
- Move the right density legend +50px away from the year grid (offset 12px → 62px).

## Test plan
- [ ] Desktop: legend no longer hugs April/August/December columns


Made with [Cursor](https://cursor.com)