### PR TITLE
Past-year confirmed counts from actual results

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -424,11 +424,25 @@
     return out;
   }
 
+  function countPastConfirmedOccurred(events) {
+    var ids = Object.create(null);
+    (events || []).forEach(function (e) {
+      if (e.status !== "confirmed") return;
+      if (!e.has_results) return;
+      if (e.event_id === null || e.event_id === undefined) return;
+      ids[String(e.event_id)] = 1;
+    });
+    return Object.keys(ids).length;
+  }
+
   function renderFilterStats(events) {
     var asOf = dataAsOf();
-    var splitYear = Number(String(asOf).slice(0, 4)) === state.year;
+    var asOfYear = Number(String(asOf).slice(0, 4));
+    var splitYear = asOfYear === state.year;
+    var isPastYear = state.year < asOfYear;
     var counts = countFilterStats(events, asOf);
     var splitKeys = { confirmed: 1, expected: 1, registry: 1, trial: 1 };
+    var pastOccurredConfirmed = isPastYear ? countPastConfirmedOccurred(events) : null;
     document.querySelectorAll("[data-stat]").forEach(function (wrap) {
       var key = wrap.getAttribute("data-stat");
       var bucket = counts[key] || emptyStatBucket();
@@ -447,7 +461,11 @@
           bucket.remaining + " " + t("statOf").replace("{n}", String(bucket.total))
         );
       } else {
-        valueEl.textContent = String(bucket.total);
+        if (isPastYear && key === "confirmed" && pastOccurredConfirmed !== null) {
+          valueEl.textContent = String(pastOccurredConfirmed);
+        } else {
+          valueEl.textContent = String(bucket.total);
+        }
         if (ofEl) {
           ofEl.hidden = true;
           ofEl.textContent = "";
@@ -620,6 +638,7 @@
   function indexByDay(events, year) {
     var map = {};
     events.forEach(function (e) {
+      if (e && e.stats_only) return;
       var start = e.start_date;
       if (!start) return;
       var end = e.end_date || e.start_date;
@@ -648,9 +667,10 @@
   function renderCalendar() {
     var root = document.getElementById("calendarRoot");
     var events = eventsForYear(state.year);
-    state.byDay = indexByDay(events, state.year);
+    var dayEvents = events.filter(function (e) { return !e.stats_only; });
+    state.byDay = indexByDay(dayEvents, state.year);
     renderFilterStats(events);
-    if (!events.length) {
+    if (!events.length || !Object.keys(state.byDay).length) {
       root.innerHTML = '<div class="empty-year">' + t("empty") + "</div>";
       return;
     }

--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-03",
-  "generated_at": "2026-08-03T21:45:06Z",
+  "generated_at": "2026-08-04T07:52:10Z",
   "years": [
     2025,
     2026,
@@ -21,7 +21,7 @@
     "end_weekday": "sun"
   },
   "counts_by_year": {
-    "2025": 176,
+    "2025": 185,
     "2026": 191,
     "2027": 186,
     "2028": 182
@@ -32,6 +32,138 @@
     "es": "Los eventos expected se proyectan desde la última edición confirmada (±1 semana según reglas WSDC) para el año actual y años cercanos del selector. Siguen sin confirmar hasta publicarse en el calendario WSDC; hiatus/cancelación detiene la proyección."
   },
   "events": [
+    {
+      "id": "confirmed:334:2025-01-01",
+      "event_id": 334,
+      "name": "Countdown Swing Boston",
+      "start_date": "2025-01-01",
+      "end_date": "2025-01-05",
+      "weekend_start": "2024-12-26",
+      "weekend_end": "2024-12-29",
+      "weekend_key": "2024-12-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Boston",
+      "country": "United States",
+      "continent": "America",
+      "lat": 42.3555076,
+      "lon": -71.0565364,
+      "url": "http://countdownswingboston.com/",
+      "year": 2025,
+      "source": "event_editions_month_only",
+      "has_results": true,
+      "stats_only": true
+    },
+    {
+      "id": "confirmed:42:2025-01-01",
+      "event_id": 42,
+      "name": "Floorplay Swing Vacation",
+      "start_date": "2025-01-01",
+      "end_date": "2025-01-06",
+      "weekend_start": "2024-12-26",
+      "weekend_end": "2024-12-29",
+      "weekend_key": "2024-12-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Orlando",
+      "country": "United States",
+      "continent": "America",
+      "lat": 28.5383832,
+      "lon": -81.3789269,
+      "url": "http://www.floorplayswingvacation.com/",
+      "year": 2025,
+      "source": "event_editions_month_only",
+      "has_results": true,
+      "stats_only": true
+    },
+    {
+      "id": "confirmed:141:2025-01-01",
+      "event_id": 141,
+      "name": "Spotlight New Year's Celebration",
+      "start_date": "2025-01-01",
+      "end_date": "2025-01-05",
+      "weekend_start": "2024-12-26",
+      "weekend_end": "2024-12-29",
+      "weekend_key": "2024-12-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Nashville",
+      "country": "United States",
+      "continent": "America",
+      "lat": 36.1626638,
+      "lon": -86.7816016,
+      "url": "http://www.spotlightnewyears.com/",
+      "year": 2025,
+      "source": "event_editions_month_only",
+      "has_results": true,
+      "stats_only": true
+    },
+    {
+      "id": "confirmed:289:2025-01-01",
+      "event_id": 289,
+      "name": "SwingVester",
+      "start_date": "2025-01-01",
+      "end_date": "2025-01-06",
+      "weekend_start": "2024-12-26",
+      "weekend_end": "2024-12-29",
+      "weekend_key": "2024-12-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Wels",
+      "country": "Austria",
+      "continent": "Europe",
+      "lat": 48.1664268,
+      "lon": 14.0388714,
+      "url": "https://www.swingvester.com/",
+      "year": 2025,
+      "source": "event_editions_month_only",
+      "has_results": true,
+      "stats_only": true
+    },
+    {
+      "id": "confirmed:75:2025-01-01",
+      "event_id": 75,
+      "name": "UCWDC Country Dance World Championship",
+      "start_date": "2025-01-01",
+      "end_date": "2025-01-01",
+      "weekend_start": "2024-12-26",
+      "weekend_end": "2024-12-29",
+      "weekend_key": "2024-12-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Dallas",
+      "country": "United States",
+      "continent": "America",
+      "lat": 32.7831,
+      "lon": -96.8067,
+      "url": "https://ucwdc.org/worlds-home/",
+      "year": 2025,
+      "source": "event_editions_month_only",
+      "has_results": true,
+      "stats_only": true
+    },
+    {
+      "id": "confirmed:240:2025-01-01",
+      "event_id": 240,
+      "name": "Westie Gala",
+      "start_date": "2025-01-01",
+      "end_date": "2025-01-05",
+      "weekend_start": "2024-12-26",
+      "weekend_end": "2024-12-29",
+      "weekend_key": "2024-12-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Stockholm",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 59.3251172,
+      "lon": 18.0710935,
+      "url": "http://www.westiegala.com/",
+      "year": 2025,
+      "source": "event_editions_month_only",
+      "has_results": true,
+      "stats_only": true
+    },
     {
       "id": "confirmed:196:2025-01-02",
       "event_id": 196,
@@ -50,7 +182,8 @@
       "lon": -122.6783853,
       "url": "http://www.swingcouver.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:184:2025-01-07",
@@ -70,7 +203,8 @@
       "lon": 19.040235,
       "url": "http://wcs-budafest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:62:2025-01-14",
@@ -90,7 +224,8 @@
       "lon": -121.8977688,
       "url": "http://Montereyswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:200:2025-01-16",
@@ -110,7 +245,8 @@
       "lon": -97.7430608,
       "url": "https://austinswingdance.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:309:2025-01-17",
@@ -130,7 +266,8 @@
       "lon": 4.359999699999999,
       "url": "http://Www.avignoncityswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:381:2025-01-17",
@@ -150,7 +287,8 @@
       "lon": 151.2057136,
       "url": "http://www.dancewcsa.com.au",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:242:2025-01-23",
@@ -170,7 +308,8 @@
       "lon": -85.7663724,
       "url": "https://derbycityswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:301:2025-01-23",
@@ -190,7 +329,8 @@
       "lon": -3.188267,
       "url": "http://www.swingresolution.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:183:2025-01-24",
@@ -210,7 +350,8 @@
       "lon": -75.5483909,
       "url": "https://freedomswingdance.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:215:2025-01-29",
@@ -230,7 +371,8 @@
       "lon": 30.3609097,
       "url": "http://swingandsnow.ru",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:273:2025-01-30",
@@ -250,7 +392,8 @@
       "lon": -80.84089329999999,
       "url": "https://www.charlottewestiefest.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:272:2025-01-30",
@@ -270,7 +413,8 @@
       "lon": 2.3513765,
       "url": "https://www.parisswingclassic.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:258:2025-02-06",
@@ -290,7 +434,8 @@
       "lon": 8.541694,
       "url": "https://swingtzerland.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:363:2025-02-07",
@@ -310,7 +455,8 @@
       "lon": -6.388300099999999,
       "url": "https://trinityswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:302:2025-02-07",
@@ -330,7 +476,8 @@
       "lon": 115.8616783,
       "url": "https://www.magneticdance.com.au/westeroz",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:12:2025-02-13",
@@ -350,7 +497,8 @@
       "lon": -121.4944209,
       "url": "http://www.CapitalSwingConvention.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:310:2025-02-14",
@@ -370,7 +518,8 @@
       "lon": 18.0710935,
       "url": "http://www.valentineswing.dance",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:344:2025-02-20",
@@ -390,7 +539,8 @@
       "lon": -8.8252502,
       "url": "http://arousawestiefest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:244:2025-02-20",
@@ -410,7 +560,8 @@
       "lon": -122.6783853,
       "url": "https://rosecityswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:343:2025-02-20",
@@ -430,7 +581,8 @@
       "lon": -98.4945922,
       "url": "https://swingcrush.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:297:2025-02-20",
@@ -450,7 +602,8 @@
       "lon": 27.7880116,
       "url": "https://www.wintercoastswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:92:2025-02-27",
@@ -490,7 +643,8 @@
       "lon": 7.725619099999999,
       "url": "https://www.euro-dance-festival.com/rust/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:143:2025-03-07",
@@ -510,7 +664,8 @@
       "lon": -118.1481016,
       "url": "http://www.highdesertdanceclassic.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:333:2025-03-07",
@@ -530,7 +685,8 @@
       "lon": 174.7787463,
       "url": "https://swingcentral.nz/swingvasion",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:318:2025-03-13",
@@ -570,7 +726,8 @@
       "lon": 5.9736992,
       "url": "https://www.dutchopenwcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:142:2025-03-13",
@@ -590,7 +747,8 @@
       "lon": -87.6323879,
       "url": "http://www.thechicagoclassic.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:186:2025-03-13",
@@ -610,7 +768,8 @@
       "lon": 4.835659,
       "url": "http://www.west-in-lyon.fr",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:314:2025-03-13",
@@ -630,7 +789,8 @@
       "lon": 19.040235,
       "url": "https://westiespringthing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:197:2025-03-20",
@@ -650,7 +810,8 @@
       "lon": -104.990251,
       "url": "https://www.5280westival.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:9:2025-03-20",
@@ -670,7 +831,8 @@
       "lon": -71.0565364,
       "url": "http://teapartyswings.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:292:2025-03-20",
@@ -690,7 +852,8 @@
       "lon": 19.9449799,
       "url": "http://kingswing.pl",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:153:2025-03-20",
@@ -710,7 +873,8 @@
       "lon": -95.3701108,
       "url": "http://Novice-invitational.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:324:2025-03-27",
@@ -730,7 +894,8 @@
       "lon": -114.0718831,
       "url": "http://Btoopen.ca",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:154:2025-03-27",
@@ -750,7 +915,8 @@
       "lon": -0.1275862,
       "url": "http://www.ukwcschamps.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:293:2025-04-04",
@@ -770,7 +936,8 @@
       "lon": -1.553621,
       "url": "https://www.westynantes.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:116:2025-04-10",
@@ -790,7 +957,8 @@
       "lon": -114.0718831,
       "url": "http://www.calgarydancestampede.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:187:2025-04-10",
@@ -810,7 +978,8 @@
       "lon": -118.3074827,
       "url": "https://cityofangelswcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:210:2025-04-10",
@@ -830,7 +999,8 @@
       "lon": 126.6312666,
       "url": "https://www.kopenwcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:352:2025-04-10",
@@ -850,7 +1020,8 @@
       "lon": 14.5057515,
       "url": "https://www.slovenianopen.dance",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:218:2025-04-17",
@@ -870,7 +1041,8 @@
       "lon": 103.819836,
       "url": "https://www.asiawcsopen.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:18:2025-04-17",
@@ -890,7 +1062,8 @@
       "lon": -122.3328481,
       "url": "https://www.easterswing.org/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:132:2025-04-18",
@@ -910,7 +1083,8 @@
       "lon": -95.989501,
       "url": "http://www.TulsaSpringSwing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:370:2025-04-23",
@@ -930,7 +1104,8 @@
       "lon": 7.0982068,
       "url": "http://www.tanzhaus-bonn.de/swingin-festival",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:203:2025-04-24",
@@ -950,7 +1125,8 @@
       "lon": -2.2426305,
       "url": "http://www.DetonationDance.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:345:2025-04-24",
@@ -970,7 +1146,8 @@
       "lon": 55.9578555,
       "url": "https://honeyfest-ufa.ru/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:259:2025-04-24",
@@ -990,7 +1167,8 @@
       "lon": -81.3789269,
       "url": "http://www.swingoverevent.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:354:2025-04-30",
@@ -1010,7 +1188,8 @@
       "lon": 7.842104299999999,
       "url": "https://springtimeswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:347:2025-05-01",
@@ -1030,7 +1209,30 @@
       "lon": -3.7032905,
       "url": "https://beemadwcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
+    },
+    {
+      "id": "confirmed:221:2025-05-01",
+      "event_id": 221,
+      "name": "Gateway Swing Classic",
+      "start_date": "2025-05-01",
+      "end_date": "2025-05-04",
+      "weekend_start": "2025-05-01",
+      "weekend_end": "2025-05-04",
+      "weekend_key": "2025-05-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "St. Louis",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.62742799999999,
+      "lon": -90.1982439,
+      "url": "http://gatewayswing.com/",
+      "year": 2025,
+      "source": "event_editions_month_only",
+      "has_results": true,
+      "stats_only": true
     },
     {
       "id": "confirmed:253:2025-05-01",
@@ -1050,7 +1252,8 @@
       "lon": 18.0710935,
       "url": "http://www.nordicwcschamps.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "cancelled:134:2025-05-01",
@@ -1090,7 +1293,8 @@
       "lon": -72.6733723,
       "url": "http://www.sis.djkenm.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:379:2025-05-08",
@@ -1110,7 +1314,8 @@
       "lon": 6.2355346,
       "url": "http://www.medinswing.rocks",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:336:2025-05-08",
@@ -1130,7 +1335,8 @@
       "lon": 14.0388714,
       "url": "https://www.swingofmusic.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:174:2025-05-09",
@@ -1150,7 +1356,8 @@
       "lon": 153.380936,
       "url": "https://rawconnection.com.au/swingsation/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:205:2025-05-15",
@@ -1170,7 +1377,8 @@
       "lon": -122.7139216,
       "url": "http://soswingdance.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:551:2025-05-15",
@@ -1210,7 +1418,8 @@
       "lon": -73.56739189999999,
       "url": "http://canadianswingchampionships.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:372:2025-05-16",
@@ -1230,7 +1439,8 @@
       "lon": -77.026088,
       "url": "http://www.dancejamproductions.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:121:2025-05-16",
@@ -1250,7 +1460,8 @@
       "lon": -97.7430608,
       "url": "http://www.thetexasclassic.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:22:2025-05-22",
@@ -1270,7 +1481,8 @@
       "lon": -84.3885209,
       "url": "http://www.usagrandnationals.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:364:2025-05-23",
@@ -1290,7 +1502,8 @@
       "lon": -123.9400647,
       "url": "http://www.nanaimodancefusion.ca",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:175:2025-05-28",
@@ -1310,7 +1523,8 @@
       "lon": 2.3513765,
       "url": "http://www.fowcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:76:2025-05-29",
@@ -1330,7 +1544,8 @@
       "lon": -83.0424533,
       "url": "http://www.michiganclassicswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:371:2025-05-30",
@@ -1350,7 +1565,8 @@
       "lon": -1.61778,
       "url": "https://festivalcityswing.co.uk/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:206:2025-05-30",
@@ -1370,7 +1586,8 @@
       "lon": 19.040235,
       "url": "http://wcs-ho.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:368:2025-05-30",
@@ -1390,7 +1607,30 @@
       "lon": 11.97456,
       "url": "http://www.next-level.dance",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
+    },
+    {
+      "id": "confirmed:255:2025-06-01",
+      "event_id": 255,
+      "name": "Indy Dance Explosion",
+      "start_date": "2025-06-01",
+      "end_date": "2025-06-01",
+      "weekend_start": "2025-05-29",
+      "weekend_end": "2025-06-01",
+      "weekend_key": "2025-05-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Fort Wayne",
+      "country": "United States",
+      "continent": "America",
+      "lat": 41.0794759,
+      "lon": -85.1362929,
+      "url": "http://www.indydancex.com",
+      "year": 2025,
+      "source": "event_editions_month_only",
+      "has_results": true,
+      "stats_only": true
     },
     {
       "id": "confirmed:222:2025-06-05",
@@ -1410,7 +1650,8 @@
       "lon": 18.6466384,
       "url": "http://www.balticswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:25:2025-06-05",
@@ -1430,7 +1671,8 @@
       "lon": -117.9379952,
       "url": "https://jackandjillorama.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:117:2025-06-05",
@@ -1450,7 +1692,8 @@
       "lon": -81.3789269,
       "url": "http://www.orangeblossomdance.net",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:220:2025-06-12",
@@ -1470,7 +1713,8 @@
       "lon": 6.7824545,
       "url": "http://www.d-townsing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:374:2025-06-19",
@@ -1490,7 +1734,8 @@
       "lon": 9.1942834,
       "url": "https://lb-barockswing.com/index.php",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:162:2025-06-20",
@@ -1510,7 +1755,8 @@
       "lon": -91.1871466,
       "url": "http://www.swingapaloozaevent.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:109:2025-06-26",
@@ -1530,7 +1776,8 @@
       "lon": -104.990251,
       "url": "http://www.coloradocountryclassic.net",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:207:2025-06-26",
@@ -1550,7 +1797,8 @@
       "lon": -121.3153096,
       "url": "https://dancenplay.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:96:2025-06-26",
@@ -1570,7 +1818,8 @@
       "lon": -74.4442802,
       "url": "http://www.libertyswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:261:2025-06-26",
@@ -1590,7 +1839,8 @@
       "lon": 4.9041389,
       "url": "http://www.neverlandswing.com/",
       "year": 2025,
-      "source": "event_editions"
+      "source": "event_editions",
+      "has_results": true
     },
     {
       "id": "confirmed:369:2025-06-27",
@@ -1610,7 +1860,8 @@
       "lon": 6.129384,
       "url": "http://FRENCHCONNECTIONWCS.COM",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:331:2025-06-27",
@@ -1630,7 +1881,8 @@
       "lon": 16.6068371,
       "url": "https://www.swingfiction.cz/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:1:2025-07-03",
@@ -1650,7 +1902,8 @@
       "lon": -112.0725488,
       "url": "http://phoenix4thofjuly.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:278:2025-07-03",
@@ -1670,7 +1923,8 @@
       "lon": 50.1728035,
       "url": "https://vk.com/americano2025 t.me/americamodancecamp",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:360:2025-07-03",
@@ -1690,7 +1944,8 @@
       "lon": 23.0746568,
       "url": "https://ekarolas.com/saunaswing/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:225:2025-07-03",
@@ -1710,7 +1965,8 @@
       "lon": -96.8067,
       "url": "http://www.WildWildWestie.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:156:2025-07-10",
@@ -1730,7 +1986,8 @@
       "lon": -74.4763123,
       "url": "http://bigapplecountrydance.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:373:2025-07-10",
@@ -1750,7 +2007,8 @@
       "lon": -80.84089329999999,
       "url": "https://carolinasummerswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:362:2025-07-10",
@@ -1770,7 +2028,8 @@
       "lon": 101.6840589,
       "url": "https://www.myswingopen.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:375:2025-07-11",
@@ -1790,7 +2049,8 @@
       "lon": 2.168568,
       "url": "https://mediterraneanopenwcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:224:2025-07-17",
@@ -1810,7 +2070,8 @@
       "lon": -94.6707917,
       "url": "http://Www.Midwestwestiefest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:280:2025-07-17",
@@ -1830,7 +2091,8 @@
       "lon": 30.3609097,
       "url": "http://wcsnights.ru",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:147:2025-07-17",
@@ -1850,7 +2112,8 @@
       "lon": -79.3831843,
       "url": "http://www.TOSHC.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:385:2025-07-18",
@@ -1870,7 +2133,8 @@
       "lon": 144.9630576,
       "url": "https://withjoy.com/revitalisewcs-melbourne2025/welcome",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:256:2025-07-18",
@@ -1890,7 +2154,8 @@
       "lon": 19.4528047,
       "url": "https://rockthebarn.se/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:148:2025-07-24",
@@ -1910,7 +2175,8 @@
       "lon": -90.0758356,
       "url": "https://dancemardigras.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:149:2025-07-24",
@@ -1930,7 +2196,8 @@
       "lon": -80.13731740000001,
       "url": "https://floridadancemagic.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:77:2025-07-31",
@@ -1950,7 +2217,8 @@
       "lon": -112.0725488,
       "url": "https://arizonadanceclassic.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:157:2025-07-31",
@@ -1970,7 +2238,8 @@
       "lon": -71.0565364,
       "url": "http://www.nedancefestival.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:164:2025-07-31",
@@ -2010,7 +2279,8 @@
       "lon": -2.58791,
       "url": "https://www.bristolcityswing.com/bsf",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:382:2025-08-01",
@@ -2030,7 +2300,30 @@
       "lon": -9.1393366,
       "url": "http://www.lisbonwestiefest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
+    },
+    {
+      "id": "confirmed:264:2025-08-01",
+      "event_id": 264,
+      "name": "Swedish Swing Summer Camp",
+      "start_date": "2025-08-01",
+      "end_date": "2025-08-03",
+      "weekend_start": "2025-07-31",
+      "weekend_end": "2025-08-03",
+      "weekend_key": "2025-07-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Stockholm",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 59.3251172,
+      "lon": 18.0710935,
+      "url": "http://www.uptownswing.se/",
+      "year": 2025,
+      "source": "event_editions_month_only",
+      "has_results": true,
+      "stats_only": true
     },
     {
       "id": "confirmed:383:2025-08-01",
@@ -2050,7 +2343,8 @@
       "lon": 21.0122287,
       "url": "https://www.summernightswestival.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:282:2025-08-07",
@@ -2070,7 +2364,8 @@
       "lon": 7.842104299999999,
       "url": "https://go-wcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:120:2025-08-07",
@@ -2090,7 +2385,8 @@
       "lon": -97.7430608,
       "url": "http://Www.lonestarcountrydance.com.",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:59:2025-08-07",
@@ -2110,7 +2406,8 @@
       "lon": -77.3860976,
       "url": "http://www.swingfling.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:227:2025-08-07",
@@ -2130,7 +2427,8 @@
       "lon": -122.4194155,
       "url": "http://www.DanceGeekProductions.Art",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:47:2025-08-14",
@@ -2150,7 +2448,8 @@
       "lon": -104.990251,
       "url": "http://www.swingtimewcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:119:2025-08-15",
@@ -2170,7 +2469,8 @@
       "lon": -87.6323879,
       "url": "http://www.chicagolanddancefestival.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:384:2025-08-15",
@@ -2190,7 +2490,8 @@
       "lon": 23.3218675,
       "url": "https://wcs-gps.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:493:2025-08-15",
@@ -2230,7 +2531,8 @@
       "lon": -71.0565364,
       "url": "https://summerhummerboston.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:391:2025-08-21",
@@ -2250,7 +2552,8 @@
       "lon": -84.5120196,
       "url": "http://swingdancemania.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:356:2025-08-21",
@@ -2270,7 +2573,8 @@
       "lon": -121.3153096,
       "url": "http://thebendconnection.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:298:2025-08-22",
@@ -2290,7 +2594,8 @@
       "lon": 172.636648,
       "url": "https://code03swing.com/shakedown",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:135:2025-08-28",
@@ -2310,7 +2615,8 @@
       "lon": -112.0725488,
       "url": "http://www.desertcityswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:177:2025-08-28",
@@ -2330,7 +2636,8 @@
       "lon": -81.6591529,
       "url": "http://www.jaxwestiefest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:313:2025-08-28",
@@ -2350,7 +2657,8 @@
       "lon": 4.835659,
       "url": "http://www.frenchywesty.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:48:2025-08-28",
@@ -2370,7 +2678,8 @@
       "lon": -121.8852525,
       "url": "https://sbdf.dance/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:268:2025-09-04",
@@ -2390,7 +2699,8 @@
       "lon": 126.519838,
       "url": "http://koreawestival.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:231:2025-09-04",
@@ -2410,7 +2720,8 @@
       "lon": -78.6381787,
       "url": "https://www.trilogywcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:338:2025-09-05",
@@ -2430,7 +2741,8 @@
       "lon": 37.6150527,
       "url": "https://vk.com/seadancefest",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:233:2025-09-11",
@@ -2450,7 +2762,8 @@
       "lon": 11.5819806,
       "url": "https://bavarianopen.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:167:2025-09-11",
@@ -2470,7 +2783,8 @@
       "lon": 151.2057136,
       "url": "https://www.bestofthebestwcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:359:2025-09-18",
@@ -2490,7 +2804,8 @@
       "lon": -122.3328481,
       "url": "https://www.retaliationswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:300:2025-09-19",
@@ -2510,7 +2825,8 @@
       "lon": -97.7430608,
       "url": "http://www.atxrox.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:254:2025-09-19",
@@ -2530,7 +2846,8 @@
       "lon": 24.938379,
       "url": "http://www.finnfest.fi",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:234:2025-09-19",
@@ -2550,7 +2867,8 @@
       "lon": -75.5483909,
       "url": "https://phillyswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:357:2025-09-19",
@@ -2570,7 +2888,8 @@
       "lon": 16.3713095,
       "url": "https://www.wcsparty.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:131:2025-09-25",
@@ -2590,7 +2909,8 @@
       "lon": -90.1982439,
       "url": "http://www.mmisl.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:165:2025-09-25",
@@ -2610,7 +2930,8 @@
       "lon": -0.1275862,
       "url": "http://www.MidlandSwingOpen.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:361:2025-09-25",
@@ -2630,7 +2951,8 @@
       "lon": 14.6360681,
       "url": "https://mooselandswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:211:2025-10-02",
@@ -2650,7 +2972,8 @@
       "lon": -84.3885209,
       "url": "https://atlantaswingclassic.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:388:2025-10-02",
@@ -2670,7 +2993,8 @@
       "lon": 11.0679977,
       "url": "https://norwegianopen.no/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:355:2025-10-08",
@@ -2690,7 +3014,8 @@
       "lon": -156.4391668,
       "url": "http://www.alohaopenwcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:322:2025-10-09",
@@ -2710,7 +3035,8 @@
       "lon": 9.1824027,
       "url": "https://www.westcoastswingmilan.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:43:2025-10-09",
@@ -2730,7 +3056,8 @@
       "lon": -117.8265049,
       "url": "http://www.paradisecountrydancefestival.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:367:2025-10-10",
@@ -2750,7 +3077,8 @@
       "lon": 115.8616783,
       "url": "https://www.gowestswingfest.au",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:8:2025-10-16",
@@ -2770,7 +3098,8 @@
       "lon": -122.4194155,
       "url": "https://boogiebythebay.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:179:2025-10-16",
@@ -2790,7 +3119,8 @@
       "lon": 174.7644881,
       "url": "https://www.streetswing.co.nz/the-new-zealand-open",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:178:2025-10-17",
@@ -2810,7 +3140,8 @@
       "lon": -73.56739189999999,
       "url": "http://montrealwestiefest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:267:2025-10-17",
@@ -2830,7 +3161,8 @@
       "lon": -75.1652215,
       "url": "http://www.swustlicious.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:350:2025-10-22",
@@ -2850,7 +3182,8 @@
       "lon": 10.89779,
       "url": "https://www.augsburgwestiestation.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:65:2025-10-23",
@@ -2870,7 +3203,8 @@
       "lon": -117.9047429,
       "url": "http://HSTswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:125:2025-10-23",
@@ -2890,7 +3224,8 @@
       "lon": -87.6323879,
       "url": "https://swingcitychicago.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:380:2025-10-24",
@@ -2910,7 +3245,8 @@
       "lon": -73.75447070000001,
       "url": "http://www.spookyalbanyswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:346:2025-10-24",
@@ -2930,7 +3266,8 @@
       "lon": 5.5689372,
       "url": "http://www.swingside-invitational.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:286:2025-10-24",
@@ -2950,7 +3287,8 @@
       "lon": 6.7824545,
       "url": "http://www.wcsfestival.de",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:31:2025-10-30",
@@ -2970,7 +3308,8 @@
       "lon": -119.7788687,
       "url": "https://mountainmagic.dance/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:229:2025-10-30",
@@ -2990,7 +3329,8 @@
       "lon": 18.0710935,
       "url": "http://www.snowcs.se",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:236:2025-10-30",
@@ -3010,7 +3350,8 @@
       "lon": 21.0122287,
       "url": "http://www.warsawhalloweenswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:340:2025-10-31",
@@ -3030,7 +3371,8 @@
       "lon": 103.819836,
       "url": "https://spookywestieweekend.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:323:2025-10-31",
@@ -3050,7 +3392,8 @@
       "lon": -86.5853155,
       "url": "https://rocketcityswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:330:2025-11-06",
@@ -3070,7 +3413,8 @@
       "lon": 138.6007456,
       "url": "http://www.simplyadelaidewcs.com.au",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:137:2025-11-06",
@@ -3090,7 +3434,8 @@
       "lon": -82.45875269999999,
       "url": "http://www.tbcwcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:269:2025-11-07",
@@ -3110,7 +3455,8 @@
       "lon": 19.040235,
       "url": "http://asc-budapest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:194:2025-11-07",
@@ -3130,7 +3476,8 @@
       "lon": 37.6150527,
       "url": "http://westiefest.org/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:270:2025-11-07",
@@ -3150,7 +3497,8 @@
       "lon": 4.835659,
       "url": "http://www.frenchywesty.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:181:2025-11-13",
@@ -3170,7 +3518,8 @@
       "lon": -77.3860976,
       "url": "http://www.dcswingexperience.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:288:2025-11-13",
@@ -3190,7 +3539,8 @@
       "lon": -96.8067,
       "url": "http://www.MidnightMadnessWCS.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:79:2025-11-13",
@@ -3230,7 +3580,8 @@
       "lon": -0.1275862,
       "url": "https://eastonswing.com/west-coast-swing-events/world-swing-dance-council/flowstate-west-coast-swing-zouk-festival-eastonswing/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:312:2025-11-14",
@@ -3250,7 +3601,8 @@
       "lon": 1.442848,
       "url": "http://www.westiepinkcity.fr",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:376:2025-11-20",
@@ -3270,7 +3622,8 @@
       "lon": -71.414199,
       "url": "http://www.northeastswingclassic.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:68:2025-11-26",
@@ -3290,7 +3643,8 @@
       "lon": -118.242643,
       "url": "http://www.theopenswing.com/",
       "year": 2025,
-      "source": "event_editions"
+      "source": "event_editions",
+      "has_results": true
     },
     {
       "id": "confirmed:87:2025-11-27",
@@ -3310,7 +3664,8 @@
       "lon": -81.6943605,
       "url": "https://cashdanceclub.org/cash-bash/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:212:2025-12-04",
@@ -3330,7 +3685,8 @@
       "lon": -117.8311428,
       "url": "http://www.tapwcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:238:2025-12-04",
@@ -3350,7 +3706,8 @@
       "lon": 10.7312704,
       "url": "http://www.winterwhite.no",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:290:2025-12-05",
@@ -3370,7 +3727,8 @@
       "lon": 37.6150527,
       "url": "https://t.me/ShoobaDoobaSwing",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:271:2025-12-11",
@@ -3390,7 +3748,8 @@
       "lon": 13.404954,
       "url": "https://berlinswingrevolution.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:377:2025-12-11",
@@ -3410,7 +3769,8 @@
       "lon": 19.9449799,
       "url": "http://santaswing.pl",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:342:2025-12-12",
@@ -3430,7 +3790,8 @@
       "lon": 1.442848,
       "url": "https://www.globalgrandprixwcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:240:2025-12-28",
@@ -3450,7 +3811,8 @@
       "lon": 18.0710935,
       "url": "http://www.westiegala.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:42:2025-12-30",
@@ -3470,7 +3832,8 @@
       "lon": -81.3789269,
       "url": "http://www.floorplayswingvacation.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:334:2025-12-31",
@@ -3490,7 +3853,8 @@
       "lon": -71.0565364,
       "url": "https://countdownswingboston.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:141:2025-12-31",
@@ -3510,7 +3874,8 @@
       "lon": -86.7816016,
       "url": "http://www.spotlightnewyears.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:196:2025-12-31",
@@ -3530,7 +3895,8 @@
       "lon": -122.6783853,
       "url": "http://www.swingcouver.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:289:2025-12-31",
@@ -3550,7 +3916,8 @@
       "lon": 14.0388714,
       "url": "http://www.swingvester.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:152:2026-01-01",
@@ -3590,7 +3957,8 @@
       "lon": 19.040235,
       "url": "http://wcs-budafest.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:200:2026-01-15",
@@ -3610,7 +3978,8 @@
       "lon": -97.7430608,
       "url": "https://austinswingdance.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:62:2026-01-15",
@@ -3630,7 +3999,8 @@
       "lon": -121.8977688,
       "url": "http://www.montereyswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:309:2026-01-16",
@@ -3650,7 +4020,8 @@
       "lon": 4.359999699999999,
       "url": "https://www.avignoncityswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:381:2026-01-16",
@@ -3690,7 +4061,8 @@
       "lon": -85.7663724,
       "url": "https://derbycityswing.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:301:2026-01-22",
@@ -3710,7 +4082,8 @@
       "lon": -3.188267,
       "url": "http://www.swingresolution.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:183:2026-01-23",
@@ -3730,7 +4103,8 @@
       "lon": -75.5483909,
       "url": "https://freedomswingdance.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:272:2026-01-23",
@@ -3750,7 +4124,8 @@
       "lon": 2.3513765,
       "url": "https://parisswingclassic.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:273:2026-01-29",
@@ -3770,7 +4145,8 @@
       "lon": -80.84089329999999,
       "url": "https://www.charlottewestiefest.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:215:2026-02-05",
@@ -3790,7 +4166,8 @@
       "lon": 30.3609097,
       "url": "https://swingandsnow.ru/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:258:2026-02-05",
@@ -3810,7 +4187,8 @@
       "lon": 8.541694,
       "url": "https://swingtzerland.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:387:2026-02-05",
@@ -3830,7 +4208,8 @@
       "lon": -80.5261203,
       "url": "http://www.waterlooopenwcs.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:363:2026-02-06",
@@ -3850,7 +4229,8 @@
       "lon": -6.388300099999999,
       "url": "http://Trinityswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:302:2026-02-06",
@@ -3890,7 +4270,8 @@
       "lon": -121.4944209,
       "url": "https://www.capitalswingconvention.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:386:2026-02-13",
@@ -3910,7 +4291,8 @@
       "lon": 14.4378005,
       "url": "https://praguealchemyswing.cz/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:310:2026-02-13",
@@ -3930,7 +4312,8 @@
       "lon": 18.0710935,
       "url": "http://valentineswing.dance",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:348:2026-02-17",
@@ -3950,7 +4333,8 @@
       "lon": 7.725619099999999,
       "url": "https://www.euro-dance-festival.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:344:2026-02-19",
@@ -3970,7 +4354,8 @@
       "lon": -8.8252502,
       "url": "https://www.arousawestiefest.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:343:2026-02-19",
@@ -3990,7 +4375,8 @@
       "lon": -98.4945922,
       "url": "https://swingcrush.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:297:2026-02-19",
@@ -4010,7 +4396,8 @@
       "lon": 27.7880116,
       "url": "http://www.wintercoastswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:244:2026-02-26",
@@ -4030,7 +4417,8 @@
       "lon": -122.6783853,
       "url": "https://rosecityswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:394:2026-02-26",
@@ -4050,7 +4438,8 @@
       "lon": 147.3257196,
       "url": "http://www.southernlightsswing.com.au",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:378:2026-02-27",
@@ -4070,7 +4459,8 @@
       "lon": -74.0059728,
       "url": "https://www.flowfest.nyc",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:92:2026-03-05",
@@ -4090,7 +4480,8 @@
       "lon": -77.0369274,
       "url": "http://www.atlanticdancejam.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:143:2026-03-06",
@@ -4110,7 +4501,8 @@
       "lon": -118.1481016,
       "url": "http://www.highdesertdanceclassic.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:333:2026-03-06",
@@ -4130,7 +4522,8 @@
       "lon": 174.7787463,
       "url": "http://Swingvasion.nz",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:314:2026-03-11",
@@ -4150,7 +4543,8 @@
       "lon": 19.040235,
       "url": "https://westiespringthing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:318:2026-03-12",
@@ -4170,7 +4564,8 @@
       "lon": -122.4194155,
       "url": "https://www.allstarswingjam.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:275:2026-03-12",
@@ -4190,7 +4585,8 @@
       "lon": 5.9736992,
       "url": "http://www.dutchopenwcs.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:186:2026-03-12",
@@ -4210,7 +4606,8 @@
       "lon": 4.835659,
       "url": "http://www.west-in-lyon.fr",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:292:2026-03-19",
@@ -4230,7 +4627,8 @@
       "lon": 19.9449799,
       "url": "http://kingswing.pl",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:142:2026-03-19",
@@ -4250,7 +4648,8 @@
       "lon": -87.6323879,
       "url": "https://thechicagoclassic.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:197:2026-03-26",
@@ -4270,7 +4669,8 @@
       "lon": -104.990251,
       "url": "https://www.5280westival.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:9:2026-03-26",
@@ -4290,7 +4690,8 @@
       "lon": -71.0565364,
       "url": "http://teapartyswings.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:153:2026-03-26",
@@ -4310,7 +4711,8 @@
       "lon": -95.3701108,
       "url": "http://htownthrowdownwcs.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:154:2026-03-26",
@@ -4330,7 +4732,8 @@
       "lon": -0.1275862,
       "url": "https://www.ukwcschamps.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:18:2026-04-02",
@@ -4350,7 +4753,8 @@
       "lon": -122.3328481,
       "url": "https://www.easterswing.org/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:132:2026-04-02",
@@ -4370,7 +4774,8 @@
       "lon": -95.989501,
       "url": "http://www.TulsaSpringSwing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:116:2026-04-09",
@@ -4390,7 +4795,8 @@
       "lon": -114.0718831,
       "url": "http://www.calgarydancestampede.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:187:2026-04-09",
@@ -4410,7 +4816,8 @@
       "lon": -118.3074827,
       "url": "http://cityofangelswcs.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:210:2026-04-09",
@@ -4430,7 +4837,8 @@
       "lon": 126.6312666,
       "url": "https://www.kopenwcs.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:304:2026-04-09",
@@ -4450,7 +4858,8 @@
       "lon": 12.4822025,
       "url": "https://www.westcoastswingroma.it/swing-in-capital/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:293:2026-04-10",
@@ -4470,7 +4879,8 @@
       "lon": -1.553621,
       "url": "https://www.westynantes.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:218:2026-04-16",
@@ -4490,7 +4900,8 @@
       "lon": 103.819836,
       "url": "https://www.asiawcsopen.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:393:2026-04-16",
@@ -4510,7 +4921,8 @@
       "lon": -75.7003397,
       "url": "http://www.swinginbloom.ca",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:203:2026-04-23",
@@ -4530,7 +4942,8 @@
       "lon": -2.2426305,
       "url": "http://www.DetonationDance.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:345:2026-04-23",
@@ -4550,7 +4963,8 @@
       "lon": 55.9578555,
       "url": "https://t.me/honeyfest",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:352:2026-04-23",
@@ -4570,7 +4984,8 @@
       "lon": 14.5057515,
       "url": "https://slovenianopen.dance/en",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:370:2026-04-23",
@@ -4590,7 +5005,8 @@
       "lon": 7.0982068,
       "url": "http://www.swinginfestival.de",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:259:2026-04-23",
@@ -4610,7 +5026,8 @@
       "lon": -81.3789269,
       "url": "http://www.swingoverevent.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:253:2026-04-30",
@@ -4630,7 +5047,8 @@
       "lon": 18.0710935,
       "url": "http://www.nordicwcschamps.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:354:2026-04-30",
@@ -4650,7 +5068,8 @@
       "lon": 7.842104299999999,
       "url": "https://springtimeswing.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:144:2026-04-30",
@@ -4670,7 +5089,8 @@
       "lon": -72.6733723,
       "url": "http://www.sis.djkenm.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:347:2026-05-01",
@@ -4690,7 +5110,8 @@
       "lon": -3.7032905,
       "url": "https://beemadwcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:379:2026-05-07",
@@ -4710,7 +5131,8 @@
       "lon": 6.2355346,
       "url": "http://www.medinswing.rocks",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:336:2026-05-07",
@@ -4730,7 +5152,8 @@
       "lon": 14.0388714,
       "url": "http://www.swingofmusic.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:372:2026-05-08",
@@ -4750,7 +5173,8 @@
       "lon": -77.026088,
       "url": "https://dancejamproductions.com/westieweekend/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:175:2026-05-13",
@@ -4770,7 +5194,8 @@
       "lon": 2.3513765,
       "url": "http://www.fowcs.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:221:2026-05-14",
@@ -4790,7 +5215,8 @@
       "lon": -90.1982439,
       "url": "http://gatewayswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:205:2026-05-14",
@@ -4810,7 +5236,8 @@
       "lon": -122.7139216,
       "url": "https://www.soswingdance.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:105:2026-05-15",
@@ -4830,7 +5257,8 @@
       "lon": -73.56739189999999,
       "url": "https://www.canadianswingchampionships.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:174:2026-05-15",
@@ -4850,7 +5278,8 @@
       "lon": 153.380936,
       "url": "https://rawconnection.com.au/swingsation/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:121:2026-05-15",
@@ -4870,7 +5299,8 @@
       "lon": -97.7430608,
       "url": "http://Www.thetexasclassic.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:22:2026-05-21",
@@ -4890,7 +5320,8 @@
       "lon": -84.3885209,
       "url": "http://www.usagrandnationals.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:206:2026-05-22",
@@ -4910,7 +5341,8 @@
       "lon": 19.040235,
       "url": "http://wcs-ho.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:76:2026-05-28",
@@ -4930,7 +5362,8 @@
       "lon": -83.0424533,
       "url": "http://MichiganClassicSwing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:371:2026-05-29",
@@ -4950,7 +5383,8 @@
       "lon": -1.61778,
       "url": "http://www.fcswing.co.uk",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:364:2026-05-29",
@@ -4970,7 +5404,8 @@
       "lon": -123.9400647,
       "url": "http://www.nanaimodancefusion.ca",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:25:2026-06-04",
@@ -4990,7 +5425,8 @@
       "lon": -117.9379952,
       "url": "https://jackandjillorama.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:117:2026-06-04",
@@ -5010,7 +5446,8 @@
       "lon": -81.3789269,
       "url": "http://www.orangeblossomdance.net",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:222:2026-06-11",
@@ -5030,7 +5467,8 @@
       "lon": 18.6466384,
       "url": "http://www.balticswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:207:2026-06-18",
@@ -5070,7 +5508,8 @@
       "lon": 9.1824027,
       "url": "https://www.westcoastswingmilan.com/milanswingvibes/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:220:2026-06-19",
@@ -5090,7 +5529,8 @@
       "lon": 6.7824545,
       "url": "http://www.d-townswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:162:2026-06-19",
@@ -5110,7 +5550,8 @@
       "lon": -91.1871466,
       "url": "http://www.swingapaloozaevent.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:374:2026-06-25",
@@ -5130,7 +5571,8 @@
       "lon": 9.1942834,
       "url": "https://baroqueswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:109:2026-06-25",
@@ -5150,7 +5592,8 @@
       "lon": -104.990251,
       "url": "https://coloradocountryclassic.net/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:96:2026-06-25",
@@ -5170,7 +5613,8 @@
       "lon": -74.4442802,
       "url": "http://www.libertyswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:261:2026-06-25",
@@ -5190,7 +5634,8 @@
       "lon": 4.9041389,
       "url": "http://www.neverlandswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:331:2026-06-26",
@@ -5210,7 +5655,8 @@
       "lon": 16.6068371,
       "url": "https://www.swingfiction.cz/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:1:2026-07-02",
@@ -5230,7 +5676,8 @@
       "lon": -112.0725488,
       "url": "http://phoenix4thofjuly.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:278:2026-07-02",
@@ -5250,7 +5697,8 @@
       "lon": 50.1728035,
       "url": "https://t.me/americamodancecamp https://vk.com/americano2025",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:360:2026-07-02",
@@ -5270,7 +5718,8 @@
       "lon": 23.0746568,
       "url": "https://ekarolas.com/saunaswing/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:225:2026-07-02",
@@ -5290,7 +5739,8 @@
       "lon": -96.8067,
       "url": "https://www.wildwildwestie.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:369:2026-07-03",
@@ -5310,7 +5760,8 @@
       "lon": 6.129384,
       "url": "https://www.frenchconnectionwcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:156:2026-07-09",
@@ -5330,7 +5781,8 @@
       "lon": -74.4763123,
       "url": "http://bigapplecountrydance.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:373:2026-07-09",
@@ -5350,7 +5802,8 @@
       "lon": -80.84089329999999,
       "url": "https://carolinasummerswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:362:2026-07-09",
@@ -5370,7 +5823,8 @@
       "lon": 101.6840589,
       "url": "https://www.myswingopen.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:375:2026-07-09",
@@ -5390,7 +5844,8 @@
       "lon": 2.168568,
       "url": "https://mediterraneanopenwcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:147:2026-07-09",
@@ -5430,7 +5885,8 @@
       "lon": 13.404954,
       "url": "http://www.swinglab-berlin.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:224:2026-07-16",
@@ -5450,7 +5906,8 @@
       "lon": -94.6707917,
       "url": "http://Www.midwestwestiefest.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:385:2026-07-16",
@@ -5470,7 +5927,8 @@
       "lon": 144.9630576,
       "url": "https://revitalisewcs.melbourne/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:256:2026-07-17",
@@ -5490,7 +5948,8 @@
       "lon": 19.4528047,
       "url": "https://rockthebarn.se/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:280:2026-07-22",
@@ -5510,7 +5969,8 @@
       "lon": 30.3609097,
       "url": "http://wcsnights.ru",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:149:2026-07-23",
@@ -5530,7 +5990,8 @@
       "lon": -80.13731740000001,
       "url": "https://floridadancemagic.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:404:2026-07-23",
@@ -5550,7 +6011,8 @@
       "lon": 11.5819806,
       "url": "http://infinite-swing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:148:2026-07-24",
@@ -5590,7 +6052,8 @@
       "lon": 4.086072000000001,
       "url": "http://www.seasunswing.fr/",
       "year": 2026,
-      "source": "scheduled_events"
+      "source": "scheduled_events",
+      "has_results": true
     },
     {
       "id": "confirmed:382:2026-07-30",
@@ -7278,7 +7741,8 @@
       "lon": -81.3789269,
       "url": "http://www.floorplayswingvacation.com/",
       "year": 2026,
-      "source": "scheduled_events"
+      "source": "scheduled_events",
+      "has_results": true
     },
     {
       "id": "confirmed:214:2026-12-30",
@@ -7318,7 +7782,8 @@
       "lon": -86.7816016,
       "url": "http://www.spotlightnewyears.com/",
       "year": 2026,
-      "source": "scheduled_events"
+      "source": "scheduled_events",
+      "has_results": true
     },
     {
       "id": "confirmed:289:2026-12-30",
@@ -7338,7 +7803,8 @@
       "lon": 14.0388714,
       "url": "https://www.swingvester.com/",
       "year": 2026,
-      "source": "scheduled_events"
+      "source": "scheduled_events",
+      "has_results": true
     },
     {
       "id": "confirmed:334:2026-12-31",
@@ -7358,7 +7824,8 @@
       "lon": -71.0565364,
       "url": "http://countdownswingboston.com/",
       "year": 2026,
-      "source": "scheduled_events"
+      "source": "scheduled_events",
+      "has_results": true
     },
     {
       "id": "confirmed:240:2026-12-31",
@@ -7378,7 +7845,8 @@
       "lon": 18.0710935,
       "url": "http://www.westiegala.com/",
       "year": 2026,
-      "source": "scheduled_events"
+      "source": "scheduled_events",
+      "has_results": true
     },
     {
       "id": "confirmed:184:2027-01-05",


### PR DESCRIPTION
## Summary
- For past years, `Confirmed` uses distinct `event_id` where `has_results=true`.
- `stats_only` events are still excluded from day grid rendering.
- Refresh `events_year_calendar.json` with `has_results` / `stats_only` markers.

## Validation
- 2025: raw confirmed rows = 180, displayed past-year confirmed = 172 (matches `core.results` unique events).
- 2025 paused remains 5 (4 hiatus + 1 cancelled).


Made with [Cursor](https://cursor.com)