### PR TITLE
Refresh calendar data for SwingCo schedule

### DIFF
--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-03",
-  "generated_at": "2026-08-03T20:42:05Z",
+  "generated_at": "2026-08-03T21:03:29Z",
   "years": [
     2025,
     2026,
@@ -22,7 +22,7 @@
   },
   "counts_by_year": {
     "2025": 176,
-    "2026": 192,
+    "2026": 191,
     "2027": 187,
     "2028": 183
   },
@@ -235,7 +235,7 @@
     {
       "id": "confirmed:273:2025-01-30",
       "event_id": 273,
-      "name": "Charlotte Westie Fest",
+      "name": "Charlotte WestieFest",
       "start_date": "2025-01-30",
       "end_date": "2025-02-03",
       "weekend_start": "2025-01-30",
@@ -1075,7 +1075,7 @@
     {
       "id": "confirmed:144:2025-05-01",
       "event_id": 144,
-      "name": "Swingin' Into Spring",
+      "name": "Swingin' Into Spring 2025",
       "start_date": "2025-05-01",
       "end_date": "2025-05-04",
       "weekend_start": "2025-05-01",
@@ -1415,7 +1415,7 @@
     {
       "id": "confirmed:25:2025-06-05",
       "event_id": 25,
-      "name": "J&J O'Rama",
+      "name": "Jack & Jill O'Rama",
       "start_date": "2025-06-05",
       "end_date": "2025-06-09",
       "weekend_start": "2025-06-05",
@@ -1815,7 +1815,7 @@
     {
       "id": "confirmed:280:2025-07-17",
       "event_id": 280,
-      "name": "Saint Petersburg WCS Nights",
+      "name": "St. Petersburg WCS Nights",
       "start_date": "2025-07-17",
       "end_date": "2025-07-20",
       "weekend_start": "2025-07-17",
@@ -2135,7 +2135,7 @@
     {
       "id": "confirmed:47:2025-08-14",
       "event_id": 47,
-      "name": "Swingtime in the Rockies",
+      "name": "SwingTime Denver",
       "start_date": "2025-08-14",
       "end_date": "2025-08-17",
       "weekend_start": "2025-08-14",
@@ -3415,7 +3415,7 @@
     {
       "id": "confirmed:342:2025-12-12",
       "event_id": 342,
-      "name": "Global Grand Prix - West Coast Swing Reunion",
+      "name": "Global Grand Prix - West Coast Swing Championships",
       "start_date": "2025-12-12",
       "end_date": "2025-12-15",
       "weekend_start": "2025-12-11",
@@ -3535,7 +3535,7 @@
     {
       "id": "confirmed:289:2025-12-31",
       "event_id": 289,
-      "name": "SwingVester",
+      "name": "SwingVester 2025",
       "start_date": "2025-12-31",
       "end_date": "2026-01-05",
       "weekend_start": "2025-12-25",
@@ -3755,7 +3755,7 @@
     {
       "id": "confirmed:273:2026-01-29",
       "event_id": 273,
-      "name": "Charlotte Westie Fest",
+      "name": "Charlotte WestieFest",
       "start_date": "2026-01-29",
       "end_date": "2026-02-02",
       "weekend_start": "2026-01-29",
@@ -4475,7 +4475,7 @@
     {
       "id": "confirmed:218:2026-04-16",
       "event_id": 218,
-      "name": "Asia West Coast Swing Open",
+      "name": "Asia WCS Open XIII",
       "start_date": "2026-04-16",
       "end_date": "2026-04-19",
       "weekend_start": "2026-04-16",
@@ -4835,7 +4835,7 @@
     {
       "id": "confirmed:174:2026-05-15",
       "event_id": 174,
-      "name": "Swingsation",
+      "name": "Swingsation 2026",
       "start_date": "2026-05-15",
       "end_date": "2026-05-18",
       "weekend_start": "2026-05-14",
@@ -4975,7 +4975,7 @@
     {
       "id": "confirmed:25:2026-06-04",
       "event_id": 25,
-      "name": "J&J O'Rama",
+      "name": "Jack & Jill O'Rama",
       "start_date": "2026-06-04",
       "end_date": "2026-06-08",
       "weekend_start": "2026-06-04",
@@ -5355,7 +5355,7 @@
     {
       "id": "confirmed:362:2026-07-09",
       "event_id": 362,
-      "name": "MY Swing",
+      "name": "MY Swing 2026",
       "start_date": "2026-07-09",
       "end_date": "2026-07-12",
       "weekend_start": "2026-07-09",
@@ -5435,7 +5435,7 @@
     {
       "id": "confirmed:224:2026-07-16",
       "event_id": 224,
-      "name": "Midwest Westie Fest",
+      "name": "Midwest Westie Fest 2026",
       "start_date": "2026-07-16",
       "end_date": "2026-07-19",
       "weekend_start": "2026-07-16",
@@ -5495,7 +5495,7 @@
     {
       "id": "confirmed:280:2026-07-22",
       "event_id": 280,
-      "name": "Saint Petersburg WCS Nights",
+      "name": "St. Petersburg WCS Nights",
       "start_date": "2026-07-22",
       "end_date": "2026-07-26",
       "weekend_start": "2026-07-16",
@@ -6101,7 +6101,7 @@
     {
       "id": "confirmed:47:2026-09-10",
       "event_id": 47,
-      "name": "Swingtime in the Rockies",
+      "name": "SwingTime Denver",
       "start_date": "2026-09-10",
       "end_date": "2026-09-13",
       "weekend_start": "2026-09-10",
@@ -6181,7 +6181,7 @@
     {
       "id": "confirmed:357:2026-09-17",
       "event_id": 357,
-      "name": "WCS Party",
+      "name": "WCS Party in Vienna",
       "start_date": "2026-09-17",
       "end_date": "2026-09-21",
       "weekend_start": "2026-09-17",
@@ -6241,7 +6241,7 @@
     {
       "id": "confirmed:342:2026-09-18",
       "event_id": 342,
-      "name": "Global Grand Prix - West Coast Swing Reunion",
+      "name": "Global Grand Prix -- West Coast Swing Championships",
       "start_date": "2026-09-18",
       "end_date": "2026-09-21",
       "weekend_start": "2026-09-17",
@@ -6361,7 +6361,7 @@
     {
       "id": "confirmed:361:2026-09-24",
       "event_id": 361,
-      "name": "Mooseland Swing",
+      "name": "Mooseland Swing 2026",
       "start_date": "2026-09-24",
       "end_date": "2026-09-28",
       "weekend_start": "2026-09-24",
@@ -6823,7 +6823,7 @@
     {
       "id": "confirmed:31:2026-11-05",
       "event_id": 31,
-      "name": "Mountain Magic",
+      "name": "Mouintain Magic Dance Convention",
       "start_date": "2026-11-05",
       "end_date": "2026-11-08",
       "weekend_start": "2026-11-05",
@@ -6843,7 +6843,7 @@
     {
       "id": "confirmed:79:2026-11-05",
       "event_id": 79,
-      "name": "Sea to Sky",
+      "name": "Sea to Sky Seattle",
       "start_date": "2026-11-05",
       "end_date": "2026-11-09",
       "weekend_start": "2026-11-05",
@@ -6943,7 +6943,7 @@
     {
       "id": "confirmed:288:2026-11-12",
       "event_id": 288,
-      "name": "Midnight Madness",
+      "name": "Midnight Madness WCS 2026",
       "start_date": "2026-11-12",
       "end_date": "2026-11-15",
       "weekend_start": "2026-11-12",
@@ -7083,7 +7083,7 @@
     {
       "id": "confirmed:68:2026-11-25",
       "event_id": 68,
-      "name": "US Open Swing Dance Championships",
+      "name": "The Open Swing Dance  Championships",
       "start_date": "2026-11-25",
       "end_date": "2026-11-29",
       "weekend_start": "2026-11-19",
@@ -7123,7 +7123,7 @@
     {
       "id": "confirmed:212:2026-12-03",
       "event_id": 212,
-      "name": "The After Party (TAP)",
+      "name": "The After Party aka TAP",
       "start_date": "2026-12-03",
       "end_date": "2026-12-07",
       "weekend_start": "2026-12-03",
@@ -7245,7 +7245,7 @@
     {
       "id": "confirmed:152:2026-12-28",
       "event_id": 152,
-      "name": "Worlds UCWDC",
+      "name": "UCWDC Country Dance World Championships",
       "start_date": "2026-12-28",
       "end_date": "2027-01-03",
       "weekend_start": "2026-12-24",
@@ -7285,7 +7285,7 @@
     {
       "id": "confirmed:214:2026-12-30",
       "event_id": 214,
-      "name": "New Year's Swing Fling",
+      "name": "New Years Swing Fling",
       "start_date": "2026-12-30",
       "end_date": "2027-01-03",
       "weekend_start": "2026-12-24",
@@ -7361,28 +7361,6 @@
       "url": "http://countdownswingboston.com/",
       "year": 2026,
       "source": "scheduled_events"
-    },
-    {
-      "id": "expected:196:2026-12-31",
-      "event_id": 196,
-      "name": "SwingCouver",
-      "start_date": "2026-12-31",
-      "end_date": "2027-01-04",
-      "weekend_start": "2026-12-31",
-      "weekend_end": "2027-01-03",
-      "weekend_key": "2026-12-31",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Portland",
-      "country": "United States",
-      "continent": "America",
-      "lat": 45.515232,
-      "lon": -122.6783853,
-      "url": "http://www.swingcouver.com",
-      "year": 2026,
-      "source": "expected_yoy",
-      "projected_from_year": 2025,
-      "projected_from_start": "2025-12-31"
     },
     {
       "id": "confirmed:240:2026-12-31",
@@ -7629,7 +7607,7 @@
     {
       "id": "confirmed:273:2027-02-04",
       "event_id": 273,
-      "name": "Charlotte Westie Fest",
+      "name": "Charlotte WestieFest",
       "start_date": "2027-02-04",
       "end_date": "2027-02-07",
       "weekend_start": "2027-02-04",
@@ -8375,7 +8353,7 @@
     {
       "id": "confirmed:218:2027-04-15",
       "event_id": 218,
-      "name": "Asia West Coast Swing Open",
+      "name": "Asia WCS Open 2027",
       "start_date": "2027-04-15",
       "end_date": "2027-04-18",
       "weekend_start": "2027-04-15",
@@ -8495,7 +8473,7 @@
     {
       "id": "confirmed:259:2027-04-22",
       "event_id": 259,
-      "name": "Swingover",
+      "name": "Swingover 2027",
       "start_date": "2027-04-22",
       "end_date": "2027-04-25",
       "weekend_start": "2027-04-22",
@@ -8951,7 +8929,7 @@
     {
       "id": "expected:25:2027-06-04",
       "event_id": 25,
-      "name": "J&J O'Rama",
+      "name": "Jack & Jill O'Rama",
       "start_date": "2027-06-04",
       "end_date": "2027-06-08",
       "weekend_start": "2027-06-03",
@@ -9015,7 +8993,7 @@
     {
       "id": "confirmed:220:2027-06-10",
       "event_id": 220,
-      "name": "D-Town Swing",
+      "name": "D-TOWNSWING 2027",
       "start_date": "2027-06-10",
       "end_date": "2027-06-13",
       "weekend_start": "2027-06-10",
@@ -9347,7 +9325,7 @@
     {
       "id": "expected:362:2027-07-09",
       "event_id": 362,
-      "name": "MY Swing",
+      "name": "MY Swing 2026",
       "start_date": "2027-07-09",
       "end_date": "2027-07-12",
       "weekend_start": "2027-07-08",
@@ -9477,7 +9455,7 @@
     {
       "id": "expected:280:2027-07-22",
       "event_id": 280,
-      "name": "Saint Petersburg WCS Nights",
+      "name": "St. Petersburg WCS Nights",
       "start_date": "2027-07-22",
       "end_date": "2027-07-26",
       "weekend_start": "2027-07-22",
@@ -10049,7 +10027,7 @@
     {
       "id": "expected:47:2027-09-10",
       "event_id": 47,
-      "name": "Swingtime in the Rockies",
+      "name": "SwingTime Denver",
       "start_date": "2027-09-10",
       "end_date": "2027-09-13",
       "weekend_start": "2027-09-09",
@@ -10137,7 +10115,7 @@
     {
       "id": "expected:357:2027-09-17",
       "event_id": 357,
-      "name": "WCS Party",
+      "name": "WCS Party in Vienna",
       "start_date": "2027-09-17",
       "end_date": "2027-09-21",
       "weekend_start": "2027-09-16",
@@ -10203,7 +10181,7 @@
     {
       "id": "expected:342:2027-09-18",
       "event_id": 342,
-      "name": "Global Grand Prix - West Coast Swing Reunion",
+      "name": "Global Grand Prix -- West Coast Swing Championships",
       "start_date": "2027-09-18",
       "end_date": "2027-09-21",
       "weekend_start": "2027-09-16",
@@ -10335,7 +10313,7 @@
     {
       "id": "expected:361:2027-09-24",
       "event_id": 361,
-      "name": "Mooseland Swing",
+      "name": "Mooseland Swing 2026",
       "start_date": "2027-09-24",
       "end_date": "2027-09-28",
       "weekend_start": "2027-09-23",
@@ -10771,7 +10749,7 @@
     {
       "id": "expected:31:2027-11-05",
       "event_id": 31,
-      "name": "Mountain Magic",
+      "name": "Mouintain Magic Dance Convention",
       "start_date": "2027-11-05",
       "end_date": "2027-11-08",
       "weekend_start": "2027-11-04",
@@ -10793,7 +10771,7 @@
     {
       "id": "expected:79:2027-11-05",
       "event_id": 79,
-      "name": "Sea to Sky",
+      "name": "Sea to Sky Seattle",
       "start_date": "2027-11-05",
       "end_date": "2027-11-09",
       "weekend_start": "2027-11-04",
@@ -10903,7 +10881,7 @@
     {
       "id": "expected:288:2027-11-12",
       "event_id": 288,
-      "name": "Midnight Madness",
+      "name": "Midnight Madness WCS 2026",
       "start_date": "2027-11-12",
       "end_date": "2027-11-15",
       "weekend_start": "2027-11-11",
@@ -11057,7 +11035,7 @@
     {
       "id": "expected:68:2027-11-25",
       "event_id": 68,
-      "name": "US Open Swing Dance Championships",
+      "name": "The Open Swing Dance  Championships",
       "start_date": "2027-11-25",
       "end_date": "2027-11-29",
       "weekend_start": "2027-11-25",
@@ -11101,7 +11079,7 @@
     {
       "id": "expected:212:2027-12-03",
       "event_id": 212,
-      "name": "The After Party (TAP)",
+      "name": "The After Party aka TAP",
       "start_date": "2027-12-03",
       "end_date": "2027-12-07",
       "weekend_start": "2027-12-02",
@@ -11211,7 +11189,7 @@
     {
       "id": "expected:152:2027-12-28",
       "event_id": 152,
-      "name": "Worlds UCWDC",
+      "name": "UCWDC Country Dance World Championships",
       "start_date": "2027-12-28",
       "end_date": "2028-01-03",
       "weekend_start": "2027-12-23",
@@ -11255,7 +11233,7 @@
     {
       "id": "expected:214:2027-12-30",
       "event_id": 214,
-      "name": "New Year's Swing Fling",
+      "name": "New Years Swing Fling",
       "start_date": "2027-12-30",
       "end_date": "2028-01-03",
       "weekend_start": "2027-12-30",
@@ -11563,7 +11541,7 @@
     {
       "id": "expected:273:2028-02-04",
       "event_id": 273,
-      "name": "Charlotte Westie Fest",
+      "name": "Charlotte WestieFest",
       "start_date": "2028-02-04",
       "end_date": "2028-02-07",
       "weekend_start": "2028-02-03",
@@ -12353,7 +12331,7 @@
     {
       "id": "expected:218:2028-04-15",
       "event_id": 218,
-      "name": "Asia West Coast Swing Open",
+      "name": "Asia WCS Open 2027",
       "start_date": "2028-04-15",
       "end_date": "2028-04-18",
       "weekend_start": "2028-04-13",
@@ -12485,7 +12463,7 @@
     {
       "id": "expected:259:2028-04-22",
       "event_id": 259,
-      "name": "Swingover",
+      "name": "Swingover 2027",
       "start_date": "2028-04-22",
       "end_date": "2028-04-25",
       "weekend_start": "2028-04-20",
@@ -12969,7 +12947,7 @@
     {
       "id": "expected:25:2028-06-04",
       "event_id": 25,
-      "name": "J&J O'Rama",
+      "name": "Jack & Jill O'Rama",
       "start_date": "2028-06-04",
       "end_date": "2028-06-08",
       "weekend_start": "2028-06-01",
@@ -13035,7 +13013,7 @@
     {
       "id": "expected:220:2028-06-10",
       "event_id": 220,
-      "name": "D-Town Swing",
+      "name": "D-TOWNSWING 2027",
       "start_date": "2028-06-10",
       "end_date": "2028-06-13",
       "weekend_start": "2028-06-08",
@@ -13365,7 +13343,7 @@
     {
       "id": "expected:362:2028-07-09",
       "event_id": 362,
-      "name": "MY Swing",
+      "name": "MY Swing 2026",
       "start_date": "2028-07-09",
       "end_date": "2028-07-12",
       "weekend_start": "2028-07-06",
@@ -13497,7 +13475,7 @@
     {
       "id": "expected:280:2028-07-22",
       "event_id": 280,
-      "name": "Saint Petersburg WCS Nights",
+      "name": "St. Petersburg WCS Nights",
       "start_date": "2028-07-22",
       "end_date": "2028-07-26",
       "weekend_start": "2028-07-20",
@@ -14069,7 +14047,7 @@
     {
       "id": "expected:47:2028-09-10",
       "event_id": 47,
-      "name": "Swingtime in the Rockies",
+      "name": "SwingTime Denver",
       "start_date": "2028-09-10",
       "end_date": "2028-09-13",
       "weekend_start": "2028-09-07",
@@ -14157,7 +14135,7 @@
     {
       "id": "expected:357:2028-09-17",
       "event_id": 357,
-      "name": "WCS Party",
+      "name": "WCS Party in Vienna",
       "start_date": "2028-09-17",
       "end_date": "2028-09-21",
       "weekend_start": "2028-09-14",
@@ -14223,7 +14201,7 @@
     {
       "id": "expected:342:2028-09-18",
       "event_id": 342,
-      "name": "Global Grand Prix - West Coast Swing Reunion",
+      "name": "Global Grand Prix -- West Coast Swing Championships",
       "start_date": "2028-09-18",
       "end_date": "2028-09-21",
       "weekend_start": "2028-09-14",
@@ -14355,7 +14333,7 @@
     {
       "id": "expected:361:2028-09-24",
       "event_id": 361,
-      "name": "Mooseland Swing",
+      "name": "Mooseland Swing 2026",
       "start_date": "2028-09-24",
       "end_date": "2028-09-28",
       "weekend_start": "2028-09-21",
@@ -14793,7 +14771,7 @@
     {
       "id": "expected:31:2028-11-05",
       "event_id": 31,
-      "name": "Mountain Magic",
+      "name": "Mouintain Magic Dance Convention",
       "start_date": "2028-11-05",
       "end_date": "2028-11-08",
       "weekend_start": "2028-11-02",
@@ -14815,7 +14793,7 @@
     {
       "id": "expected:79:2028-11-05",
       "event_id": 79,
-      "name": "Sea to Sky",
+      "name": "Sea to Sky Seattle",
       "start_date": "2028-11-05",
       "end_date": "2028-11-09",
       "weekend_start": "2028-11-02",
@@ -14925,7 +14903,7 @@
     {
       "id": "expected:288:2028-11-12",
       "event_id": 288,
-      "name": "Midnight Madness",
+      "name": "Midnight Madness WCS 2026",
       "start_date": "2028-11-12",
       "end_date": "2028-11-15",
       "weekend_start": "2028-11-09",
@@ -15079,7 +15057,7 @@
     {
       "id": "expected:68:2028-11-25",
       "event_id": 68,
-      "name": "US Open Swing Dance Championships",
+      "name": "The Open Swing Dance  Championships",
       "start_date": "2028-11-25",
       "end_date": "2028-11-29",
       "weekend_start": "2028-11-23",
@@ -15123,7 +15101,7 @@
     {
       "id": "expected:212:2028-12-03",
       "event_id": 212,
-      "name": "The After Party (TAP)",
+      "name": "The After Party aka TAP",
       "start_date": "2028-12-03",
       "end_date": "2028-12-07",
       "weekend_start": "2028-11-30",
@@ -15233,7 +15211,7 @@
     {
       "id": "expected:152:2028-12-28",
       "event_id": 152,
-      "name": "Worlds UCWDC",
+      "name": "UCWDC Country Dance World Championships",
       "start_date": "2028-12-28",
       "end_date": "2029-01-03",
       "weekend_start": "2028-12-28",
@@ -15277,7 +15255,7 @@
     {
       "id": "expected:214:2028-12-30",
       "event_id": 214,
-      "name": "New Year's Swing Fling",
+      "name": "New Years Swing Fling",
       "start_date": "2028-12-30",
       "end_date": "2029-01-03",
       "weekend_start": "2028-12-28",


### PR DESCRIPTION
## Summary
- Sync JSON after pipeline expected cross-year match (companion to wsdc-data-pipeline PR for SwingCo).
- 2026 no longer shows a Dec 31 SwingCouver expected; Jan 2027 shows confirmed SwingCo.

## Test plan
- [ ] 2026: no hanging SwingCouver expected at year-end
- [ ] 2027 January: SwingCo confirmed (Portland)


Made with [Cursor](https://cursor.com)