### PR TITLE
Calendar stats: put remaining of total on one line

### DIFF
--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -321,10 +321,10 @@ h1 {
 .cal-stats {
   position: absolute;
   top: 8px;
-  left: max(4px, calc(50% - 410px - 104px));
+  left: max(4px, calc(50% - 410px - 120px));
   transform: none;
   z-index: 2;
-  width: 92px;
+  width: 108px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -461,18 +461,21 @@ h1 {
 
 .cal-stats__nums {
   display: flex;
-  flex-direction: column;
-  gap: 1px;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: baseline;
+  gap: 4px;
   min-width: 0;
 }
 
 .cal-stats__of {
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 400;
   letter-spacing: 0.01em;
-  line-height: 1.15;
+  line-height: 1.1;
   color: var(--text-tertiary);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 /* Right gutter: density / empty / today legend (vertical) */


### PR DESCRIPTION
## Summary
- Render current-year stats as inline `82 of 184` (same row, muted total).
- Slightly widen the left stats rail so the line fits.

## Test plan
- [ ] Current year: Confirmed shows `82 of 184` on one line (not stacked).
- [ ] Past/future years still show a single number.
- [ ] America filter: e.g. `39 of 84` still fits in the left gutter.


Made with [Cursor](https://cursor.com)