### PR TITLE
Clarify calendar legend: Events/day header + gap

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -137,19 +137,22 @@
             </aside>
             <div id="calendarRoot"></div>
             <aside class="cal-legend" aria-label="Calendar legend">
-                <div class="cal-legend__item" title="Events overlapping that calendar day">
-                    <i class="swatch dens-1"></i>
-                    <span data-i18n="legDens1">1–2</span>
+                <div class="cal-legend__title"><span data-i18n="legDensity">Events/day</span>:</div>
+                <div class="cal-legend__group">
+                    <div class="cal-legend__item" title="Events overlapping that calendar day">
+                        <i class="swatch dens-1"></i>
+                        <span data-i18n="legDens1">1–2</span>
+                    </div>
+                    <div class="cal-legend__item" title="Events overlapping that calendar day">
+                        <i class="swatch dens-2"></i>
+                        <span data-i18n="legDens2">3–4</span>
+                    </div>
+                    <div class="cal-legend__item" title="Events overlapping that calendar day">
+                        <i class="swatch dens-3"></i>
+                        <span data-i18n="legDens3">5+</span>
+                    </div>
                 </div>
-                <div class="cal-legend__item" title="Events overlapping that calendar day">
-                    <i class="swatch dens-2"></i>
-                    <span data-i18n="legDens2">3–4</span>
-                </div>
-                <div class="cal-legend__item" title="Events overlapping that calendar day">
-                    <i class="swatch dens-3"></i>
-                    <span data-i18n="legDens3">5+</span>
-                </div>
-                <div class="cal-legend__note" data-i18n="legDensity">events/day</div>
+                <div class="cal-legend__gap" aria-hidden="true"></div>
                 <div class="cal-legend__item">
                     <i class="swatch empty-day"></i>
                     <span data-i18n="legEmpty">Empty day</span>
@@ -202,7 +205,7 @@
       legDens1: "1–2",
       legDens2: "3–4",
       legDens3: "5+",
-      legDensity: "events/day",
+      legDensity: "Events/day",
       legEmpty: "Empty day",
       legToday: "Today",
       statConfirmed: "Confirmed",
@@ -243,7 +246,7 @@
       legDens1: "1–2",
       legDens2: "3–4",
       legDens3: "5+",
-      legDensity: "ивентов/день",
+      legDensity: "Ивентов/день",
       legEmpty: "Пустой день",
       legToday: "Сегодня",
       statConfirmed: "Confirmed",
@@ -284,7 +287,7 @@
       legDens1: "1–2",
       legDens2: "3–4",
       legDens3: "5+",
-      legDensity: "eventos/día",
+      legDensity: "Eventos/día",
       legEmpty: "Dia vacío",
       legToday: "Hoy",
       statConfirmed: "Confirmed",

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -486,12 +486,24 @@ h1 {
   min-width: 0;
 }
 
-.cal-legend__note {
+.cal-legend__title {
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.02em;
   color: var(--text-tertiary);
-  margin: -2px 0 2px 16px;
+  line-height: 1.2;
+  margin-bottom: 2px;
+}
+
+.cal-legend__group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cal-legend__gap {
+  height: 10px;
+  flex-shrink: 0;
 }
 
 #calendarRoot {
@@ -942,9 +954,17 @@ h1 {
     align-items: center;
     gap: 8px 12px;
   }
-  .cal-legend__note {
-    margin: 0;
+  .cal-legend__title {
     width: 100%;
+    margin-bottom: 0;
+  }
+  .cal-legend__group {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+  }
+  .cal-legend__gap {
+    display: none;
   }
   .calendar-stage {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Move `Events/day:` to the top of the right legend (with colon).
- Keep 1–2 / 3–4 / 5+ under that header; add a gap before Empty day and Today.

## Test plan
- [ ] Right legend reads: Events/day: → density rows → gap → Empty / Today
- [ ] RU/ES labels update correctly; colon remains


Made with [Cursor](https://cursor.com)