### PR TITLE
Calendar: Dance Mardi Gras 2026 hiatus

### DIFF
--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-03",
-  "generated_at": "2026-08-03T21:03:29Z",
+  "generated_at": "2026-08-03T21:45:06Z",
   "years": [
     2025,
     2026,
@@ -23,8 +23,8 @@
   "counts_by_year": {
     "2025": 176,
     "2026": 191,
-    "2027": 187,
-    "2028": 183
+    "2027": 186,
+    "2028": 182
   },
   "disclaimer": {
     "en": "Expected events are projected from the latest confirmed edition (±1 week per WSDC Registry Rules) for the current year and near-future years in the selector. They stay unconfirmed until published on the WSDC calendar; hiatus/cancelled stops the projection.",
@@ -5553,15 +5553,15 @@
       "source": "edition_calendar_dates"
     },
     {
-      "id": "expected:148:2026-07-24",
+      "id": "hiatus:148:2026-07-24",
       "event_id": 148,
-      "name": "Dance Mardi Gras",
+      "name": "Dance Mardi Gras (Hiatus -- 2026)",
       "start_date": "2026-07-24",
       "end_date": "2026-07-27",
       "weekend_start": "2026-07-23",
       "weekend_end": "2026-07-26",
       "weekend_key": "2026-07-23",
-      "status": "expected",
+      "status": "hiatus",
       "kind": "registry",
       "city": "New Orleans",
       "country": "United States",
@@ -5570,9 +5570,7 @@
       "lon": -90.0758356,
       "url": "https://dancemardigras.com/",
       "year": 2026,
-      "source": "expected_yoy",
-      "projected_from_year": 2025,
-      "projected_from_start": "2025-07-24"
+      "source": "edition_calendar_dates"
     },
     {
       "id": "confirmed:164:2026-07-25",
@@ -9517,28 +9515,6 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-07-23"
-    },
-    {
-      "id": "expected:148:2027-07-24",
-      "event_id": 148,
-      "name": "Dance Mardi Gras",
-      "start_date": "2027-07-24",
-      "end_date": "2027-07-27",
-      "weekend_start": "2027-07-22",
-      "weekend_end": "2027-07-25",
-      "weekend_key": "2027-07-22",
-      "status": "expected",
-      "kind": "registry",
-      "city": "New Orleans",
-      "country": "United States",
-      "continent": "America",
-      "lat": 29.9508941,
-      "lon": -90.0758356,
-      "url": "https://dancemardigras.com/",
-      "year": 2027,
-      "source": "expected_yoy",
-      "projected_from_year": 2025,
-      "projected_from_start": "2025-07-24"
     },
     {
       "id": "expected:164:2027-07-25",
@@ -13537,28 +13513,6 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-07-23"
-    },
-    {
-      "id": "expected:148:2028-07-24",
-      "event_id": 148,
-      "name": "Dance Mardi Gras",
-      "start_date": "2028-07-24",
-      "end_date": "2028-07-27",
-      "weekend_start": "2028-07-20",
-      "weekend_end": "2028-07-23",
-      "weekend_key": "2028-07-20",
-      "status": "expected",
-      "kind": "registry",
-      "city": "New Orleans",
-      "country": "United States",
-      "continent": "America",
-      "lat": 29.9508941,
-      "lon": -90.0758356,
-      "url": "https://dancemardigras.com/",
-      "year": 2028,
-      "source": "expected_yoy",
-      "projected_from_year": 2025,
-      "projected_from_start": "2025-07-24"
     },
     {
       "id": "expected:164:2028-07-25",


### PR DESCRIPTION
## Summary
- Rebuild `events_year_calendar.json` after pipeline operator hiatus for Dance Mardi Gras 2026.
- 2025 stays confirmed; 2026 is hiatus; expected rows for 2026–2028 for this series are gone.

## Test plan
- [ ] Events Calendar 2026: Dance Mardi Gras shows as Hiatus (not Expected).
- [ ] 2025: still Confirmed Jul 24–27.
- [ ] 2027/2028: no Dance Mardi Gras expected ghost.


Made with [Cursor](https://cursor.com)