### PR TITLE
Past-year Confirmed from results; skip stats-only day pins

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -229,7 +229,7 @@
       statRegistry: "Registry",
       statTrial: "Trial",
       statOf: "of {n}",
-      statTip: "After filters. Past and future years show full-year totals. For the current year, Confirmed / Expected / Registry / Trial show remaining (not yet ended as of the data date), with the year total in quieter type — not a separate highlight. Hiatus / Cancelled is always the full-year count.",
+      statTip: "After filters. Past years: Confirmed counts distinct events with competition results. Future years show full-year calendar totals. For the current year, Confirmed / Expected / Registry / Trial show remaining (not yet ended as of the data date), with the year total in quieter type — not a separate highlight. Hiatus / Cancelled is always the full-year count.",
       statAria: "Selection counts",
       empty: "No day-precision events for this year yet.",
       day: "Day",
@@ -271,7 +271,7 @@
       statRegistry: "Registry",
       statTrial: "Trial",
       statOf: "из {n}",
-      statTip: "После фильтров. Прошлый и будущий год — полные итоги. Для текущего года Confirmed / Expected / Registry / Trial показывают остаток (ещё не закончились на дату данных), а итог года — приглушённо, без отдельной подсветки. Hiatus / Cancelled всегда за весь год.",
+      statTip: "После фильтров. Прошлый год: Confirmed — число уникальных ивентов с результатами. Будущий год — полные календарные итоги. Для текущего года Confirmed / Expected / Registry / Trial показывают остаток (ещё не закончились на дату данных), а итог года — приглушённо, без отдельной подсветки. Hiatus / Cancelled всегда за весь год.",
       statAria: "Счётчики выборки",
       empty: "Для этого года пока нет дат с точностью до дня.",
       day: "День",
@@ -313,7 +313,7 @@
       statRegistry: "Registry",
       statTrial: "Trial",
       statOf: "de {n}",
-      statTip: "Tras los filtros. Años pasados y futuros: totales del año. En el año actual, Confirmed / Expected / Registry / Trial muestran lo que queda (aún no terminados a la fecha de los datos), con el total del año en tipografía más discreta. Hiatus / Cancelled es siempre el total del año.",
+      statTip: "Tras los filtros. Años pasados: Confirmed cuenta eventos distintos con resultados. Años futuros: totales del calendario. En el año actual, Confirmed / Expected / Registry / Trial muestran lo que queda (aún no terminados a la fecha de los datos), con el total del año en tipografía más discreta. Hiatus / Cancelled es siempre el total del año.",
       statAria: "Conteos de la selección",
       empty: "Aún no hay eventos con fecha exacta para este año.",
       day: "Dia",
@@ -401,12 +401,26 @@
       registry: emptyStatBucket(),
       trial: emptyStatBucket()
     };
+    var asOfYear = Number(String(asOf || "").slice(0, 4));
+    var pastYearResultsConfirmed =
+      Number.isFinite(asOfYear) && state.year < asOfYear;
+    var confirmedSeen = {};
     (events || []).forEach(function (e) {
       var rem = isEventRemaining(e, asOf);
-      if (e.status === "confirmed") {
+      if (pastYearResultsConfirmed) {
+        if (e.has_results) {
+          var ckey =
+            e.event_id != null ? "id:" + e.event_id : "name:" + (e.name || "");
+          if (!confirmedSeen[ckey]) {
+            confirmedSeen[ckey] = true;
+            out.confirmed.total += 1;
+          }
+        }
+      } else if (e.status === "confirmed") {
         out.confirmed.total += 1;
         if (rem) out.confirmed.remaining += 1;
-      } else if (e.status === "expected") {
+      }
+      if (e.status === "expected") {
         out.expected.total += 1;
         if (rem) out.expected.remaining += 1;
       } else if (e.status === "hiatus" || e.status === "cancelled") {
@@ -620,6 +634,7 @@
   function indexByDay(events, year) {
     var map = {};
     events.forEach(function (e) {
+      if (e.stats_only) return;
       var start = e.start_date;
       if (!start) return;
       var end = e.end_date || e.start_date;

--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,7 +1,8 @@
 {
-  "as_of": "2026-08-03",
-  "generated_at": "2026-08-03T21:45:06Z",
+  "as_of": "2026-08-04",
+  "generated_at": "2026-08-04T08:29:01Z",
   "years": [
+    2024,
     2025,
     2026,
     2027,
@@ -21,10 +22,11 @@
     "end_weekday": "sun"
   },
   "counts_by_year": {
-    "2025": 176,
+    "2024": 139,
+    "2025": 179,
     "2026": 191,
-    "2027": 186,
-    "2028": 182
+    "2027": 188,
+    "2028": 184
   },
   "disclaimer": {
     "en": "Expected events are projected from the latest confirmed edition (±1 week per WSDC Registry Rules) for the current year and near-future years in the selector. They stay unconfirmed until published on the WSDC calendar; hiatus/cancelled stops the projection.",
@@ -32,6 +34,3190 @@
     "es": "Los eventos expected se proyectan desde la última edición confirmada (±1 semana según reglas WSDC) para el año actual y años cercanos del selector. Siguen sin confirmar hasta publicarse en el calendario WSDC; hiatus/cancelación detiene la proyección."
   },
   "events": [
+    {
+      "id": "confirmed:200:2024-01-01",
+      "event_id": 200,
+      "name": "Austin Swing Dance Championships",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Austin",
+      "country": "United States",
+      "continent": "America",
+      "lat": 30.267153,
+      "lon": -97.7430608,
+      "url": "https://austinswingdance.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:309:2024-01-01",
+      "event_id": 309,
+      "name": "Avignon City Swing",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Nimes",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 43.8338727,
+      "lon": 4.359999699999999,
+      "url": "https://www.avignoncityswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:184:2024-01-01",
+      "event_id": 184,
+      "name": "BudaFest Open WCS Championships",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Budapest",
+      "country": "Hungary",
+      "continent": "Europe",
+      "lat": 47.497912,
+      "lon": 19.040235,
+      "url": "http://wcs-budafest.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:334:2024-01-01",
+      "event_id": 334,
+      "name": "Countdown Swing Boston",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Boston",
+      "country": "United States",
+      "continent": "America",
+      "lat": 42.3555076,
+      "lon": -71.0565364,
+      "url": "http://countdownswingboston.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:242:2024-01-01",
+      "event_id": 242,
+      "name": "Derby City Swing",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Louisville",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.2468618,
+      "lon": -85.7663724,
+      "url": "https://derbycityswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:42:2024-01-01",
+      "event_id": 42,
+      "name": "Floorplay Swing Vacation",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Orlando",
+      "country": "United States",
+      "continent": "America",
+      "lat": 28.5383832,
+      "lon": -81.3789269,
+      "url": "http://www.floorplayswingvacation.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:183:2024-01-01",
+      "event_id": 183,
+      "name": "Freedom Swing Dance Challenge",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Wilmington",
+      "country": "United States",
+      "continent": "America",
+      "lat": 39.744655,
+      "lon": -75.5483909,
+      "url": "https://freedomswingdance.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:62:2024-01-01",
+      "event_id": 62,
+      "name": "Monterey SwingFest",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Monterey",
+      "country": "United States",
+      "continent": "America",
+      "lat": 36.5972925,
+      "lon": -121.8977688,
+      "url": "http://www.montereyswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:141:2024-01-01",
+      "event_id": 141,
+      "name": "Spotlight New Year's Celebration",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Nashville",
+      "country": "United States",
+      "continent": "America",
+      "lat": 36.1626638,
+      "lon": -86.7816016,
+      "url": "http://www.spotlightnewyears.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:301:2024-01-01",
+      "event_id": 301,
+      "name": "Swing Resolution",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Edinburgh",
+      "country": "United Kingdom",
+      "continent": "Europe",
+      "lat": 55.953252,
+      "lon": -3.188267,
+      "url": "http://www.swingresolution.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:196:2024-01-01",
+      "event_id": 196,
+      "name": "SwingCouver",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Portland",
+      "country": "United States",
+      "continent": "America",
+      "lat": 45.515232,
+      "lon": -122.6783853,
+      "url": "https://swingco.dance/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:289:2024-01-01",
+      "event_id": 289,
+      "name": "SwingVester",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Wels",
+      "country": "Austria",
+      "continent": "Europe",
+      "lat": 48.1664268,
+      "lon": 14.0388714,
+      "url": "https://www.swingvester.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:75:2024-01-01",
+      "event_id": 75,
+      "name": "UCWDC Country Dance World Championship",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Dallas",
+      "country": "United States",
+      "continent": "America",
+      "lat": 32.7831,
+      "lon": -96.8067,
+      "url": "https://ucwdc.org/worlds-home/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:240:2024-01-01",
+      "event_id": 240,
+      "name": "Westie Gala",
+      "start_date": "2024-01-01",
+      "end_date": null,
+      "weekend_start": "2023-12-28",
+      "weekend_end": "2023-12-31",
+      "weekend_key": "2023-12-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Stockholm",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 59.3251172,
+      "lon": 18.0710935,
+      "url": "http://www.westiegala.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:12:2024-02-01",
+      "event_id": 12,
+      "name": "Capital Swing Dance Convention",
+      "start_date": "2024-02-01",
+      "end_date": null,
+      "weekend_start": "2024-02-01",
+      "weekend_end": "2024-02-04",
+      "weekend_key": "2024-02-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Sacramento",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.5781342,
+      "lon": -121.4944209,
+      "url": "http://www.capitalswingconvention.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:273:2024-02-01",
+      "event_id": 273,
+      "name": "Charlotte Westie Fest",
+      "start_date": "2024-02-01",
+      "end_date": null,
+      "weekend_start": "2024-02-01",
+      "weekend_end": "2024-02-04",
+      "weekend_key": "2024-02-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Charlotte",
+      "country": "United States",
+      "continent": "America",
+      "lat": 35.2270768,
+      "lon": -80.84089329999999,
+      "url": "https://charlottewestiefest.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:272:2024-02-01",
+      "event_id": 272,
+      "name": "Paris Westie Fest",
+      "start_date": "2024-02-01",
+      "end_date": null,
+      "weekend_start": "2024-02-01",
+      "weekend_end": "2024-02-04",
+      "weekend_key": "2024-02-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Paris",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 48.8575475,
+      "lon": 2.3513765,
+      "url": "http://https//parisswingclassic.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:244:2024-02-01",
+      "event_id": 244,
+      "name": "Rose City Swing",
+      "start_date": "2024-02-01",
+      "end_date": null,
+      "weekend_start": "2024-02-01",
+      "weekend_end": "2024-02-04",
+      "weekend_key": "2024-02-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Portland",
+      "country": "United States",
+      "continent": "America",
+      "lat": 45.515232,
+      "lon": -122.6783853,
+      "url": "https://rosecityswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:215:2024-02-01",
+      "event_id": 215,
+      "name": "Swing & Snow",
+      "start_date": "2024-02-01",
+      "end_date": null,
+      "weekend_start": "2024-02-01",
+      "weekend_end": "2024-02-04",
+      "weekend_key": "2024-02-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "St. Petersburg",
+      "country": "Russia",
+      "continent": "Europe",
+      "lat": 59.9310584,
+      "lon": 30.3609097,
+      "url": "http://swingandsnow.ru/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:258:2024-02-01",
+      "event_id": 258,
+      "name": "Swingtzerland",
+      "start_date": "2024-02-01",
+      "end_date": null,
+      "weekend_start": "2024-02-01",
+      "weekend_end": "2024-02-04",
+      "weekend_key": "2024-02-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Zürich",
+      "country": "Switzerland",
+      "continent": "Europe",
+      "lat": 47.3768866,
+      "lon": 8.541694,
+      "url": "https://swingtzerland.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:310:2024-02-01",
+      "event_id": 310,
+      "name": "Valentine Swing",
+      "start_date": "2024-02-01",
+      "end_date": null,
+      "weekend_start": "2024-02-01",
+      "weekend_end": "2024-02-04",
+      "weekend_key": "2024-02-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Stockholm",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 59.3251172,
+      "lon": 18.0710935,
+      "url": "http://www.valentineswing.dance",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:297:2024-02-01",
+      "event_id": 297,
+      "name": "Winter Coast Swing",
+      "start_date": "2024-02-01",
+      "end_date": null,
+      "weekend_start": "2024-02-01",
+      "weekend_end": "2024-02-04",
+      "weekend_key": "2024-02-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Kuopio",
+      "country": "Finland",
+      "continent": "Europe",
+      "lat": 62.4917035,
+      "lon": 27.7880116,
+      "url": "https://www.wintercoastswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:197:2024-03-01",
+      "event_id": 197,
+      "name": "5280 Westival",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Denver",
+      "country": "United States",
+      "continent": "America",
+      "lat": 39.7392358,
+      "lon": -104.990251,
+      "url": "http://www.5280westival.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:318:2024-03-01",
+      "event_id": 318,
+      "name": "All Star SwingJam",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "San Francisco",
+      "country": "United States",
+      "continent": "America",
+      "lat": 37.7749295,
+      "lon": -122.4194155,
+      "url": "http://www.allstarswingjam.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:324:2024-03-01",
+      "event_id": 324,
+      "name": "BTO Open",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Calgary",
+      "country": "Canada",
+      "continent": "America",
+      "lat": 51.04473309999999,
+      "lon": -114.0718831,
+      "url": "https://ctodance.ca/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:9:2024-03-01",
+      "event_id": 9,
+      "name": "Boston Tea Party",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Boston",
+      "country": "United States",
+      "continent": "America",
+      "lat": 42.3555076,
+      "lon": -71.0565364,
+      "url": "http://teapartyswings.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:143:2024-03-01",
+      "event_id": 143,
+      "name": "High Desert Dance Classic",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Lancaster",
+      "country": "United States",
+      "continent": "America",
+      "lat": 34.703947,
+      "lon": -118.1481016,
+      "url": "http://www.highdesertdanceclassic.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:292:2024-03-01",
+      "event_id": 292,
+      "name": "King Swing",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Kraków",
+      "country": "Poland",
+      "continent": "Europe",
+      "lat": 50.06465009999999,
+      "lon": 19.9449799,
+      "url": "https://kingswing.pl/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:92:2024-03-01",
+      "event_id": 92,
+      "name": "MADjam",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Washington",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.9072873,
+      "lon": -77.0369274,
+      "url": "http://www.atlanticdancejam.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:153:2024-03-01",
+      "event_id": 153,
+      "name": "Novice Invitational",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Houston",
+      "country": "United States",
+      "continent": "America",
+      "lat": 29.7600771,
+      "lon": -95.3701108,
+      "url": "http://www.htownthrowdownwcs.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:217:2024-03-01",
+      "event_id": 217,
+      "name": "San Diego Dance Festival",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "San Diego",
+      "country": "United States",
+      "continent": "America",
+      "lat": 32.715738,
+      "lon": -117.1610838,
+      "url": null,
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:333:2024-03-01",
+      "event_id": 333,
+      "name": "Swingvasion",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Wellington",
+      "country": "New Zealand",
+      "continent": "Australia",
+      "lat": -41.2923814,
+      "lon": 174.7787463,
+      "url": "https://swingvasion.nz/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:142:2024-03-01",
+      "event_id": 142,
+      "name": "The Chicago Classic",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Chicago",
+      "country": "United States",
+      "continent": "America",
+      "lat": 41.88325,
+      "lon": -87.6323879,
+      "url": "https://thechicagoclassic.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:132:2024-03-01",
+      "event_id": 132,
+      "name": "Tulsa Spring Swing",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Tulsa",
+      "country": "United States",
+      "continent": "America",
+      "lat": 36.1551375,
+      "lon": -95.989501,
+      "url": "http://www.tulsaspringswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:186:2024-03-01",
+      "event_id": 186,
+      "name": "West in Lyon",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Lyon",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 45.764043,
+      "lon": 4.835659,
+      "url": "http://www.west-in-lyon.fr/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:314:2024-03-01",
+      "event_id": 314,
+      "name": "Westie Spring Thing",
+      "start_date": "2024-03-01",
+      "end_date": null,
+      "weekend_start": "2024-02-29",
+      "weekend_end": "2024-03-03",
+      "weekend_key": "2024-02-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Budapest",
+      "country": "Hungary",
+      "continent": "Europe",
+      "lat": 47.497912,
+      "lon": 19.040235,
+      "url": "https://westiespringthing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:218:2024-04-01",
+      "event_id": 218,
+      "name": "Asia West Coast Swing Open",
+      "start_date": "2024-04-01",
+      "end_date": null,
+      "weekend_start": "2024-03-28",
+      "weekend_end": "2024-03-31",
+      "weekend_key": "2024-03-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Singapore",
+      "country": "Singapore",
+      "continent": "Asia",
+      "lat": 1.352083,
+      "lon": 103.819836,
+      "url": "https://asiawcsopen.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:116:2024-04-01",
+      "event_id": 116,
+      "name": "Calgary Dance Stampede",
+      "start_date": "2024-04-01",
+      "end_date": null,
+      "weekend_start": "2024-03-28",
+      "weekend_end": "2024-03-31",
+      "weekend_key": "2024-03-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Calgary",
+      "country": "Canada",
+      "continent": "America",
+      "lat": 51.04473309999999,
+      "lon": -114.0718831,
+      "url": "http://www.calgarydancestampede.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:187:2024-04-01",
+      "event_id": 187,
+      "name": "City of Angels WCS",
+      "start_date": "2024-04-01",
+      "end_date": null,
+      "weekend_start": "2024-03-28",
+      "weekend_end": "2024-03-31",
+      "weekend_key": "2024-03-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Burbank",
+      "country": "United States",
+      "continent": "America",
+      "lat": 34.1820605,
+      "lon": -118.3074827,
+      "url": "https://cityofangelswcs.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:203:2024-04-01",
+      "event_id": 203,
+      "name": "Detonation Dance",
+      "start_date": "2024-04-01",
+      "end_date": null,
+      "weekend_start": "2024-03-28",
+      "weekend_end": "2024-03-31",
+      "weekend_key": "2024-03-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Manchester",
+      "country": "United Kingdom",
+      "continent": "Europe",
+      "lat": 53.4807593,
+      "lon": -2.2426305,
+      "url": "http://www.detonationdance.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:275:2024-04-01",
+      "event_id": 275,
+      "name": "Dutch Open West Coast Swing",
+      "start_date": "2024-04-01",
+      "end_date": null,
+      "weekend_start": "2024-03-28",
+      "weekend_end": "2024-03-31",
+      "weekend_key": "2024-03-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Venray",
+      "country": "Netherlands",
+      "continent": "Europe",
+      "lat": 51.5256257,
+      "lon": 5.9736992,
+      "url": "http://www.dutchopenwcs.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:18:2024-04-01",
+      "event_id": 18,
+      "name": "Easter Swing",
+      "start_date": "2024-04-01",
+      "end_date": null,
+      "weekend_start": "2024-03-28",
+      "weekend_end": "2024-03-31",
+      "weekend_key": "2024-03-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Seattle",
+      "country": "United States",
+      "continent": "America",
+      "lat": 47.6061389,
+      "lon": -122.3328481,
+      "url": "https://easterswing.org/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:345:2024-04-01",
+      "event_id": 345,
+      "name": "HONEY FEST",
+      "start_date": "2024-04-01",
+      "end_date": null,
+      "weekend_start": "2024-03-28",
+      "weekend_end": "2024-03-31",
+      "weekend_key": "2024-03-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Ufa",
+      "country": "Russia",
+      "continent": "Europe",
+      "lat": 54.73479099999999,
+      "lon": 55.9578555,
+      "url": "https://t.me/honeyfest",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:210:2024-04-01",
+      "event_id": 210,
+      "name": "Korean Open WCS Championships",
+      "start_date": "2024-04-01",
+      "end_date": null,
+      "weekend_start": "2024-03-28",
+      "weekend_end": "2024-03-31",
+      "weekend_key": "2024-03-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Incheon",
+      "country": "Republic of Korea",
+      "continent": "Asia",
+      "lat": 37.4751578,
+      "lon": 126.6312666,
+      "url": "https://www.kopenwcs.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:253:2024-04-01",
+      "event_id": 253,
+      "name": "Nordic WCS Championships",
+      "start_date": "2024-04-01",
+      "end_date": null,
+      "weekend_start": "2024-03-28",
+      "weekend_end": "2024-03-31",
+      "weekend_key": "2024-03-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Stockholm",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 59.3251172,
+      "lon": 18.0710935,
+      "url": "http://www.nordicwcschamps.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:259:2024-04-01",
+      "event_id": 259,
+      "name": "Swingover",
+      "start_date": "2024-04-01",
+      "end_date": null,
+      "weekend_start": "2024-03-28",
+      "weekend_end": "2024-03-31",
+      "weekend_key": "2024-03-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Orlando",
+      "country": "United States",
+      "continent": "America",
+      "lat": 28.5383832,
+      "lon": -81.3789269,
+      "url": "http://swingoverevent.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:293:2024-04-01",
+      "event_id": 293,
+      "name": "Westy Nantes",
+      "start_date": "2024-04-01",
+      "end_date": null,
+      "weekend_start": "2024-03-28",
+      "weekend_end": "2024-03-31",
+      "weekend_key": "2024-03-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Nantes",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 47.218371,
+      "lon": -1.553621,
+      "url": "https://www.westynantes.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:105:2024-05-01",
+      "event_id": 105,
+      "name": "Canadian Swing Championships",
+      "start_date": "2024-05-01",
+      "end_date": null,
+      "weekend_start": "2024-04-25",
+      "weekend_end": "2024-04-28",
+      "weekend_key": "2024-04-25",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Montreal",
+      "country": "Canada",
+      "continent": "America",
+      "lat": 45.5018869,
+      "lon": -73.56739189999999,
+      "url": "http://www.canadianswingchampionships.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:175:2024-05-01",
+      "event_id": 175,
+      "name": "French Open West Coast Swing",
+      "start_date": "2024-05-01",
+      "end_date": null,
+      "weekend_start": "2024-04-25",
+      "weekend_end": "2024-04-28",
+      "weekend_key": "2024-04-25",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Paris",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 48.8575475,
+      "lon": 2.3513765,
+      "url": "http://www.fowcs.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:221:2024-05-01",
+      "event_id": 221,
+      "name": "Gateway Swing Classic",
+      "start_date": "2024-05-01",
+      "end_date": null,
+      "weekend_start": "2024-04-25",
+      "weekend_end": "2024-04-28",
+      "weekend_key": "2024-04-25",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "St. Louis",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.62742799999999,
+      "lon": -90.1982439,
+      "url": "http://gatewayswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:205:2024-05-01",
+      "event_id": 205,
+      "name": "SOswing",
+      "start_date": "2024-05-01",
+      "end_date": null,
+      "weekend_start": "2024-04-25",
+      "weekend_end": "2024-04-28",
+      "weekend_key": "2024-04-25",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Ashland",
+      "country": "United States",
+      "continent": "America",
+      "lat": 42.1967113,
+      "lon": -122.7139216,
+      "url": "http://wwww.soswingdance.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:134:2024-05-01",
+      "event_id": 134,
+      "name": "Swing Dance America",
+      "start_date": "2024-05-01",
+      "end_date": null,
+      "weekend_start": "2024-04-25",
+      "weekend_end": "2024-04-28",
+      "weekend_key": "2024-04-25",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Lake Geneva",
+      "country": "United States",
+      "continent": "America",
+      "lat": 42.5916836,
+      "lon": -88.4334301,
+      "url": null,
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:144:2024-05-01",
+      "event_id": 144,
+      "name": "Swingin' Into Spring",
+      "start_date": "2024-05-01",
+      "end_date": null,
+      "weekend_start": "2024-04-25",
+      "weekend_end": "2024-04-28",
+      "weekend_key": "2024-04-25",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Hartford",
+      "country": "United States",
+      "continent": "America",
+      "lat": 41.7658043,
+      "lon": -72.6733723,
+      "url": "http://www.sis.djkenm.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:174:2024-05-01",
+      "event_id": 174,
+      "name": "Swingsation",
+      "start_date": "2024-05-01",
+      "end_date": null,
+      "weekend_start": "2024-04-25",
+      "weekend_end": "2024-04-28",
+      "weekend_key": "2024-04-25",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Gold Coast",
+      "country": "Australia",
+      "continent": "Australia",
+      "lat": -27.9769248,
+      "lon": 153.380936,
+      "url": "https://rawconnection.com.au/swingsation/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:121:2024-05-01",
+      "event_id": 121,
+      "name": "The Texas Classic",
+      "start_date": "2024-05-01",
+      "end_date": null,
+      "weekend_start": "2024-04-25",
+      "weekend_end": "2024-04-28",
+      "weekend_key": "2024-04-25",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Austin",
+      "country": "United States",
+      "continent": "America",
+      "lat": 30.267153,
+      "lon": -97.7430608,
+      "url": "http://Www.thetexasclassic.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:22:2024-05-01",
+      "event_id": 22,
+      "name": "USA Grand Nationals",
+      "start_date": "2024-05-01",
+      "end_date": null,
+      "weekend_start": "2024-04-25",
+      "weekend_end": "2024-04-28",
+      "weekend_key": "2024-04-25",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Atlanta",
+      "country": "United States",
+      "continent": "America",
+      "lat": 33.7501275,
+      "lon": -84.3885209,
+      "url": "http://www.usagrandnationals.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:222:2024-06-01",
+      "event_id": 222,
+      "name": "Baltic Swing",
+      "start_date": "2024-06-01",
+      "end_date": null,
+      "weekend_start": "2024-05-30",
+      "weekend_end": "2024-06-02",
+      "weekend_key": "2024-05-30",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Gdańsk",
+      "country": "Poland",
+      "continent": "Europe",
+      "lat": 54.35202520000001,
+      "lon": 18.6466384,
+      "url": "http://www.balticswing.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:109:2024-06-01",
+      "event_id": 109,
+      "name": "Colorado Country Classic",
+      "start_date": "2024-06-01",
+      "end_date": null,
+      "weekend_start": "2024-05-30",
+      "weekend_end": "2024-06-02",
+      "weekend_key": "2024-05-30",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Denver",
+      "country": "United States",
+      "continent": "America",
+      "lat": 39.7392358,
+      "lon": -104.990251,
+      "url": "https://coloradocountryclassic.net/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:220:2024-06-01",
+      "event_id": 220,
+      "name": "D-Town Swing",
+      "start_date": "2024-06-01",
+      "end_date": null,
+      "weekend_start": "2024-05-30",
+      "weekend_end": "2024-06-02",
+      "weekend_key": "2024-05-30",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Düsseldorf",
+      "country": "Germany",
+      "continent": "Europe",
+      "lat": 51.2230411,
+      "lon": 6.7824545,
+      "url": "http://www.d-townswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:207:2024-06-01",
+      "event_id": 207,
+      "name": "Dance N Play",
+      "start_date": "2024-06-01",
+      "end_date": null,
+      "weekend_start": "2024-05-30",
+      "weekend_end": "2024-06-02",
+      "weekend_key": "2024-05-30",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Bend",
+      "country": "United States",
+      "continent": "America",
+      "lat": 44.0581728,
+      "lon": -121.3153096,
+      "url": "https://dancenplay.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:206:2024-06-01",
+      "event_id": 206,
+      "name": "Hungarian Open",
+      "start_date": "2024-06-01",
+      "end_date": null,
+      "weekend_start": "2024-05-30",
+      "weekend_end": "2024-06-02",
+      "weekend_key": "2024-05-30",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Budapest",
+      "country": "Hungary",
+      "continent": "Europe",
+      "lat": 47.497912,
+      "lon": 19.040235,
+      "url": "http://wcs-ho.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:25:2024-06-01",
+      "event_id": 25,
+      "name": "J&J O'Rama",
+      "start_date": "2024-06-01",
+      "end_date": null,
+      "weekend_start": "2024-05-30",
+      "weekend_end": "2024-06-02",
+      "weekend_key": "2024-05-30",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Anaheim",
+      "country": "United States",
+      "continent": "America",
+      "lat": 33.7742692,
+      "lon": -117.9379952,
+      "url": "https://jackandjillorama.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:96:2024-06-01",
+      "event_id": 96,
+      "name": "Liberty Swing Dance Championships",
+      "start_date": "2024-06-01",
+      "end_date": null,
+      "weekend_start": "2024-05-30",
+      "weekend_end": "2024-06-02",
+      "weekend_key": "2024-05-30",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "New Brunswick",
+      "country": "United States",
+      "continent": "America",
+      "lat": 40.4966567,
+      "lon": -74.4442802,
+      "url": "http://www.libertyswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:76:2024-06-01",
+      "event_id": 76,
+      "name": "Michigan Dance Classic",
+      "start_date": "2024-06-01",
+      "end_date": null,
+      "weekend_start": "2024-05-30",
+      "weekend_end": "2024-06-02",
+      "weekend_key": "2024-05-30",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Detroit",
+      "country": "United States",
+      "continent": "America",
+      "lat": 42.32971819999999,
+      "lon": -83.0424533,
+      "url": "http://michiganclassicswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:117:2024-06-01",
+      "event_id": 117,
+      "name": "Orange Blossom Dance Festival",
+      "start_date": "2024-06-01",
+      "end_date": null,
+      "weekend_start": "2024-05-30",
+      "weekend_end": "2024-06-02",
+      "weekend_key": "2024-05-30",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Orlando",
+      "country": "United States",
+      "continent": "America",
+      "lat": 28.5383832,
+      "lon": -81.3789269,
+      "url": "http://www.orangeblossomdance.net",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:331:2024-06-01",
+      "event_id": 331,
+      "name": "Swing Fiction",
+      "start_date": "2024-06-01",
+      "end_date": null,
+      "weekend_start": "2024-05-30",
+      "weekend_end": "2024-06-02",
+      "weekend_key": "2024-05-30",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Brno",
+      "country": "Czech Republic",
+      "continent": "Europe",
+      "lat": 49.1950602,
+      "lon": 16.6068371,
+      "url": "https://swingfiction.cz/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:162:2024-06-01",
+      "event_id": 162,
+      "name": "Swingapalooza",
+      "start_date": "2024-06-01",
+      "end_date": null,
+      "weekend_start": "2024-05-30",
+      "weekend_end": "2024-06-02",
+      "weekend_key": "2024-05-30",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Baton Rouge",
+      "country": "United States",
+      "continent": "America",
+      "lat": 30.4514677,
+      "lon": -91.1871466,
+      "url": "http://www.swingapaloozaevent.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:1:2024-07-01",
+      "event_id": 1,
+      "name": "4TH of July Convention",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Phoenix",
+      "country": "United States",
+      "continent": "America",
+      "lat": 33.4482948,
+      "lon": -112.0725488,
+      "url": "http://phoenix4thofjuly.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:278:2024-07-01",
+      "event_id": 278,
+      "name": "Americano Dance Camp",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Samara",
+      "country": "Russia",
+      "continent": "Europe",
+      "lat": 53.2226496,
+      "lon": 50.1728035,
+      "url": "https://t.me/americamodancecamp https://vk.com/americano2025",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:156:2024-07-01",
+      "event_id": 156,
+      "name": "Big Apple Dance Festival",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Morristown",
+      "country": "United States",
+      "continent": "America",
+      "lat": 40.7922983,
+      "lon": -74.4763123,
+      "url": "http://bigapplecountrydance.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:148:2024-07-01",
+      "event_id": 148,
+      "name": "Dance Mardi Gras",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "New Orleans",
+      "country": "United States",
+      "continent": "America",
+      "lat": 29.9508941,
+      "lon": -90.0758356,
+      "url": "http://www.dancemardigras.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:149:2024-07-01",
+      "event_id": 149,
+      "name": "Florida Dance Magic",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Fort Lauderdale",
+      "country": "United States",
+      "continent": "America",
+      "lat": 26.1224386,
+      "lon": -80.13731740000001,
+      "url": "https://floridadancemagic.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:224:2024-07-01",
+      "event_id": 224,
+      "name": "Midwest Westie Fest",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Overland Park",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.9822282,
+      "lon": -94.6707917,
+      "url": "http://www.midwestwestiefest.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:261:2024-07-01",
+      "event_id": 261,
+      "name": "Neverland Swing",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Amsterdam",
+      "country": "Netherlands",
+      "continent": "Europe",
+      "lat": 52.3675734,
+      "lon": 4.9041389,
+      "url": "http://www.neverlandswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:303:2024-07-01",
+      "event_id": 303,
+      "name": "Odyssey West Coast Swing",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Gold Coast",
+      "country": "Australia",
+      "continent": "Australia",
+      "lat": -27.9769248,
+      "lon": 153.380936,
+      "url": "http://www.odysseywcs.dance",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:263:2024-07-01",
+      "event_id": 263,
+      "name": "Riga Summer Swing",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Riga",
+      "country": "Latvia",
+      "continent": "Europe",
+      "lat": 56.9676941,
+      "lon": 24.1056221,
+      "url": null,
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:256:2024-07-01",
+      "event_id": 256,
+      "name": "Rock the Barn",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Umeå",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 63.5391027,
+      "lon": 19.4528047,
+      "url": "http://rockthebarn.se",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:280:2024-07-01",
+      "event_id": 280,
+      "name": "Saint Petersburg WCS Nights",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "St. Petersburg",
+      "country": "Russia",
+      "continent": "Europe",
+      "lat": 59.9310584,
+      "lon": 30.3609097,
+      "url": "http://wcsnights.ru",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:147:2024-07-01",
+      "event_id": 147,
+      "name": "Toronto Open Swing & Hustle Championships",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Toronto",
+      "country": "Canada",
+      "continent": "America",
+      "lat": 43.653226,
+      "lon": -79.3831843,
+      "url": "http://www.TOSHC.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:225:2024-07-01",
+      "event_id": 225,
+      "name": "Wild Wild Westie",
+      "start_date": "2024-07-01",
+      "end_date": null,
+      "weekend_start": "2024-06-27",
+      "weekend_end": "2024-06-30",
+      "weekend_key": "2024-06-27",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Dallas",
+      "country": "United States",
+      "continent": "America",
+      "lat": 32.7831,
+      "lon": -96.8067,
+      "url": "http://www.WildWildWestie.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:77:2024-08-01",
+      "event_id": 77,
+      "name": "Arizona Dance Classic",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Phoenix",
+      "country": "United States",
+      "continent": "America",
+      "lat": 33.4482948,
+      "lon": -112.0725488,
+      "url": "https://arizonadanceclassic.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:339:2024-08-01",
+      "event_id": 339,
+      "name": "Bristol Swing Fiesta",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Bristol",
+      "country": "United Kingdom",
+      "continent": "Europe",
+      "lat": 51.454513,
+      "lon": -2.58791,
+      "url": "https://www.bristolcityswing.com/bsf",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:119:2024-08-01",
+      "event_id": 119,
+      "name": "Chicagoland Country and Swing Dance Festival",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Chicago",
+      "country": "United States",
+      "continent": "America",
+      "lat": 41.88325,
+      "lon": -87.6323879,
+      "url": "http://www.chicagolanddancefestival.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:282:2024-08-01",
+      "event_id": 282,
+      "name": "German Open",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Freiburg",
+      "country": "Germany",
+      "continent": "Europe",
+      "lat": 47.9990077,
+      "lon": 7.842104299999999,
+      "url": "http://www.go-wcs.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:120:2024-08-01",
+      "event_id": 120,
+      "name": "Lone Star Invitational",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Austin",
+      "country": "United States",
+      "continent": "America",
+      "lat": 30.267153,
+      "lon": -97.7430608,
+      "url": null,
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:157:2024-08-01",
+      "event_id": 157,
+      "name": "New England Dance Festival",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Boston",
+      "country": "United States",
+      "continent": "America",
+      "lat": 42.3555076,
+      "lon": -71.0565364,
+      "url": "http://www.nedancefestival.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:164:2024-08-01",
+      "event_id": 164,
+      "name": "Sea Sun and Swing",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "La Grande Motte",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 43.560704,
+      "lon": 4.086072000000001,
+      "url": "https://www.seasunswing.fr/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:298:2024-08-01",
+      "event_id": 298,
+      "name": "Shakedown Swing",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Christchurch",
+      "country": "New Zealand",
+      "continent": "Australia",
+      "lat": -43.5320301,
+      "lon": 172.636648,
+      "url": "http://www.code03swing.com/shakedown",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:53:2024-08-01",
+      "event_id": 53,
+      "name": "Summer Hummer",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Boston",
+      "country": "United States",
+      "continent": "America",
+      "lat": 42.3555076,
+      "lon": -71.0565364,
+      "url": "http://summerhummerboston.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:264:2024-08-01",
+      "event_id": 264,
+      "name": "Swedish Swing Summer Camp",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Stockholm",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 59.3251172,
+      "lon": 18.0710935,
+      "url": "http://www.uptownswing.se/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:59:2024-08-01",
+      "event_id": 59,
+      "name": "Swing Fling",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Herndon",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.9695545,
+      "lon": -77.3860976,
+      "url": "http://www.swingfling.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:227:2024-08-01",
+      "event_id": 227,
+      "name": "Swingtacular: The Galactic Open",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "San Francisco",
+      "country": "United States",
+      "continent": "America",
+      "lat": 37.7749295,
+      "lon": -122.4194155,
+      "url": "http://www.dancegeekproductions.art/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:47:2024-08-01",
+      "event_id": 47,
+      "name": "Swingtime in the Rockies",
+      "start_date": "2024-08-01",
+      "end_date": null,
+      "weekend_start": "2024-08-01",
+      "weekend_end": "2024-08-04",
+      "weekend_key": "2024-08-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Denver",
+      "country": "United States",
+      "continent": "America",
+      "lat": 39.7392358,
+      "lon": -104.990251,
+      "url": "http://www.swingtimewcs.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:300:2024-09-01",
+      "event_id": 300,
+      "name": "Austin Rocks",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Austin",
+      "country": "United States",
+      "continent": "America",
+      "lat": 30.267153,
+      "lon": -97.7430608,
+      "url": "https://atxrox.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:233:2024-09-01",
+      "event_id": 233,
+      "name": "Bavarian Open",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Munich",
+      "country": "Germany",
+      "continent": "Europe",
+      "lat": 48.1351253,
+      "lon": 11.5819806,
+      "url": "https://bavarianopen.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:167:2024-09-01",
+      "event_id": 167,
+      "name": "Best of the Best WCS",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Sydney",
+      "country": "Australia",
+      "continent": "Australia",
+      "lat": -33.8727409,
+      "lon": 151.2057136,
+      "url": "https://www.bestofthebestwcs.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:135:2024-09-01",
+      "event_id": 135,
+      "name": "Desert City Swing",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Phoenix",
+      "country": "United States",
+      "continent": "America",
+      "lat": 33.4482948,
+      "lon": -112.0725488,
+      "url": "http://www.desertcityswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:254:2024-09-01",
+      "event_id": 254,
+      "name": "Finnfest",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Helsinki",
+      "country": "Finland",
+      "continent": "Europe",
+      "lat": 60.16985569999999,
+      "lon": 24.938379,
+      "url": "http://www.finnfest.fi/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:268:2024-09-01",
+      "event_id": 268,
+      "name": "Korea Westival",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Brno",
+      "country": "Czech Republic",
+      "continent": "Europe",
+      "lat": 49.1950602,
+      "lon": 16.6068371,
+      "url": "http://koreawestival.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:131:2024-09-01",
+      "event_id": 131,
+      "name": "Meet Me In St Louis",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "St. Louis",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.62742799999999,
+      "lon": -90.1982439,
+      "url": "http://www.mmisl.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:165:2024-09-01",
+      "event_id": 165,
+      "name": "Midland Swing Open",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "London",
+      "country": "United Kingdom",
+      "continent": "Europe",
+      "lat": 51.5072178,
+      "lon": -0.1275862,
+      "url": "http://www.midlandswingopen.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:234:2024-09-01",
+      "event_id": 234,
+      "name": "Philly Swing Classic",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Wilmington",
+      "country": "United States",
+      "continent": "America",
+      "lat": 39.744655,
+      "lon": -75.5483909,
+      "url": "http://www.phillyswing.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:177:2024-09-01",
+      "event_id": 177,
+      "name": "River City Swing",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Jacksonville",
+      "country": "United States",
+      "continent": "America",
+      "lat": 30.3297566,
+      "lon": -81.6591529,
+      "url": "http://www.jaxwestiefest.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:313:2024-09-01",
+      "event_id": 313,
+      "name": "Rolling Swing",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Lyon",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 45.764043,
+      "lon": 4.835659,
+      "url": "http://www.frenchywesty.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:338:2024-09-01",
+      "event_id": 338,
+      "name": "Sea Dance Fest",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Moscow",
+      "country": "Russia",
+      "continent": "Europe",
+      "lat": 55.7568721,
+      "lon": 37.6150527,
+      "url": "https://vk.com/seadancefest",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:48:2024-09-01",
+      "event_id": 48,
+      "name": "South Bay Dance Fling",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "San Jose",
+      "country": "United States",
+      "continent": "America",
+      "lat": 37.33874,
+      "lon": -121.8852525,
+      "url": "https://sbdf.dance/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:231:2024-09-01",
+      "event_id": 231,
+      "name": "Trilogy Swing",
+      "start_date": "2024-09-01",
+      "end_date": null,
+      "weekend_start": "2024-08-29",
+      "weekend_end": "2024-09-01",
+      "weekend_key": "2024-08-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Raleigh",
+      "country": "United States",
+      "continent": "America",
+      "lat": 35.7795897,
+      "lon": -78.6381787,
+      "url": "https://trilogywcs.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:211:2024-10-01",
+      "event_id": 211,
+      "name": "Atlanta Swing Classic",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Atlanta",
+      "country": "United States",
+      "continent": "America",
+      "lat": 33.7501275,
+      "lon": -84.3885209,
+      "url": "https://www.atlantaswingclassic.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:350:2024-10-01",
+      "event_id": 350,
+      "name": "Augsburg Westie Station",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Augsburg",
+      "country": "Germany",
+      "continent": "Europe",
+      "lat": 48.3705449,
+      "lon": 10.89779,
+      "url": "https://www.augsburgwestiestation.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:8:2024-10-01",
+      "event_id": 8,
+      "name": "Boogie By The Bay",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "San Francisco",
+      "country": "United States",
+      "continent": "America",
+      "lat": 37.7749295,
+      "lon": -122.4194155,
+      "url": "https://boogiebythebay.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:367:2024-10-01",
+      "event_id": 367,
+      "name": "Go West SwingFest",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Perth",
+      "country": "Australia",
+      "continent": "Australia",
+      "lat": -31.9513993,
+      "lon": 115.8616783,
+      "url": "https://www.gowestdancefest.com/go-west-swingfest",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:65:2024-10-01",
+      "event_id": 65,
+      "name": "Halloween SwingThing",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Costa Mesa",
+      "country": "United States",
+      "continent": "America",
+      "lat": 33.6638439,
+      "lon": -117.9047429,
+      "url": "http://hstswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:322:2024-10-01",
+      "event_id": 322,
+      "name": "Milan Modern Swing",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Milan",
+      "country": "Italy",
+      "continent": "Europe",
+      "lat": 45.468503,
+      "lon": 9.1824027,
+      "url": "https://www.westcoastswingmilan.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:178:2024-10-01",
+      "event_id": 178,
+      "name": "Montreal Westie Fest",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "New York",
+      "country": "United States",
+      "continent": "America",
+      "lat": 40.7127753,
+      "lon": -74.0059728,
+      "url": "http://montrealwestiefest.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:43:2024-10-01",
+      "event_id": 43,
+      "name": "Paradise Dance Festival",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Irvine",
+      "country": "United States",
+      "continent": "America",
+      "lat": 33.6845673,
+      "lon": -117.8265049,
+      "url": "https://paradisecountrydancefestival.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:125:2024-10-01",
+      "event_id": 125,
+      "name": "Swing City Chicago",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Chicago",
+      "country": "United States",
+      "continent": "America",
+      "lat": 41.88325,
+      "lon": -87.6323879,
+      "url": "https://swingcitychicago.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:346:2024-10-01",
+      "event_id": 346,
+      "name": "Swingside Invitational",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Liège",
+      "country": "Belgium",
+      "continent": "Europe",
+      "lat": 50.6402286,
+      "lon": 5.5689372,
+      "url": "http://www.swingside-invitational.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:267:2024-10-01",
+      "event_id": 267,
+      "name": "Swustlicious",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Philadelphia",
+      "country": "United States",
+      "continent": "America",
+      "lat": 39.9525839,
+      "lon": -75.1652215,
+      "url": "http://www.swustlicious.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:286:2024-10-01",
+      "event_id": 286,
+      "name": "WCS Festival",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Düsseldorf",
+      "country": "Germany",
+      "continent": "Europe",
+      "lat": 51.2230411,
+      "lon": 6.7824545,
+      "url": "http://www.wcsfestival.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:236:2024-10-01",
+      "event_id": 236,
+      "name": "Warsaw Halloween Swing",
+      "start_date": "2024-10-01",
+      "end_date": null,
+      "weekend_start": "2024-09-26",
+      "weekend_end": "2024-09-29",
+      "weekend_key": "2024-09-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Warsaw",
+      "country": "Poland",
+      "continent": "Europe",
+      "lat": 52.2296756,
+      "lon": 21.0122287,
+      "url": "http://www.warsawhalloweenswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:269:2024-11-01",
+      "event_id": 269,
+      "name": "Autumn Swing Challenge",
+      "start_date": "2024-11-01",
+      "end_date": null,
+      "weekend_start": "2024-10-31",
+      "weekend_end": "2024-11-03",
+      "weekend_key": "2024-10-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Budapest",
+      "country": "Hungary",
+      "continent": "Europe",
+      "lat": 47.497912,
+      "lon": 19.040235,
+      "url": "http://www.asc-budapest.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:181:2024-11-01",
+      "event_id": 181,
+      "name": "DC Swing eXperience (DCSX)",
+      "start_date": "2024-11-01",
+      "end_date": null,
+      "weekend_start": "2024-10-31",
+      "weekend_end": "2024-11-03",
+      "weekend_key": "2024-10-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Herndon",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.9695545,
+      "lon": -77.3860976,
+      "url": "http://www.dcswingexperience.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:288:2024-11-01",
+      "event_id": 288,
+      "name": "Midnight Madness",
+      "start_date": "2024-11-01",
+      "end_date": null,
+      "weekend_start": "2024-10-31",
+      "weekend_end": "2024-11-03",
+      "weekend_key": "2024-10-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Dallas",
+      "country": "United States",
+      "continent": "America",
+      "lat": 32.7831,
+      "lon": -96.8067,
+      "url": "http://www.midnightmadnesswcs.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:31:2024-11-01",
+      "event_id": 31,
+      "name": "Mountain Magic",
+      "start_date": "2024-11-01",
+      "end_date": null,
+      "weekend_start": "2024-10-31",
+      "weekend_end": "2024-11-03",
+      "weekend_key": "2024-10-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "South Lake Tahoe (near Reno)",
+      "country": "United States",
+      "continent": "America",
+      "lat": 39.5056072,
+      "lon": -119.7788687,
+      "url": "http://mountainmagic.dance/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:179:2024-11-01",
+      "event_id": 179,
+      "name": "New Zealand Open Swing Dance Championships",
+      "start_date": "2024-11-01",
+      "end_date": null,
+      "weekend_start": "2024-10-31",
+      "weekend_end": "2024-11-03",
+      "weekend_key": "2024-10-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Auckland",
+      "country": "New Zealand",
+      "continent": "Australia",
+      "lat": -36.85088270000001,
+      "lon": 174.7644881,
+      "url": "https://www.streetswing.co.nz/the-new-zealand-open",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:229:2024-11-01",
+      "event_id": 229,
+      "name": "Scandinavian Open",
+      "start_date": "2024-11-01",
+      "end_date": null,
+      "weekend_start": "2024-10-31",
+      "weekend_end": "2024-11-03",
+      "weekend_key": "2024-10-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Stockholm",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 59.3251172,
+      "lon": 18.0710935,
+      "url": "http://www.snowcs.se/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:79:2024-11-01",
+      "event_id": 79,
+      "name": "Sea to Sky",
+      "start_date": "2024-11-01",
+      "end_date": null,
+      "weekend_start": "2024-10-31",
+      "weekend_end": "2024-11-03",
+      "weekend_key": "2024-10-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Seattle",
+      "country": "United States",
+      "continent": "America",
+      "lat": 47.6061389,
+      "lon": -122.3328481,
+      "url": "http://Seatoskywcs.com",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:330:2024-11-01",
+      "event_id": 330,
+      "name": "Simply Adelaide West Coast Swing",
+      "start_date": "2024-11-01",
+      "end_date": null,
+      "weekend_start": "2024-10-31",
+      "weekend_end": "2024-11-03",
+      "weekend_key": "2024-10-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Adelaide",
+      "country": "Australia",
+      "continent": "Australia",
+      "lat": -34.9284989,
+      "lon": 138.6007456,
+      "url": "http://www.simplyadelaidewcs.com.au/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:340:2024-11-01",
+      "event_id": 340,
+      "name": "Spooky Westie Weekend",
+      "start_date": "2024-11-01",
+      "end_date": null,
+      "weekend_start": "2024-10-31",
+      "weekend_end": "2024-11-03",
+      "weekend_key": "2024-10-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Singapore",
+      "country": "Singapore",
+      "continent": "Asia",
+      "lat": 1.352083,
+      "lon": 103.819836,
+      "url": "https://spookywestieweekend.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:312:2024-11-01",
+      "event_id": 312,
+      "name": "Westie Pink City",
+      "start_date": "2024-11-01",
+      "end_date": null,
+      "weekend_start": "2024-10-31",
+      "weekend_end": "2024-11-03",
+      "weekend_key": "2024-10-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Toulouse",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 43.6048462,
+      "lon": 1.442848,
+      "url": "http://www.westiepinkcity.fr/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:270:2024-11-01",
+      "event_id": 270,
+      "name": "Westie's Angels",
+      "start_date": "2024-11-01",
+      "end_date": null,
+      "weekend_start": "2024-10-31",
+      "weekend_end": "2024-11-03",
+      "weekend_key": "2024-10-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Lyon",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 45.764043,
+      "lon": 4.835659,
+      "url": "http://www.frenchywesty.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:323:2024-11-01",
+      "event_id": 323,
+      "name": "Westies on the Water",
+      "start_date": "2024-11-01",
+      "end_date": null,
+      "weekend_start": "2024-10-31",
+      "weekend_end": "2024-11-03",
+      "weekend_key": "2024-10-31",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Huntsville",
+      "country": "United States",
+      "continent": "America",
+      "lat": 34.7295497,
+      "lon": -86.5853155,
+      "url": "http://rocketcityswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:271:2024-12-01",
+      "event_id": 271,
+      "name": "Berlin Swing Revolution",
+      "start_date": "2024-12-01",
+      "end_date": null,
+      "weekend_start": "2024-11-28",
+      "weekend_end": "2024-12-01",
+      "weekend_key": "2024-11-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Berlin",
+      "country": "Germany",
+      "continent": "Europe",
+      "lat": 52.52000659999999,
+      "lon": 13.404954,
+      "url": "https://berlinswingrevolution.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:87:2024-12-01",
+      "event_id": 87,
+      "name": "CASH Bash",
+      "start_date": "2024-12-01",
+      "end_date": null,
+      "weekend_start": "2024-11-28",
+      "weekend_end": "2024-12-01",
+      "weekend_key": "2024-11-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Cleveland",
+      "country": "United States",
+      "continent": "America",
+      "lat": 41.49932,
+      "lon": -81.6943605,
+      "url": "https://cashdanceclub.org/cash-bash/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:342:2024-12-01",
+      "event_id": 342,
+      "name": "Global Grand Prix - West Coast Swing Reunion",
+      "start_date": "2024-12-01",
+      "end_date": null,
+      "weekend_start": "2024-11-28",
+      "weekend_end": "2024-12-01",
+      "weekend_key": "2024-11-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Toulouse",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 43.6048462,
+      "lon": 1.442848,
+      "url": "https://www.globalgrandprixwcs.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:290:2024-12-01",
+      "event_id": 290,
+      "name": "Shooba Dooba Swing",
+      "start_date": "2024-12-01",
+      "end_date": null,
+      "weekend_start": "2024-11-28",
+      "weekend_end": "2024-12-01",
+      "weekend_key": "2024-11-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Moscow",
+      "country": "Russia",
+      "continent": "Europe",
+      "lat": 55.7568721,
+      "lon": 37.6150527,
+      "url": "https://danceconvention.net/eventdirector/ru/eventpage/6023470-shooba-dooba-swing-2020/info",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:212:2024-12-01",
+      "event_id": 212,
+      "name": "The After Party (TAP)",
+      "start_date": "2024-12-01",
+      "end_date": null,
+      "weekend_start": "2024-11-28",
+      "weekend_end": "2024-12-01",
+      "weekend_key": "2024-11-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Orange County",
+      "country": "United States",
+      "continent": "America",
+      "lat": 33.7174708,
+      "lon": -117.8311428,
+      "url": "http://www.tapwcs.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:68:2024-12-01",
+      "event_id": 68,
+      "name": "US Open Swing Dance Championships",
+      "start_date": "2024-12-01",
+      "end_date": null,
+      "weekend_start": "2024-11-28",
+      "weekend_end": "2024-12-01",
+      "weekend_key": "2024-11-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Los Angeles",
+      "country": "United States",
+      "continent": "America",
+      "lat": 34.0549076,
+      "lon": -118.242643,
+      "url": "http://www.theopenswing.com/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:238:2024-12-01",
+      "event_id": 238,
+      "name": "Winter White",
+      "start_date": "2024-12-01",
+      "end_date": null,
+      "weekend_start": "2024-11-28",
+      "weekend_end": "2024-12-01",
+      "weekend_key": "2024-11-28",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Oslo",
+      "country": "Norway",
+      "continent": "Europe",
+      "lat": 59.9121746,
+      "lon": 10.7312704,
+      "url": "http://www.winterwhite.no/",
+      "year": 2024,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
+    },
+    {
+      "id": "confirmed:42:2024-12-27",
+      "event_id": 42,
+      "name": "Floorplay Swing Vacation",
+      "start_date": "2024-12-27",
+      "end_date": "2025-01-01",
+      "weekend_start": "2024-12-26",
+      "weekend_end": "2024-12-29",
+      "weekend_key": "2024-12-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Orlando",
+      "country": "United States",
+      "continent": "America",
+      "lat": 28.5383832,
+      "lon": -81.3789269,
+      "url": "http://www.floorplayswingvacation.com",
+      "year": 2025,
+      "source": "edition_calendar_dates",
+      "has_results": true
+    },
+    {
+      "id": "confirmed:141:2024-12-28",
+      "event_id": 141,
+      "name": "Spotlight New Year's Celebration",
+      "start_date": "2024-12-28",
+      "end_date": "2025-01-01",
+      "weekend_start": "2024-12-26",
+      "weekend_end": "2024-12-29",
+      "weekend_key": "2024-12-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Nashville",
+      "country": "United States",
+      "continent": "America",
+      "lat": 36.1626638,
+      "lon": -86.7816016,
+      "url": "http://www.spotlightnewyears.com",
+      "year": 2025,
+      "source": "edition_calendar_dates",
+      "has_results": true
+    },
+    {
+      "id": "confirmed:289:2024-12-28",
+      "event_id": 289,
+      "name": "SwingVester",
+      "start_date": "2024-12-28",
+      "end_date": "2025-01-02",
+      "weekend_start": "2024-12-26",
+      "weekend_end": "2024-12-29",
+      "weekend_key": "2024-12-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Wels",
+      "country": "Austria",
+      "continent": "Europe",
+      "lat": 48.1664268,
+      "lon": 14.0388714,
+      "url": "http://www.swingvester.com",
+      "year": 2025,
+      "source": "edition_calendar_dates",
+      "has_results": true
+    },
+    {
+      "id": "confirmed:240:2024-12-28",
+      "event_id": 240,
+      "name": "Westie Gala",
+      "start_date": "2024-12-28",
+      "end_date": "2025-01-01",
+      "weekend_start": "2024-12-26",
+      "weekend_end": "2024-12-29",
+      "weekend_key": "2024-12-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Stockholm",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 59.3251172,
+      "lon": 18.0710935,
+      "url": "http://www.westiegala.com",
+      "year": 2025,
+      "source": "edition_calendar_dates",
+      "has_results": true
+    },
+    {
+      "id": "confirmed:75:2024-12-29",
+      "event_id": 75,
+      "name": "UCWDC Country Dance World Championship",
+      "start_date": "2024-12-29",
+      "end_date": "2025-01-05",
+      "weekend_start": "2024-12-26",
+      "weekend_end": "2024-12-29",
+      "weekend_key": "2024-12-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Dallas",
+      "country": "United States",
+      "continent": "America",
+      "lat": 32.7831,
+      "lon": -96.8067,
+      "url": "https://ucwdc.org/worlds-home/",
+      "year": 2025,
+      "source": "edition_calendar_dates",
+      "has_results": true
+    },
+    {
+      "id": "confirmed:334:2024-12-31",
+      "event_id": 334,
+      "name": "Countdown Swing Boston",
+      "start_date": "2024-12-31",
+      "end_date": "2025-01-05",
+      "weekend_start": "2024-12-26",
+      "weekend_end": "2024-12-29",
+      "weekend_key": "2024-12-26",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Boston",
+      "country": "United States",
+      "continent": "America",
+      "lat": 42.3555076,
+      "lon": -71.0565364,
+      "url": "http://Countdownswingboston.com",
+      "year": 2025,
+      "source": "edition_calendar_dates",
+      "has_results": true
+    },
     {
       "id": "confirmed:196:2025-01-02",
       "event_id": 196,
@@ -50,7 +3236,8 @@
       "lon": -122.6783853,
       "url": "http://www.swingcouver.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:184:2025-01-07",
@@ -70,7 +3257,8 @@
       "lon": 19.040235,
       "url": "http://wcs-budafest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:62:2025-01-14",
@@ -90,7 +3278,8 @@
       "lon": -121.8977688,
       "url": "http://Montereyswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:200:2025-01-16",
@@ -110,7 +3299,8 @@
       "lon": -97.7430608,
       "url": "https://austinswingdance.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:309:2025-01-17",
@@ -130,7 +3320,8 @@
       "lon": 4.359999699999999,
       "url": "http://Www.avignoncityswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:381:2025-01-17",
@@ -150,7 +3341,8 @@
       "lon": 151.2057136,
       "url": "http://www.dancewcsa.com.au",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:242:2025-01-23",
@@ -170,7 +3362,8 @@
       "lon": -85.7663724,
       "url": "https://derbycityswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:301:2025-01-23",
@@ -190,7 +3383,8 @@
       "lon": -3.188267,
       "url": "http://www.swingresolution.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:183:2025-01-24",
@@ -210,7 +3404,8 @@
       "lon": -75.5483909,
       "url": "https://freedomswingdance.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:215:2025-01-29",
@@ -230,7 +3425,8 @@
       "lon": 30.3609097,
       "url": "http://swingandsnow.ru",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:273:2025-01-30",
@@ -250,7 +3446,8 @@
       "lon": -80.84089329999999,
       "url": "https://www.charlottewestiefest.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:272:2025-01-30",
@@ -270,7 +3467,8 @@
       "lon": 2.3513765,
       "url": "https://www.parisswingclassic.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:258:2025-02-06",
@@ -290,7 +3488,8 @@
       "lon": 8.541694,
       "url": "https://swingtzerland.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:363:2025-02-07",
@@ -310,7 +3509,8 @@
       "lon": -6.388300099999999,
       "url": "https://trinityswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:302:2025-02-07",
@@ -330,7 +3530,8 @@
       "lon": 115.8616783,
       "url": "https://www.magneticdance.com.au/westeroz",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:12:2025-02-13",
@@ -350,7 +3551,8 @@
       "lon": -121.4944209,
       "url": "http://www.CapitalSwingConvention.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:310:2025-02-14",
@@ -370,7 +3572,8 @@
       "lon": 18.0710935,
       "url": "http://www.valentineswing.dance",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:344:2025-02-20",
@@ -390,7 +3593,8 @@
       "lon": -8.8252502,
       "url": "http://arousawestiefest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:244:2025-02-20",
@@ -410,7 +3614,8 @@
       "lon": -122.6783853,
       "url": "https://rosecityswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:343:2025-02-20",
@@ -430,7 +3635,8 @@
       "lon": -98.4945922,
       "url": "https://swingcrush.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:297:2025-02-20",
@@ -450,7 +3656,8 @@
       "lon": 27.7880116,
       "url": "https://www.wintercoastswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:92:2025-02-27",
@@ -490,7 +3697,8 @@
       "lon": 7.725619099999999,
       "url": "https://www.euro-dance-festival.com/rust/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:143:2025-03-07",
@@ -510,7 +3718,8 @@
       "lon": -118.1481016,
       "url": "http://www.highdesertdanceclassic.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:333:2025-03-07",
@@ -530,7 +3739,8 @@
       "lon": 174.7787463,
       "url": "https://swingcentral.nz/swingvasion",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:318:2025-03-13",
@@ -570,7 +3780,8 @@
       "lon": 5.9736992,
       "url": "https://www.dutchopenwcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:142:2025-03-13",
@@ -590,7 +3801,8 @@
       "lon": -87.6323879,
       "url": "http://www.thechicagoclassic.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:186:2025-03-13",
@@ -610,7 +3822,8 @@
       "lon": 4.835659,
       "url": "http://www.west-in-lyon.fr",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:314:2025-03-13",
@@ -630,7 +3843,8 @@
       "lon": 19.040235,
       "url": "https://westiespringthing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:197:2025-03-20",
@@ -650,7 +3864,8 @@
       "lon": -104.990251,
       "url": "https://www.5280westival.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:9:2025-03-20",
@@ -670,7 +3885,8 @@
       "lon": -71.0565364,
       "url": "http://teapartyswings.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:292:2025-03-20",
@@ -690,7 +3906,8 @@
       "lon": 19.9449799,
       "url": "http://kingswing.pl",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:153:2025-03-20",
@@ -710,7 +3927,8 @@
       "lon": -95.3701108,
       "url": "http://Novice-invitational.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:324:2025-03-27",
@@ -730,7 +3948,8 @@
       "lon": -114.0718831,
       "url": "http://Btoopen.ca",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:154:2025-03-27",
@@ -750,7 +3969,8 @@
       "lon": -0.1275862,
       "url": "http://www.ukwcschamps.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:293:2025-04-04",
@@ -770,7 +3990,8 @@
       "lon": -1.553621,
       "url": "https://www.westynantes.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:116:2025-04-10",
@@ -790,7 +4011,8 @@
       "lon": -114.0718831,
       "url": "http://www.calgarydancestampede.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:187:2025-04-10",
@@ -810,7 +4032,8 @@
       "lon": -118.3074827,
       "url": "https://cityofangelswcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:210:2025-04-10",
@@ -830,7 +4053,8 @@
       "lon": 126.6312666,
       "url": "https://www.kopenwcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:352:2025-04-10",
@@ -850,7 +4074,8 @@
       "lon": 14.5057515,
       "url": "https://www.slovenianopen.dance",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:218:2025-04-17",
@@ -870,7 +4095,8 @@
       "lon": 103.819836,
       "url": "https://www.asiawcsopen.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:18:2025-04-17",
@@ -890,7 +4116,8 @@
       "lon": -122.3328481,
       "url": "https://www.easterswing.org/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:132:2025-04-18",
@@ -910,7 +4137,8 @@
       "lon": -95.989501,
       "url": "http://www.TulsaSpringSwing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:370:2025-04-23",
@@ -930,7 +4158,8 @@
       "lon": 7.0982068,
       "url": "http://www.tanzhaus-bonn.de/swingin-festival",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:203:2025-04-24",
@@ -950,7 +4179,8 @@
       "lon": -2.2426305,
       "url": "http://www.DetonationDance.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:345:2025-04-24",
@@ -970,7 +4200,8 @@
       "lon": 55.9578555,
       "url": "https://honeyfest-ufa.ru/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:259:2025-04-24",
@@ -990,7 +4221,8 @@
       "lon": -81.3789269,
       "url": "http://www.swingoverevent.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:354:2025-04-30",
@@ -1010,7 +4242,8 @@
       "lon": 7.842104299999999,
       "url": "https://springtimeswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:347:2025-05-01",
@@ -1030,7 +4263,30 @@
       "lon": -3.7032905,
       "url": "https://beemadwcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
+    },
+    {
+      "id": "confirmed:221:2025-05-01",
+      "event_id": 221,
+      "name": "Gateway Swing Classic",
+      "start_date": "2025-05-01",
+      "end_date": null,
+      "weekend_start": "2025-05-01",
+      "weekend_end": "2025-05-04",
+      "weekend_key": "2025-05-01",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "St. Louis",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.62742799999999,
+      "lon": -90.1982439,
+      "url": "http://gatewayswing.com/",
+      "year": 2025,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
     },
     {
       "id": "confirmed:253:2025-05-01",
@@ -1050,7 +4306,8 @@
       "lon": 18.0710935,
       "url": "http://www.nordicwcschamps.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "cancelled:134:2025-05-01",
@@ -1090,7 +4347,8 @@
       "lon": -72.6733723,
       "url": "http://www.sis.djkenm.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:379:2025-05-08",
@@ -1110,7 +4368,8 @@
       "lon": 6.2355346,
       "url": "http://www.medinswing.rocks",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:336:2025-05-08",
@@ -1130,7 +4389,8 @@
       "lon": 14.0388714,
       "url": "https://www.swingofmusic.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:174:2025-05-09",
@@ -1150,7 +4410,8 @@
       "lon": 153.380936,
       "url": "https://rawconnection.com.au/swingsation/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:205:2025-05-15",
@@ -1170,7 +4431,8 @@
       "lon": -122.7139216,
       "url": "http://soswingdance.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:551:2025-05-15",
@@ -1210,7 +4472,8 @@
       "lon": -73.56739189999999,
       "url": "http://canadianswingchampionships.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:372:2025-05-16",
@@ -1230,7 +4493,8 @@
       "lon": -77.026088,
       "url": "http://www.dancejamproductions.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:121:2025-05-16",
@@ -1250,7 +4514,8 @@
       "lon": -97.7430608,
       "url": "http://www.thetexasclassic.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:22:2025-05-22",
@@ -1270,7 +4535,8 @@
       "lon": -84.3885209,
       "url": "http://www.usagrandnationals.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:364:2025-05-23",
@@ -1290,7 +4556,8 @@
       "lon": -123.9400647,
       "url": "http://www.nanaimodancefusion.ca",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:175:2025-05-28",
@@ -1310,7 +4577,8 @@
       "lon": 2.3513765,
       "url": "http://www.fowcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:76:2025-05-29",
@@ -1330,7 +4598,8 @@
       "lon": -83.0424533,
       "url": "http://www.michiganclassicswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:371:2025-05-30",
@@ -1350,7 +4619,8 @@
       "lon": -1.61778,
       "url": "https://festivalcityswing.co.uk/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:206:2025-05-30",
@@ -1370,7 +4640,8 @@
       "lon": 19.040235,
       "url": "http://wcs-ho.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:368:2025-05-30",
@@ -1390,7 +4661,30 @@
       "lon": 11.97456,
       "url": "http://www.next-level.dance",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
+    },
+    {
+      "id": "confirmed:255:2025-06-01",
+      "event_id": 255,
+      "name": "Indy Dance Explosion",
+      "start_date": "2025-06-01",
+      "end_date": null,
+      "weekend_start": "2025-05-29",
+      "weekend_end": "2025-06-01",
+      "weekend_key": "2025-05-29",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Fort Wayne",
+      "country": "United States",
+      "continent": "America",
+      "lat": 41.0794759,
+      "lon": -85.1362929,
+      "url": "http://www.indydancex.com",
+      "year": 2025,
+      "source": "event_editions_month_only",
+      "stats_only": true,
+      "has_results": true
     },
     {
       "id": "confirmed:222:2025-06-05",
@@ -1410,7 +4704,8 @@
       "lon": 18.6466384,
       "url": "http://www.balticswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:25:2025-06-05",
@@ -1430,7 +4725,8 @@
       "lon": -117.9379952,
       "url": "https://jackandjillorama.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:117:2025-06-05",
@@ -1450,7 +4746,8 @@
       "lon": -81.3789269,
       "url": "http://www.orangeblossomdance.net",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:220:2025-06-12",
@@ -1470,7 +4767,8 @@
       "lon": 6.7824545,
       "url": "http://www.d-townsing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:374:2025-06-19",
@@ -1490,7 +4788,8 @@
       "lon": 9.1942834,
       "url": "https://lb-barockswing.com/index.php",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:162:2025-06-20",
@@ -1510,7 +4809,8 @@
       "lon": -91.1871466,
       "url": "http://www.swingapaloozaevent.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:109:2025-06-26",
@@ -1530,7 +4830,8 @@
       "lon": -104.990251,
       "url": "http://www.coloradocountryclassic.net",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:207:2025-06-26",
@@ -1550,7 +4851,8 @@
       "lon": -121.3153096,
       "url": "https://dancenplay.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:96:2025-06-26",
@@ -1570,7 +4872,8 @@
       "lon": -74.4442802,
       "url": "http://www.libertyswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:261:2025-06-26",
@@ -1590,7 +4893,8 @@
       "lon": 4.9041389,
       "url": "http://www.neverlandswing.com/",
       "year": 2025,
-      "source": "event_editions"
+      "source": "event_editions",
+      "has_results": true
     },
     {
       "id": "confirmed:369:2025-06-27",
@@ -1610,7 +4914,8 @@
       "lon": 6.129384,
       "url": "http://FRENCHCONNECTIONWCS.COM",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:331:2025-06-27",
@@ -1630,7 +4935,8 @@
       "lon": 16.6068371,
       "url": "https://www.swingfiction.cz/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:1:2025-07-03",
@@ -1650,7 +4956,8 @@
       "lon": -112.0725488,
       "url": "http://phoenix4thofjuly.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:278:2025-07-03",
@@ -1670,7 +4977,8 @@
       "lon": 50.1728035,
       "url": "https://vk.com/americano2025 t.me/americamodancecamp",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:360:2025-07-03",
@@ -1690,7 +4998,8 @@
       "lon": 23.0746568,
       "url": "https://ekarolas.com/saunaswing/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:225:2025-07-03",
@@ -1710,7 +5019,8 @@
       "lon": -96.8067,
       "url": "http://www.WildWildWestie.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:156:2025-07-10",
@@ -1730,7 +5040,8 @@
       "lon": -74.4763123,
       "url": "http://bigapplecountrydance.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:373:2025-07-10",
@@ -1750,7 +5061,8 @@
       "lon": -80.84089329999999,
       "url": "https://carolinasummerswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:362:2025-07-10",
@@ -1770,7 +5082,8 @@
       "lon": 101.6840589,
       "url": "https://www.myswingopen.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:375:2025-07-11",
@@ -1790,7 +5103,8 @@
       "lon": 2.168568,
       "url": "https://mediterraneanopenwcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:224:2025-07-17",
@@ -1810,7 +5124,8 @@
       "lon": -94.6707917,
       "url": "http://Www.Midwestwestiefest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:280:2025-07-17",
@@ -1830,7 +5145,8 @@
       "lon": 30.3609097,
       "url": "http://wcsnights.ru",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:147:2025-07-17",
@@ -1850,7 +5166,8 @@
       "lon": -79.3831843,
       "url": "http://www.TOSHC.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:385:2025-07-18",
@@ -1863,14 +5180,15 @@
       "weekend_key": "2025-07-17",
       "status": "confirmed",
       "kind": "trial",
-      "city": "Melbourne",
-      "country": "Australia",
-      "continent": "Australia",
-      "lat": -37.8136276,
-      "lon": 144.9630576,
+      "city": "St. Petersburg",
+      "country": "Russia",
+      "continent": "Europe",
+      "lat": 59.9310584,
+      "lon": 30.3609097,
       "url": "https://withjoy.com/revitalisewcs-melbourne2025/welcome",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:256:2025-07-18",
@@ -1890,7 +5208,8 @@
       "lon": 19.4528047,
       "url": "https://rockthebarn.se/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:148:2025-07-24",
@@ -1910,7 +5229,8 @@
       "lon": -90.0758356,
       "url": "https://dancemardigras.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:149:2025-07-24",
@@ -1930,7 +5250,8 @@
       "lon": -80.13731740000001,
       "url": "https://floridadancemagic.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:77:2025-07-31",
@@ -1950,7 +5271,8 @@
       "lon": -112.0725488,
       "url": "https://arizonadanceclassic.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:157:2025-07-31",
@@ -1970,7 +5292,8 @@
       "lon": -71.0565364,
       "url": "http://www.nedancefestival.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:164:2025-07-31",
@@ -2010,7 +5333,8 @@
       "lon": -2.58791,
       "url": "https://www.bristolcityswing.com/bsf",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:382:2025-08-01",
@@ -2030,7 +5354,8 @@
       "lon": -9.1393366,
       "url": "http://www.lisbonwestiefest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:383:2025-08-01",
@@ -2043,14 +5368,15 @@
       "weekend_key": "2025-07-31",
       "status": "confirmed",
       "kind": "trial",
-      "city": "Warsaw",
-      "country": "Poland",
-      "continent": "Europe",
-      "lat": 52.2296756,
-      "lon": 21.0122287,
+      "city": "Washington",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.9072873,
+      "lon": -77.0369274,
       "url": "https://www.summernightswestival.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:282:2025-08-07",
@@ -2070,7 +5396,8 @@
       "lon": 7.842104299999999,
       "url": "https://go-wcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:120:2025-08-07",
@@ -2090,7 +5417,8 @@
       "lon": -97.7430608,
       "url": "http://Www.lonestarcountrydance.com.",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:59:2025-08-07",
@@ -2110,7 +5438,8 @@
       "lon": -77.3860976,
       "url": "http://www.swingfling.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:227:2025-08-07",
@@ -2130,7 +5459,8 @@
       "lon": -122.4194155,
       "url": "http://www.DanceGeekProductions.Art",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:47:2025-08-14",
@@ -2150,7 +5480,8 @@
       "lon": -104.990251,
       "url": "http://www.swingtimewcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:119:2025-08-15",
@@ -2170,7 +5501,8 @@
       "lon": -87.6323879,
       "url": "http://www.chicagolanddancefestival.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:384:2025-08-15",
@@ -2190,7 +5522,29 @@
       "lon": 23.3218675,
       "url": "https://wcs-gps.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
+    },
+    {
+      "id": "confirmed:264:2025-08-15",
+      "event_id": 264,
+      "name": "Swedish Swing Summer Camp",
+      "start_date": "2025-08-15",
+      "end_date": "2025-08-18",
+      "weekend_start": "2025-08-14",
+      "weekend_end": "2025-08-17",
+      "weekend_key": "2025-08-14",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Stockholm",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 59.3251172,
+      "lon": 18.0710935,
+      "url": "http://www.uptownswing.se/",
+      "year": 2025,
+      "source": "event_editions",
+      "has_results": true
     },
     {
       "id": "confirmed:493:2025-08-15",
@@ -2230,7 +5584,8 @@
       "lon": -71.0565364,
       "url": "https://summerhummerboston.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:391:2025-08-21",
@@ -2250,7 +5605,8 @@
       "lon": -84.5120196,
       "url": "http://swingdancemania.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:356:2025-08-21",
@@ -2270,7 +5626,8 @@
       "lon": -121.3153096,
       "url": "http://thebendconnection.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:298:2025-08-22",
@@ -2290,7 +5647,8 @@
       "lon": 172.636648,
       "url": "https://code03swing.com/shakedown",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:135:2025-08-28",
@@ -2310,7 +5668,8 @@
       "lon": -112.0725488,
       "url": "http://www.desertcityswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:177:2025-08-28",
@@ -2330,7 +5689,8 @@
       "lon": -81.6591529,
       "url": "http://www.jaxwestiefest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:313:2025-08-28",
@@ -2350,7 +5710,8 @@
       "lon": 4.835659,
       "url": "http://www.frenchywesty.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:48:2025-08-28",
@@ -2370,7 +5731,8 @@
       "lon": -121.8852525,
       "url": "https://sbdf.dance/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:268:2025-09-04",
@@ -2383,14 +5745,15 @@
       "weekend_key": "2025-09-04",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Jeju",
-      "country": "Republic of Korea",
-      "continent": "Asia",
-      "lat": 33.5042779,
-      "lon": 126.519838,
+      "city": "Brno",
+      "country": "Czech Republic",
+      "continent": "Europe",
+      "lat": 49.1950602,
+      "lon": 16.6068371,
       "url": "http://koreawestival.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:231:2025-09-04",
@@ -2410,7 +5773,8 @@
       "lon": -78.6381787,
       "url": "https://www.trilogywcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:338:2025-09-05",
@@ -2430,7 +5794,8 @@
       "lon": 37.6150527,
       "url": "https://vk.com/seadancefest",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:233:2025-09-11",
@@ -2450,7 +5815,8 @@
       "lon": 11.5819806,
       "url": "https://bavarianopen.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:167:2025-09-11",
@@ -2470,7 +5836,8 @@
       "lon": 151.2057136,
       "url": "https://www.bestofthebestwcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:359:2025-09-18",
@@ -2490,7 +5857,8 @@
       "lon": -122.3328481,
       "url": "https://www.retaliationswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:300:2025-09-19",
@@ -2510,7 +5878,8 @@
       "lon": -97.7430608,
       "url": "http://www.atxrox.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:254:2025-09-19",
@@ -2530,7 +5899,8 @@
       "lon": 24.938379,
       "url": "http://www.finnfest.fi",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:234:2025-09-19",
@@ -2550,7 +5920,8 @@
       "lon": -75.5483909,
       "url": "https://phillyswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:357:2025-09-19",
@@ -2570,7 +5941,8 @@
       "lon": 16.3713095,
       "url": "https://www.wcsparty.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:131:2025-09-25",
@@ -2590,7 +5962,8 @@
       "lon": -90.1982439,
       "url": "http://www.mmisl.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:165:2025-09-25",
@@ -2610,7 +5983,8 @@
       "lon": -0.1275862,
       "url": "http://www.MidlandSwingOpen.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:361:2025-09-25",
@@ -2623,14 +5997,15 @@
       "weekend_key": "2025-09-25",
       "status": "confirmed",
       "kind": "trial",
-      "city": "Östersund",
-      "country": "Sweden",
-      "continent": "Europe",
-      "lat": 63.1766832,
-      "lon": 14.6360681,
+      "city": "Phoenix",
+      "country": "United States",
+      "continent": "America",
+      "lat": 33.4482948,
+      "lon": -112.0725488,
       "url": "https://mooselandswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:211:2025-10-02",
@@ -2650,7 +6025,8 @@
       "lon": -84.3885209,
       "url": "https://atlantaswingclassic.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:388:2025-10-02",
@@ -2670,7 +6046,8 @@
       "lon": 11.0679977,
       "url": "https://norwegianopen.no/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:355:2025-10-08",
@@ -2690,7 +6067,8 @@
       "lon": -156.4391668,
       "url": "http://www.alohaopenwcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:322:2025-10-09",
@@ -2710,7 +6088,8 @@
       "lon": 9.1824027,
       "url": "https://www.westcoastswingmilan.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:43:2025-10-09",
@@ -2730,7 +6109,8 @@
       "lon": -117.8265049,
       "url": "http://www.paradisecountrydancefestival.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:367:2025-10-10",
@@ -2750,7 +6130,8 @@
       "lon": 115.8616783,
       "url": "https://www.gowestswingfest.au",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:8:2025-10-16",
@@ -2770,7 +6151,8 @@
       "lon": -122.4194155,
       "url": "https://boogiebythebay.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:179:2025-10-16",
@@ -2783,14 +6165,15 @@
       "weekend_key": "2025-10-16",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Auckland",
-      "country": "New Zealand",
+      "city": "Perth",
+      "country": "Australia",
       "continent": "Australia",
-      "lat": -36.85088270000001,
-      "lon": 174.7644881,
+      "lat": -31.9513993,
+      "lon": 115.8616783,
       "url": "https://www.streetswing.co.nz/the-new-zealand-open",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:178:2025-10-17",
@@ -2803,14 +6186,15 @@
       "weekend_key": "2025-10-16",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Montreal",
-      "country": "Canada",
+      "city": "New York",
+      "country": "United States",
       "continent": "America",
-      "lat": 45.5018869,
-      "lon": -73.56739189999999,
+      "lat": 40.7127753,
+      "lon": -74.0059728,
       "url": "http://montrealwestiefest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:267:2025-10-17",
@@ -2830,7 +6214,8 @@
       "lon": -75.1652215,
       "url": "http://www.swustlicious.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:350:2025-10-22",
@@ -2850,7 +6235,8 @@
       "lon": 10.89779,
       "url": "https://www.augsburgwestiestation.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:65:2025-10-23",
@@ -2870,7 +6256,8 @@
       "lon": -117.9047429,
       "url": "http://HSTswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:125:2025-10-23",
@@ -2890,7 +6277,8 @@
       "lon": -87.6323879,
       "url": "https://swingcitychicago.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:380:2025-10-24",
@@ -2910,7 +6298,8 @@
       "lon": -73.75447070000001,
       "url": "http://www.spookyalbanyswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:346:2025-10-24",
@@ -2930,7 +6319,8 @@
       "lon": 5.5689372,
       "url": "http://www.swingside-invitational.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:286:2025-10-24",
@@ -2950,7 +6340,8 @@
       "lon": 6.7824545,
       "url": "http://www.wcsfestival.de",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:31:2025-10-30",
@@ -2970,7 +6361,8 @@
       "lon": -119.7788687,
       "url": "https://mountainmagic.dance/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:229:2025-10-30",
@@ -2990,7 +6382,8 @@
       "lon": 18.0710935,
       "url": "http://www.snowcs.se",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:236:2025-10-30",
@@ -3010,7 +6403,8 @@
       "lon": 21.0122287,
       "url": "http://www.warsawhalloweenswing.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:340:2025-10-31",
@@ -3030,7 +6424,8 @@
       "lon": 103.819836,
       "url": "https://spookywestieweekend.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:323:2025-10-31",
@@ -3050,7 +6445,8 @@
       "lon": -86.5853155,
       "url": "https://rocketcityswing.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:330:2025-11-06",
@@ -3070,7 +6466,8 @@
       "lon": 138.6007456,
       "url": "http://www.simplyadelaidewcs.com.au",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:137:2025-11-06",
@@ -3090,7 +6487,8 @@
       "lon": -82.45875269999999,
       "url": "http://www.tbcwcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:269:2025-11-07",
@@ -3110,7 +6508,8 @@
       "lon": 19.040235,
       "url": "http://asc-budapest.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:194:2025-11-07",
@@ -3130,7 +6529,8 @@
       "lon": 37.6150527,
       "url": "http://westiefest.org/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:270:2025-11-07",
@@ -3150,7 +6550,8 @@
       "lon": 4.835659,
       "url": "http://www.frenchywesty.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:181:2025-11-13",
@@ -3170,7 +6571,8 @@
       "lon": -77.3860976,
       "url": "http://www.dcswingexperience.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:288:2025-11-13",
@@ -3190,7 +6592,8 @@
       "lon": -96.8067,
       "url": "http://www.MidnightMadnessWCS.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:79:2025-11-13",
@@ -3230,7 +6633,8 @@
       "lon": -0.1275862,
       "url": "https://eastonswing.com/west-coast-swing-events/world-swing-dance-council/flowstate-west-coast-swing-zouk-festival-eastonswing/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:312:2025-11-14",
@@ -3250,7 +6654,8 @@
       "lon": 1.442848,
       "url": "http://www.westiepinkcity.fr",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:376:2025-11-20",
@@ -3270,7 +6675,8 @@
       "lon": -71.414199,
       "url": "http://www.northeastswingclassic.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:68:2025-11-26",
@@ -3290,7 +6696,8 @@
       "lon": -118.242643,
       "url": "http://www.theopenswing.com/",
       "year": 2025,
-      "source": "event_editions"
+      "source": "event_editions",
+      "has_results": true
     },
     {
       "id": "confirmed:87:2025-11-27",
@@ -3310,7 +6717,8 @@
       "lon": -81.6943605,
       "url": "https://cashdanceclub.org/cash-bash/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:212:2025-12-04",
@@ -3330,7 +6738,8 @@
       "lon": -117.8311428,
       "url": "http://www.tapwcs.com",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:238:2025-12-04",
@@ -3350,7 +6759,8 @@
       "lon": 10.7312704,
       "url": "http://www.winterwhite.no",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:290:2025-12-05",
@@ -3370,7 +6780,8 @@
       "lon": 37.6150527,
       "url": "https://t.me/ShoobaDoobaSwing",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:271:2025-12-11",
@@ -3390,7 +6801,8 @@
       "lon": 13.404954,
       "url": "https://berlinswingrevolution.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:377:2025-12-11",
@@ -3410,7 +6822,8 @@
       "lon": 19.9449799,
       "url": "http://santaswing.pl",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:342:2025-12-12",
@@ -3430,7 +6843,8 @@
       "lon": 1.442848,
       "url": "https://www.globalgrandprixwcs.com/",
       "year": 2025,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:240:2025-12-28",
@@ -3449,8 +6863,9 @@
       "lat": 59.3251172,
       "lon": 18.0710935,
       "url": "http://www.westiegala.com",
-      "year": 2025,
-      "source": "edition_calendar_dates"
+      "year": 2026,
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:42:2025-12-30",
@@ -3469,8 +6884,9 @@
       "lat": 28.5383832,
       "lon": -81.3789269,
       "url": "http://www.floorplayswingvacation.com",
-      "year": 2025,
-      "source": "edition_calendar_dates"
+      "year": 2026,
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:334:2025-12-31",
@@ -3489,8 +6905,9 @@
       "lat": 42.3555076,
       "lon": -71.0565364,
       "url": "https://countdownswingboston.com/",
-      "year": 2025,
-      "source": "edition_calendar_dates"
+      "year": 2026,
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:141:2025-12-31",
@@ -3509,8 +6926,9 @@
       "lat": 36.1626638,
       "lon": -86.7816016,
       "url": "http://www.spotlightnewyears.com",
-      "year": 2025,
-      "source": "edition_calendar_dates"
+      "year": 2026,
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:196:2025-12-31",
@@ -3529,8 +6947,9 @@
       "lat": 45.515232,
       "lon": -122.6783853,
       "url": "http://www.swingcouver.com",
-      "year": 2025,
-      "source": "edition_calendar_dates"
+      "year": 2026,
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:289:2025-12-31",
@@ -3549,13 +6968,14 @@
       "lat": 48.1664268,
       "lon": 14.0388714,
       "url": "http://www.swingvester.com",
-      "year": 2025,
-      "source": "edition_calendar_dates"
+      "year": 2026,
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
-      "id": "confirmed:152:2026-01-01",
-      "event_id": 152,
-      "name": "UCWDC Country Dance World Championships",
+      "id": "confirmed:75:2026-01-01",
+      "event_id": 75,
+      "name": "UCWDC Country Dance World Championship",
       "start_date": "2026-01-01",
       "end_date": "2026-01-03",
       "weekend_start": "2026-01-01",
@@ -3563,14 +6983,15 @@
       "weekend_key": "2026-01-01",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Orlando",
+      "city": "Dallas",
       "country": "United States",
       "continent": "America",
-      "lat": 28.5383832,
-      "lon": -81.3789269,
+      "lat": 32.7831,
+      "lon": -96.8067,
       "url": "http://www.ucwdcworlds.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:184:2026-01-06",
@@ -3590,7 +7011,8 @@
       "lon": 19.040235,
       "url": "http://wcs-budafest.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:200:2026-01-15",
@@ -3610,7 +7032,8 @@
       "lon": -97.7430608,
       "url": "https://austinswingdance.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:62:2026-01-15",
@@ -3630,7 +7053,8 @@
       "lon": -121.8977688,
       "url": "http://www.montereyswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:309:2026-01-16",
@@ -3650,7 +7074,8 @@
       "lon": 4.359999699999999,
       "url": "https://www.avignoncityswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:381:2026-01-16",
@@ -3690,7 +7115,8 @@
       "lon": -85.7663724,
       "url": "https://derbycityswing.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:301:2026-01-22",
@@ -3710,7 +7136,8 @@
       "lon": -3.188267,
       "url": "http://www.swingresolution.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:183:2026-01-23",
@@ -3730,7 +7157,8 @@
       "lon": -75.5483909,
       "url": "https://freedomswingdance.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:272:2026-01-23",
@@ -3750,7 +7178,8 @@
       "lon": 2.3513765,
       "url": "https://parisswingclassic.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:273:2026-01-29",
@@ -3770,7 +7199,8 @@
       "lon": -80.84089329999999,
       "url": "https://www.charlottewestiefest.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:215:2026-02-05",
@@ -3790,7 +7220,8 @@
       "lon": 30.3609097,
       "url": "https://swingandsnow.ru/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:258:2026-02-05",
@@ -3810,7 +7241,8 @@
       "lon": 8.541694,
       "url": "https://swingtzerland.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:387:2026-02-05",
@@ -3830,7 +7262,8 @@
       "lon": -80.5261203,
       "url": "http://www.waterlooopenwcs.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:363:2026-02-06",
@@ -3850,7 +7283,8 @@
       "lon": -6.388300099999999,
       "url": "http://Trinityswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:302:2026-02-06",
@@ -3890,7 +7324,8 @@
       "lon": -121.4944209,
       "url": "https://www.capitalswingconvention.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:386:2026-02-13",
@@ -3910,7 +7345,8 @@
       "lon": 14.4378005,
       "url": "https://praguealchemyswing.cz/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:310:2026-02-13",
@@ -3930,7 +7366,8 @@
       "lon": 18.0710935,
       "url": "http://valentineswing.dance",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:348:2026-02-17",
@@ -3950,7 +7387,8 @@
       "lon": 7.725619099999999,
       "url": "https://www.euro-dance-festival.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:344:2026-02-19",
@@ -3970,7 +7408,8 @@
       "lon": -8.8252502,
       "url": "https://www.arousawestiefest.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:343:2026-02-19",
@@ -3990,7 +7429,8 @@
       "lon": -98.4945922,
       "url": "https://swingcrush.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:297:2026-02-19",
@@ -4010,7 +7450,8 @@
       "lon": 27.7880116,
       "url": "http://www.wintercoastswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:244:2026-02-26",
@@ -4030,7 +7471,8 @@
       "lon": -122.6783853,
       "url": "https://rosecityswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:394:2026-02-26",
@@ -4050,7 +7492,8 @@
       "lon": 147.3257196,
       "url": "http://www.southernlightsswing.com.au",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:378:2026-02-27",
@@ -4070,7 +7513,8 @@
       "lon": -74.0059728,
       "url": "https://www.flowfest.nyc",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:92:2026-03-05",
@@ -4090,7 +7534,8 @@
       "lon": -77.0369274,
       "url": "http://www.atlanticdancejam.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:143:2026-03-06",
@@ -4110,7 +7555,8 @@
       "lon": -118.1481016,
       "url": "http://www.highdesertdanceclassic.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:333:2026-03-06",
@@ -4130,7 +7576,8 @@
       "lon": 174.7787463,
       "url": "http://Swingvasion.nz",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:314:2026-03-11",
@@ -4150,7 +7597,8 @@
       "lon": 19.040235,
       "url": "https://westiespringthing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:318:2026-03-12",
@@ -4170,7 +7618,8 @@
       "lon": -122.4194155,
       "url": "https://www.allstarswingjam.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:275:2026-03-12",
@@ -4190,7 +7639,8 @@
       "lon": 5.9736992,
       "url": "http://www.dutchopenwcs.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:186:2026-03-12",
@@ -4210,7 +7660,8 @@
       "lon": 4.835659,
       "url": "http://www.west-in-lyon.fr",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:292:2026-03-19",
@@ -4230,7 +7681,8 @@
       "lon": 19.9449799,
       "url": "http://kingswing.pl",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:142:2026-03-19",
@@ -4250,7 +7702,8 @@
       "lon": -87.6323879,
       "url": "https://thechicagoclassic.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:197:2026-03-26",
@@ -4270,7 +7723,8 @@
       "lon": -104.990251,
       "url": "https://www.5280westival.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:9:2026-03-26",
@@ -4290,7 +7744,8 @@
       "lon": -71.0565364,
       "url": "http://teapartyswings.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:153:2026-03-26",
@@ -4310,7 +7765,8 @@
       "lon": -95.3701108,
       "url": "http://htownthrowdownwcs.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:154:2026-03-26",
@@ -4330,7 +7786,8 @@
       "lon": -0.1275862,
       "url": "https://www.ukwcschamps.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:18:2026-04-02",
@@ -4350,7 +7807,8 @@
       "lon": -122.3328481,
       "url": "https://www.easterswing.org/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:132:2026-04-02",
@@ -4370,7 +7828,8 @@
       "lon": -95.989501,
       "url": "http://www.TulsaSpringSwing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:116:2026-04-09",
@@ -4390,7 +7849,8 @@
       "lon": -114.0718831,
       "url": "http://www.calgarydancestampede.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:187:2026-04-09",
@@ -4410,7 +7870,8 @@
       "lon": -118.3074827,
       "url": "http://cityofangelswcs.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:210:2026-04-09",
@@ -4430,7 +7891,8 @@
       "lon": 126.6312666,
       "url": "https://www.kopenwcs.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:304:2026-04-09",
@@ -4450,7 +7912,8 @@
       "lon": 12.4822025,
       "url": "https://www.westcoastswingroma.it/swing-in-capital/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:293:2026-04-10",
@@ -4470,7 +7933,8 @@
       "lon": -1.553621,
       "url": "https://www.westynantes.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:218:2026-04-16",
@@ -4490,7 +7954,8 @@
       "lon": 103.819836,
       "url": "https://www.asiawcsopen.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:393:2026-04-16",
@@ -4510,7 +7975,8 @@
       "lon": -75.7003397,
       "url": "http://www.swinginbloom.ca",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:203:2026-04-23",
@@ -4530,7 +7996,8 @@
       "lon": -2.2426305,
       "url": "http://www.DetonationDance.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:345:2026-04-23",
@@ -4550,7 +8017,8 @@
       "lon": 55.9578555,
       "url": "https://t.me/honeyfest",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:352:2026-04-23",
@@ -4570,7 +8038,8 @@
       "lon": 14.5057515,
       "url": "https://slovenianopen.dance/en",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:370:2026-04-23",
@@ -4590,7 +8059,8 @@
       "lon": 7.0982068,
       "url": "http://www.swinginfestival.de",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:259:2026-04-23",
@@ -4610,7 +8080,8 @@
       "lon": -81.3789269,
       "url": "http://www.swingoverevent.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:253:2026-04-30",
@@ -4630,7 +8101,8 @@
       "lon": 18.0710935,
       "url": "http://www.nordicwcschamps.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:354:2026-04-30",
@@ -4650,7 +8122,8 @@
       "lon": 7.842104299999999,
       "url": "https://springtimeswing.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:144:2026-04-30",
@@ -4670,7 +8143,8 @@
       "lon": -72.6733723,
       "url": "http://www.sis.djkenm.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:347:2026-05-01",
@@ -4690,7 +8164,8 @@
       "lon": -3.7032905,
       "url": "https://beemadwcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:379:2026-05-07",
@@ -4710,7 +8185,8 @@
       "lon": 6.2355346,
       "url": "http://www.medinswing.rocks",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:336:2026-05-07",
@@ -4730,7 +8206,8 @@
       "lon": 14.0388714,
       "url": "http://www.swingofmusic.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:372:2026-05-08",
@@ -4750,7 +8227,8 @@
       "lon": -77.026088,
       "url": "https://dancejamproductions.com/westieweekend/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:175:2026-05-13",
@@ -4770,7 +8248,8 @@
       "lon": 2.3513765,
       "url": "http://www.fowcs.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:221:2026-05-14",
@@ -4790,7 +8269,8 @@
       "lon": -90.1982439,
       "url": "http://gatewayswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:205:2026-05-14",
@@ -4810,7 +8290,8 @@
       "lon": -122.7139216,
       "url": "https://www.soswingdance.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:105:2026-05-15",
@@ -4830,7 +8311,8 @@
       "lon": -73.56739189999999,
       "url": "https://www.canadianswingchampionships.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:174:2026-05-15",
@@ -4850,7 +8332,8 @@
       "lon": 153.380936,
       "url": "https://rawconnection.com.au/swingsation/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:121:2026-05-15",
@@ -4870,7 +8353,8 @@
       "lon": -97.7430608,
       "url": "http://Www.thetexasclassic.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:22:2026-05-21",
@@ -4890,7 +8374,8 @@
       "lon": -84.3885209,
       "url": "http://www.usagrandnationals.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:206:2026-05-22",
@@ -4910,7 +8395,8 @@
       "lon": 19.040235,
       "url": "http://wcs-ho.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:76:2026-05-28",
@@ -4930,7 +8416,8 @@
       "lon": -83.0424533,
       "url": "http://MichiganClassicSwing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:371:2026-05-29",
@@ -4950,7 +8437,8 @@
       "lon": -1.61778,
       "url": "http://www.fcswing.co.uk",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:364:2026-05-29",
@@ -4970,7 +8458,8 @@
       "lon": -123.9400647,
       "url": "http://www.nanaimodancefusion.ca",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:25:2026-06-04",
@@ -4990,7 +8479,8 @@
       "lon": -117.9379952,
       "url": "https://jackandjillorama.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:117:2026-06-04",
@@ -5010,7 +8500,8 @@
       "lon": -81.3789269,
       "url": "http://www.orangeblossomdance.net",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:222:2026-06-11",
@@ -5030,7 +8521,8 @@
       "lon": 18.6466384,
       "url": "http://www.balticswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:207:2026-06-18",
@@ -5070,7 +8562,8 @@
       "lon": 9.1824027,
       "url": "https://www.westcoastswingmilan.com/milanswingvibes/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:220:2026-06-19",
@@ -5090,7 +8583,8 @@
       "lon": 6.7824545,
       "url": "http://www.d-townswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:162:2026-06-19",
@@ -5110,7 +8604,8 @@
       "lon": -91.1871466,
       "url": "http://www.swingapaloozaevent.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:374:2026-06-25",
@@ -5130,7 +8625,8 @@
       "lon": 9.1942834,
       "url": "https://baroqueswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:109:2026-06-25",
@@ -5150,7 +8646,8 @@
       "lon": -104.990251,
       "url": "https://coloradocountryclassic.net/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:96:2026-06-25",
@@ -5170,7 +8667,8 @@
       "lon": -74.4442802,
       "url": "http://www.libertyswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:261:2026-06-25",
@@ -5190,7 +8688,8 @@
       "lon": 4.9041389,
       "url": "http://www.neverlandswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:331:2026-06-26",
@@ -5210,7 +8709,8 @@
       "lon": 16.6068371,
       "url": "https://www.swingfiction.cz/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:1:2026-07-02",
@@ -5230,7 +8730,8 @@
       "lon": -112.0725488,
       "url": "http://phoenix4thofjuly.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:278:2026-07-02",
@@ -5250,7 +8751,8 @@
       "lon": 50.1728035,
       "url": "https://t.me/americamodancecamp https://vk.com/americano2025",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:360:2026-07-02",
@@ -5270,7 +8772,8 @@
       "lon": 23.0746568,
       "url": "https://ekarolas.com/saunaswing/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:225:2026-07-02",
@@ -5290,7 +8793,8 @@
       "lon": -96.8067,
       "url": "https://www.wildwildwestie.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:369:2026-07-03",
@@ -5310,7 +8814,8 @@
       "lon": 6.129384,
       "url": "https://www.frenchconnectionwcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:156:2026-07-09",
@@ -5330,7 +8835,8 @@
       "lon": -74.4763123,
       "url": "http://bigapplecountrydance.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:373:2026-07-09",
@@ -5350,7 +8856,8 @@
       "lon": -80.84089329999999,
       "url": "https://carolinasummerswing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:362:2026-07-09",
@@ -5370,7 +8877,8 @@
       "lon": 101.6840589,
       "url": "https://www.myswingopen.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:375:2026-07-09",
@@ -5390,7 +8898,8 @@
       "lon": 2.168568,
       "url": "https://mediterraneanopenwcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:147:2026-07-09",
@@ -5430,7 +8939,8 @@
       "lon": 13.404954,
       "url": "http://www.swinglab-berlin.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:224:2026-07-16",
@@ -5450,7 +8960,8 @@
       "lon": -94.6707917,
       "url": "http://Www.midwestwestiefest.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:385:2026-07-16",
@@ -5463,14 +8974,15 @@
       "weekend_key": "2026-07-16",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Melbourne",
-      "country": "Australia",
-      "continent": "Australia",
-      "lat": -37.8136276,
-      "lon": 144.9630576,
+      "city": "St. Petersburg",
+      "country": "Russia",
+      "continent": "Europe",
+      "lat": 59.9310584,
+      "lon": 30.3609097,
       "url": "https://revitalisewcs.melbourne/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:256:2026-07-17",
@@ -5490,7 +9002,8 @@
       "lon": 19.4528047,
       "url": "https://rockthebarn.se/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:280:2026-07-22",
@@ -5510,7 +9023,8 @@
       "lon": 30.3609097,
       "url": "http://wcsnights.ru",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:149:2026-07-23",
@@ -5530,7 +9044,8 @@
       "lon": -80.13731740000001,
       "url": "https://floridadancemagic.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "confirmed:404:2026-07-23",
@@ -5550,7 +9065,8 @@
       "lon": 11.5819806,
       "url": "http://infinite-swing.com",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "edition_calendar_dates",
+      "has_results": true
     },
     {
       "id": "hiatus:148:2026-07-24",
@@ -5590,7 +9106,8 @@
       "lon": 4.086072000000001,
       "url": "http://www.seasunswing.fr/",
       "year": 2026,
-      "source": "scheduled_events"
+      "source": "scheduled_events",
+      "has_results": true
     },
     {
       "id": "confirmed:382:2026-07-30",
@@ -5626,8 +9143,8 @@
       "city": "Warsaw",
       "country": "Poland",
       "continent": "Europe",
-      "lat": 52.2296756,
-      "lon": 21.0122287,
+      "lat": 38.9072873,
+      "lon": -77.0369274,
       "url": "https://www.summernightswestival.com/",
       "year": 2026,
       "source": "scheduled_events"
@@ -5752,7 +9269,8 @@
       "year": 2026,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-08-07"
+      "projected_from_start": "2025-08-07",
+      "has_results": true
     },
     {
       "id": "confirmed:384:2026-08-14",
@@ -5793,6 +9311,29 @@
       "url": "http://www.uptownswing.se/",
       "year": 2026,
       "source": "scheduled_events"
+    },
+    {
+      "id": "expected:264:2026-08-15",
+      "event_id": 264,
+      "name": "Swedish Swing Summer Camp",
+      "start_date": "2026-08-15",
+      "end_date": "2026-08-18",
+      "weekend_start": "2026-08-13",
+      "weekend_end": "2026-08-16",
+      "weekend_key": "2026-08-13",
+      "status": "expected",
+      "kind": "registry",
+      "city": "Stockholm",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 59.3251172,
+      "lon": 18.0710935,
+      "url": "http://www.uptownswing.se/",
+      "year": 2026,
+      "source": "expected_yoy",
+      "projected_from_year": 2025,
+      "projected_from_start": "2025-08-15",
+      "has_results": true
     },
     {
       "id": "confirmed:298:2026-08-20",
@@ -5934,7 +9475,8 @@
       "year": 2026,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-08-21"
+      "projected_from_start": "2025-08-21",
+      "has_results": true
     },
     {
       "id": "confirmed:x:2026-08-21",
@@ -6030,8 +9572,8 @@
       "city": "Jeju",
       "country": "Republic of Korea",
       "continent": "Asia",
-      "lat": 33.5042779,
-      "lon": 126.519838,
+      "lat": 49.1950602,
+      "lon": 16.6068371,
       "url": "http://koreawestival.com/",
       "year": 2026,
       "source": "scheduled_events"
@@ -6370,8 +9912,8 @@
       "city": "Östersund",
       "country": "Sweden",
       "continent": "Europe",
-      "lat": 63.1766832,
-      "lon": 14.6360681,
+      "lat": 33.4482948,
+      "lon": -112.0725488,
       "url": "https://mooselandswing.com/",
       "year": 2026,
       "source": "scheduled_events"
@@ -6530,8 +10072,8 @@
       "city": "Montreal",
       "country": "Canada",
       "continent": "America",
-      "lat": 45.5018869,
-      "lon": -73.56739189999999,
+      "lat": 40.7127753,
+      "lon": -74.0059728,
       "url": "http://montrealwestiefest.com/",
       "year": 2026,
       "source": "scheduled_events"
@@ -6556,7 +10098,8 @@
       "year": 2026,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-10-10"
+      "projected_from_start": "2025-10-10",
+      "has_results": true
     },
     {
       "id": "confirmed:322:2026-10-15",
@@ -6592,8 +10135,8 @@
       "city": "Auckland",
       "country": "New Zealand",
       "continent": "Australia",
-      "lat": -36.85088270000001,
-      "lon": 174.7644881,
+      "lat": -31.9513993,
+      "lon": 115.8616783,
       "url": "https://www.streetswing.co.nz/the-new-zealand-open",
       "year": 2026,
       "source": "scheduled_events"
@@ -7178,7 +10721,8 @@
       "year": 2026,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-12-05"
+      "projected_from_start": "2025-12-05",
+      "has_results": true
     },
     {
       "id": "confirmed:271:2026-12-10",
@@ -7257,7 +10801,7 @@
       "lat": 28.5383832,
       "lon": -81.3789269,
       "url": "http://www.ucwdcworlds.com/",
-      "year": 2026,
+      "year": 2027,
       "source": "scheduled_events"
     },
     {
@@ -7277,7 +10821,7 @@
       "lat": 28.5383832,
       "lon": -81.3789269,
       "url": "http://www.floorplayswingvacation.com/",
-      "year": 2026,
+      "year": 2027,
       "source": "scheduled_events"
     },
     {
@@ -7297,7 +10841,7 @@
       "lat": 51.5072178,
       "lon": -0.1275862,
       "url": "http://nysf.uk/",
-      "year": 2026,
+      "year": 2027,
       "source": "scheduled_events"
     },
     {
@@ -7317,7 +10861,7 @@
       "lat": 36.1626638,
       "lon": -86.7816016,
       "url": "http://www.spotlightnewyears.com/",
-      "year": 2026,
+      "year": 2027,
       "source": "scheduled_events"
     },
     {
@@ -7337,7 +10881,7 @@
       "lat": 48.1664268,
       "lon": 14.0388714,
       "url": "https://www.swingvester.com/",
-      "year": 2026,
+      "year": 2027,
       "source": "scheduled_events"
     },
     {
@@ -7357,7 +10901,7 @@
       "lat": 42.3555076,
       "lon": -71.0565364,
       "url": "http://countdownswingboston.com/",
-      "year": 2026,
+      "year": 2027,
       "source": "scheduled_events"
     },
     {
@@ -7377,8 +10921,31 @@
       "lat": 59.3251172,
       "lon": 18.0710935,
       "url": "http://www.westiegala.com/",
-      "year": 2026,
+      "year": 2027,
       "source": "scheduled_events"
+    },
+    {
+      "id": "expected:75:2027-01-01",
+      "event_id": 75,
+      "name": "UCWDC Country Dance World Championship",
+      "start_date": "2027-01-01",
+      "end_date": "2027-01-03",
+      "weekend_start": "2026-12-31",
+      "weekend_end": "2027-01-03",
+      "weekend_key": "2026-12-31",
+      "status": "expected",
+      "kind": "registry",
+      "city": "Dallas",
+      "country": "United States",
+      "continent": "America",
+      "lat": 32.7831,
+      "lon": -96.8067,
+      "url": "http://www.ucwdcworlds.com",
+      "year": 2027,
+      "source": "expected_yoy",
+      "projected_from_year": 2026,
+      "projected_from_start": "2026-01-01",
+      "has_results": true
     },
     {
       "id": "confirmed:184:2027-01-05",
@@ -8104,7 +11671,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-03-12"
+      "projected_from_start": "2026-03-12",
+      "has_results": true
     },
     {
       "id": "confirmed:143:2027-03-12",
@@ -8326,7 +11894,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-04-09"
+      "projected_from_start": "2026-04-09",
+      "has_results": true
     },
     {
       "id": "confirmed:352:2027-04-14",
@@ -8588,7 +12157,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-04-30"
+      "projected_from_start": "2026-04-30",
+      "has_results": true
     },
     {
       "id": "expected:354:2027-04-30",
@@ -8610,7 +12180,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-04-30"
+      "projected_from_start": "2026-04-30",
+      "has_results": true
     },
     {
       "id": "confirmed:372:2027-05-07",
@@ -8652,7 +12223,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-05-07"
+      "projected_from_start": "2026-05-07",
+      "has_results": true
     },
     {
       "id": "expected:175:2027-05-13",
@@ -8674,7 +12246,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-05-13"
+      "projected_from_start": "2026-05-13",
+      "has_results": true
     },
     {
       "id": "confirmed:205:2027-05-13",
@@ -8756,7 +12329,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-05-15"
+      "projected_from_start": "2026-05-15",
+      "has_results": true
     },
     {
       "id": "expected:121:2027-05-15",
@@ -8778,7 +12352,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-05-15"
+      "projected_from_start": "2026-05-15",
+      "has_results": true
     },
     {
       "id": "confirmed:221:2027-05-20",
@@ -8840,7 +12415,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-05-22"
+      "projected_from_start": "2026-05-22",
+      "has_results": true
     },
     {
       "id": "confirmed:22:2027-05-27",
@@ -8882,7 +12458,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-05-30"
+      "projected_from_start": "2025-05-30",
+      "has_results": true
     },
     {
       "id": "confirmed:371:2027-06-03",
@@ -8944,7 +12521,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-06-04"
+      "projected_from_start": "2026-06-04",
+      "has_results": true
     },
     {
       "id": "expected:117:2027-06-04",
@@ -8966,7 +12544,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-06-04"
+      "projected_from_start": "2026-06-04",
+      "has_results": true
     },
     {
       "id": "confirmed:222:2027-06-10",
@@ -9048,7 +12627,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-06-18"
+      "projected_from_start": "2026-06-18",
+      "has_results": true
     },
     {
       "id": "confirmed:374:2027-06-24",
@@ -9130,7 +12710,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-06-25"
+      "projected_from_start": "2026-06-25",
+      "has_results": true
     },
     {
       "id": "confirmed:369:2027-06-25",
@@ -9172,7 +12753,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-06-26"
+      "projected_from_start": "2026-06-26",
+      "has_results": true
     },
     {
       "id": "confirmed:278:2027-07-01",
@@ -9254,7 +12836,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-02"
+      "projected_from_start": "2026-07-02",
+      "has_results": true
     },
     {
       "id": "expected:225:2027-07-02",
@@ -9276,7 +12859,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-02"
+      "projected_from_start": "2026-07-02",
+      "has_results": true
     },
     {
       "id": "confirmed:373:2027-07-08",
@@ -9318,7 +12902,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-09"
+      "projected_from_start": "2026-07-09",
+      "has_results": true
     },
     {
       "id": "expected:362:2027-07-09",
@@ -9340,7 +12925,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-09"
+      "projected_from_start": "2026-07-09",
+      "has_results": true
     },
     {
       "id": "expected:375:2027-07-09",
@@ -9362,7 +12948,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-09"
+      "projected_from_start": "2026-07-09",
+      "has_results": true
     },
     {
       "id": "expected:389:2027-07-10",
@@ -9384,7 +12971,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-10"
+      "projected_from_start": "2026-07-10",
+      "has_results": true
     },
     {
       "id": "confirmed:224:2027-07-15",
@@ -9417,16 +13005,17 @@
       "weekend_key": "2027-07-15",
       "status": "expected",
       "kind": "registry",
-      "city": "Melbourne",
-      "country": "Australia",
-      "continent": "Australia",
-      "lat": -37.8136276,
-      "lon": 144.9630576,
+      "city": "St. Petersburg",
+      "country": "Russia",
+      "continent": "Europe",
+      "lat": 59.9310584,
+      "lon": 30.3609097,
       "url": "https://revitalisewcs.melbourne/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-16"
+      "projected_from_start": "2026-07-16",
+      "has_results": true
     },
     {
       "id": "expected:256:2027-07-17",
@@ -9448,7 +13037,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-17"
+      "projected_from_start": "2026-07-17",
+      "has_results": true
     },
     {
       "id": "expected:280:2027-07-22",
@@ -9470,7 +13060,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-22"
+      "projected_from_start": "2026-07-22",
+      "has_results": true
     },
     {
       "id": "expected:149:2027-07-23",
@@ -9492,7 +13083,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-23"
+      "projected_from_start": "2026-07-23",
+      "has_results": true
     },
     {
       "id": "expected:404:2027-07-23",
@@ -9514,7 +13106,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-23"
+      "projected_from_start": "2026-07-23",
+      "has_results": true
     },
     {
       "id": "expected:164:2027-07-25",
@@ -9536,7 +13129,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-25"
+      "projected_from_start": "2026-07-25",
+      "has_results": true
     },
     {
       "id": "expected:382:2027-07-30",
@@ -9574,8 +13168,8 @@
       "city": "Warsaw",
       "country": "Poland",
       "continent": "Europe",
-      "lat": 52.2296756,
-      "lon": 21.0122287,
+      "lat": 38.9072873,
+      "lon": -77.0369274,
       "url": "https://www.summernightswestival.com/",
       "year": 2027,
       "source": "expected_yoy",
@@ -9712,7 +13306,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-08-07"
+      "projected_from_start": "2025-08-07",
+      "has_results": true
     },
     {
       "id": "expected:384:2027-08-14",
@@ -9735,6 +13330,29 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-08-14"
+    },
+    {
+      "id": "expected:264:2027-08-15",
+      "event_id": 264,
+      "name": "Swedish Swing Summer Camp",
+      "start_date": "2027-08-15",
+      "end_date": "2027-08-18",
+      "weekend_start": "2027-08-12",
+      "weekend_end": "2027-08-15",
+      "weekend_key": "2027-08-12",
+      "status": "expected",
+      "kind": "registry",
+      "city": "Stockholm",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 59.3251172,
+      "lon": 18.0710935,
+      "url": "http://www.uptownswing.se/",
+      "year": 2027,
+      "source": "expected_yoy",
+      "projected_from_year": 2025,
+      "projected_from_start": "2025-08-15",
+      "has_results": true
     },
     {
       "id": "expected:298:2027-08-20",
@@ -9844,7 +13462,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-08-21"
+      "projected_from_start": "2025-08-21",
+      "has_results": true
     },
     {
       "id": "expected:135:2027-08-27",
@@ -9926,8 +13545,8 @@
       "city": "Jeju",
       "country": "Republic of Korea",
       "continent": "Asia",
-      "lat": 33.5042779,
-      "lon": 126.519838,
+      "lat": 49.1950602,
+      "lon": 16.6068371,
       "url": "http://koreawestival.com/",
       "year": 2027,
       "source": "expected_yoy",
@@ -10300,8 +13919,8 @@
       "city": "Östersund",
       "country": "Sweden",
       "continent": "Europe",
-      "lat": 63.1766832,
-      "lon": 14.6360681,
+      "lat": 33.4482948,
+      "lon": -112.0725488,
       "url": "https://mooselandswing.com/",
       "year": 2027,
       "source": "expected_yoy",
@@ -10408,8 +14027,8 @@
       "city": "Montreal",
       "country": "Canada",
       "continent": "America",
-      "lat": 45.5018869,
-      "lon": -73.56739189999999,
+      "lat": 40.7127753,
+      "lon": -74.0059728,
       "url": "http://montrealwestiefest.com/",
       "year": 2027,
       "source": "expected_yoy",
@@ -10436,7 +14055,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-10-10"
+      "projected_from_start": "2025-10-10",
+      "has_results": true
     },
     {
       "id": "expected:322:2027-10-15",
@@ -10474,8 +14094,8 @@
       "city": "Auckland",
       "country": "New Zealand",
       "continent": "Australia",
-      "lat": -36.85088270000001,
-      "lon": 174.7644881,
+      "lat": -31.9513993,
+      "lon": 115.8616783,
       "url": "https://www.streetswing.co.nz/the-new-zealand-open",
       "year": 2027,
       "source": "expected_yoy",
@@ -11116,7 +14736,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-12-05"
+      "projected_from_start": "2025-12-05",
+      "has_results": true
     },
     {
       "id": "expected:271:2027-12-10",
@@ -11163,158 +14784,27 @@
       "projected_from_start": "2026-12-10"
     },
     {
-      "id": "expected:152:2027-12-28",
-      "event_id": 152,
-      "name": "UCWDC Country Dance World Championships",
-      "start_date": "2027-12-28",
+      "id": "expected:75:2028-01-01",
+      "event_id": 75,
+      "name": "UCWDC Country Dance World Championship",
+      "start_date": "2028-01-01",
       "end_date": "2028-01-03",
-      "weekend_start": "2027-12-23",
-      "weekend_end": "2027-12-26",
-      "weekend_key": "2027-12-23",
+      "weekend_start": "2027-12-30",
+      "weekend_end": "2028-01-02",
+      "weekend_key": "2027-12-30",
       "status": "expected",
       "kind": "registry",
-      "city": "Orlando",
+      "city": "Dallas",
       "country": "United States",
       "continent": "America",
-      "lat": 28.5383832,
-      "lon": -81.3789269,
-      "url": "http://www.ucwdcworlds.com/",
-      "year": 2027,
+      "lat": 32.7831,
+      "lon": -96.8067,
+      "url": "http://www.ucwdcworlds.com",
+      "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-12-28"
-    },
-    {
-      "id": "expected:42:2027-12-30",
-      "event_id": 42,
-      "name": "Floorplay Swing Vacation",
-      "start_date": "2027-12-30",
-      "end_date": "2028-01-03",
-      "weekend_start": "2027-12-30",
-      "weekend_end": "2028-01-02",
-      "weekend_key": "2027-12-30",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Orlando",
-      "country": "United States",
-      "continent": "America",
-      "lat": 28.5383832,
-      "lon": -81.3789269,
-      "url": "http://www.floorplayswingvacation.com/",
-      "year": 2027,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-12-30"
-    },
-    {
-      "id": "expected:214:2027-12-30",
-      "event_id": 214,
-      "name": "New Years Swing Fling",
-      "start_date": "2027-12-30",
-      "end_date": "2028-01-03",
-      "weekend_start": "2027-12-30",
-      "weekend_end": "2028-01-02",
-      "weekend_key": "2027-12-30",
-      "status": "expected",
-      "kind": "registry",
-      "city": "London",
-      "country": "United Kingdom",
-      "continent": "Europe",
-      "lat": 51.5072178,
-      "lon": -0.1275862,
-      "url": "http://nysf.uk/",
-      "year": 2027,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-12-30"
-    },
-    {
-      "id": "expected:141:2027-12-30",
-      "event_id": 141,
-      "name": "Spotlight New Year's Celebration",
-      "start_date": "2027-12-30",
-      "end_date": "2028-01-03",
-      "weekend_start": "2027-12-30",
-      "weekend_end": "2028-01-02",
-      "weekend_key": "2027-12-30",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Nashville",
-      "country": "United States",
-      "continent": "America",
-      "lat": 36.1626638,
-      "lon": -86.7816016,
-      "url": "http://www.spotlightnewyears.com/",
-      "year": 2027,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-12-30"
-    },
-    {
-      "id": "expected:289:2027-12-30",
-      "event_id": 289,
-      "name": "SwingVester",
-      "start_date": "2027-12-30",
-      "end_date": "2028-01-04",
-      "weekend_start": "2027-12-30",
-      "weekend_end": "2028-01-02",
-      "weekend_key": "2027-12-30",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Wels",
-      "country": "Austria",
-      "continent": "Europe",
-      "lat": 48.1664268,
-      "lon": 14.0388714,
-      "url": "https://www.swingvester.com/",
-      "year": 2027,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-12-30"
-    },
-    {
-      "id": "expected:334:2027-12-31",
-      "event_id": 334,
-      "name": "Countdown Swing Boston",
-      "start_date": "2027-12-31",
-      "end_date": "2028-01-03",
-      "weekend_start": "2027-12-30",
-      "weekend_end": "2028-01-02",
-      "weekend_key": "2027-12-30",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Boston",
-      "country": "United States",
-      "continent": "America",
-      "lat": 42.3555076,
-      "lon": -71.0565364,
-      "url": "http://countdownswingboston.com/",
-      "year": 2027,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-12-31"
-    },
-    {
-      "id": "expected:240:2027-12-31",
-      "event_id": 240,
-      "name": "Westie Gala",
-      "start_date": "2027-12-31",
-      "end_date": "2028-01-04",
-      "weekend_start": "2027-12-30",
-      "weekend_end": "2028-01-02",
-      "weekend_key": "2027-12-30",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Stockholm",
-      "country": "Sweden",
-      "continent": "Europe",
-      "lat": 59.3251172,
-      "lon": 18.0710935,
-      "url": "http://www.westiegala.com/",
-      "year": 2027,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-12-31"
+      "projected_from_start": "2026-01-01",
+      "has_results": true
     },
     {
       "id": "expected:184:2028-01-05",
@@ -12060,7 +15550,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-03-12"
+      "projected_from_start": "2026-03-12",
+      "has_results": true
     },
     {
       "id": "expected:143:2028-03-12",
@@ -12280,7 +15771,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-04-09"
+      "projected_from_start": "2026-04-09",
+      "has_results": true
     },
     {
       "id": "expected:352:2028-04-14",
@@ -12566,7 +16058,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-04-30"
+      "projected_from_start": "2026-04-30",
+      "has_results": true
     },
     {
       "id": "expected:354:2028-04-30",
@@ -12588,7 +16081,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-04-30"
+      "projected_from_start": "2026-04-30",
+      "has_results": true
     },
     {
       "id": "expected:372:2028-05-07",
@@ -12632,7 +16126,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-05-07"
+      "projected_from_start": "2026-05-07",
+      "has_results": true
     },
     {
       "id": "expected:175:2028-05-13",
@@ -12654,7 +16149,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-05-13"
+      "projected_from_start": "2026-05-13",
+      "has_results": true
     },
     {
       "id": "expected:205:2028-05-13",
@@ -12742,7 +16238,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-05-15"
+      "projected_from_start": "2026-05-15",
+      "has_results": true
     },
     {
       "id": "expected:121:2028-05-15",
@@ -12764,7 +16261,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-05-15"
+      "projected_from_start": "2026-05-15",
+      "has_results": true
     },
     {
       "id": "expected:221:2028-05-20",
@@ -12830,7 +16328,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-05-22"
+      "projected_from_start": "2026-05-22",
+      "has_results": true
     },
     {
       "id": "expected:22:2028-05-27",
@@ -12874,7 +16373,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-05-30"
+      "projected_from_start": "2025-05-30",
+      "has_results": true
     },
     {
       "id": "expected:371:2028-06-03",
@@ -12940,7 +16440,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-06-04"
+      "projected_from_start": "2026-06-04",
+      "has_results": true
     },
     {
       "id": "expected:117:2028-06-04",
@@ -12962,7 +16463,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-06-04"
+      "projected_from_start": "2026-06-04",
+      "has_results": true
     },
     {
       "id": "expected:222:2028-06-10",
@@ -13050,7 +16552,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-06-18"
+      "projected_from_start": "2026-06-18",
+      "has_results": true
     },
     {
       "id": "expected:374:2028-06-24",
@@ -13138,7 +16641,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-06-25"
+      "projected_from_start": "2026-06-25",
+      "has_results": true
     },
     {
       "id": "expected:369:2028-06-25",
@@ -13182,7 +16686,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-06-26"
+      "projected_from_start": "2026-06-26",
+      "has_results": true
     },
     {
       "id": "expected:278:2028-07-01",
@@ -13248,7 +16753,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-02"
+      "projected_from_start": "2026-07-02",
+      "has_results": true
     },
     {
       "id": "expected:225:2028-07-02",
@@ -13270,7 +16776,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-02"
+      "projected_from_start": "2026-07-02",
+      "has_results": true
     },
     {
       "id": "expected:373:2028-07-08",
@@ -13314,7 +16821,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-09"
+      "projected_from_start": "2026-07-09",
+      "has_results": true
     },
     {
       "id": "expected:362:2028-07-09",
@@ -13336,7 +16844,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-09"
+      "projected_from_start": "2026-07-09",
+      "has_results": true
     },
     {
       "id": "expected:375:2028-07-09",
@@ -13358,7 +16867,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-09"
+      "projected_from_start": "2026-07-09",
+      "has_results": true
     },
     {
       "id": "expected:389:2028-07-10",
@@ -13380,7 +16890,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-10"
+      "projected_from_start": "2026-07-10",
+      "has_results": true
     },
     {
       "id": "expected:224:2028-07-15",
@@ -13415,16 +16926,17 @@
       "weekend_key": "2028-07-13",
       "status": "expected",
       "kind": "registry",
-      "city": "Melbourne",
-      "country": "Australia",
-      "continent": "Australia",
-      "lat": -37.8136276,
-      "lon": 144.9630576,
+      "city": "St. Petersburg",
+      "country": "Russia",
+      "continent": "Europe",
+      "lat": 59.9310584,
+      "lon": 30.3609097,
       "url": "https://revitalisewcs.melbourne/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-16"
+      "projected_from_start": "2026-07-16",
+      "has_results": true
     },
     {
       "id": "expected:256:2028-07-17",
@@ -13446,7 +16958,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-17"
+      "projected_from_start": "2026-07-17",
+      "has_results": true
     },
     {
       "id": "expected:280:2028-07-22",
@@ -13468,7 +16981,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-22"
+      "projected_from_start": "2026-07-22",
+      "has_results": true
     },
     {
       "id": "expected:149:2028-07-23",
@@ -13490,7 +17004,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-23"
+      "projected_from_start": "2026-07-23",
+      "has_results": true
     },
     {
       "id": "expected:404:2028-07-23",
@@ -13512,7 +17027,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-23"
+      "projected_from_start": "2026-07-23",
+      "has_results": true
     },
     {
       "id": "expected:164:2028-07-25",
@@ -13534,7 +17050,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-07-25"
+      "projected_from_start": "2026-07-25",
+      "has_results": true
     },
     {
       "id": "expected:382:2028-07-30",
@@ -13572,8 +17089,8 @@
       "city": "Warsaw",
       "country": "Poland",
       "continent": "Europe",
-      "lat": 52.2296756,
-      "lon": 21.0122287,
+      "lat": 38.9072873,
+      "lon": -77.0369274,
       "url": "https://www.summernightswestival.com/",
       "year": 2028,
       "source": "expected_yoy",
@@ -13710,7 +17227,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-08-07"
+      "projected_from_start": "2025-08-07",
+      "has_results": true
     },
     {
       "id": "expected:384:2028-08-14",
@@ -13733,6 +17251,29 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-08-14"
+    },
+    {
+      "id": "expected:264:2028-08-15",
+      "event_id": 264,
+      "name": "Swedish Swing Summer Camp",
+      "start_date": "2028-08-15",
+      "end_date": "2028-08-18",
+      "weekend_start": "2028-08-10",
+      "weekend_end": "2028-08-13",
+      "weekend_key": "2028-08-10",
+      "status": "expected",
+      "kind": "registry",
+      "city": "Stockholm",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 59.3251172,
+      "lon": 18.0710935,
+      "url": "http://www.uptownswing.se/",
+      "year": 2028,
+      "source": "expected_yoy",
+      "projected_from_year": 2025,
+      "projected_from_start": "2025-08-15",
+      "has_results": true
     },
     {
       "id": "expected:298:2028-08-20",
@@ -13842,7 +17383,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-08-21"
+      "projected_from_start": "2025-08-21",
+      "has_results": true
     },
     {
       "id": "expected:135:2028-08-27",
@@ -13924,8 +17466,8 @@
       "city": "Jeju",
       "country": "Republic of Korea",
       "continent": "Asia",
-      "lat": 33.5042779,
-      "lon": 126.519838,
+      "lat": 49.1950602,
+      "lon": 16.6068371,
       "url": "http://koreawestival.com/",
       "year": 2028,
       "source": "expected_yoy",
@@ -14298,8 +17840,8 @@
       "city": "Östersund",
       "country": "Sweden",
       "continent": "Europe",
-      "lat": 63.1766832,
-      "lon": 14.6360681,
+      "lat": 33.4482948,
+      "lon": -112.0725488,
       "url": "https://mooselandswing.com/",
       "year": 2028,
       "source": "expected_yoy",
@@ -14406,8 +17948,8 @@
       "city": "Montreal",
       "country": "Canada",
       "continent": "America",
-      "lat": 45.5018869,
-      "lon": -73.56739189999999,
+      "lat": 40.7127753,
+      "lon": -74.0059728,
       "url": "http://montrealwestiefest.com/",
       "year": 2028,
       "source": "expected_yoy",
@@ -14434,7 +17976,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-10-10"
+      "projected_from_start": "2025-10-10",
+      "has_results": true
     },
     {
       "id": "expected:322:2028-10-15",
@@ -14472,8 +18015,8 @@
       "city": "Auckland",
       "country": "New Zealand",
       "continent": "Australia",
-      "lat": -36.85088270000001,
-      "lon": 174.7644881,
+      "lat": -31.9513993,
+      "lon": 115.8616783,
       "url": "https://www.streetswing.co.nz/the-new-zealand-open",
       "year": 2028,
       "source": "expected_yoy",
@@ -15116,7 +18659,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2025,
-      "projected_from_start": "2025-12-05"
+      "projected_from_start": "2025-12-05",
+      "has_results": true
     },
     {
       "id": "expected:271:2028-12-10",


### PR DESCRIPTION
## Summary
- Past years: Confirmed = distinct `event_id` with `has_results` (2025 → **172**).
- Day grid skips `stats_only` rows; ISO day clipping to selected year unchanged.
- Refreshed `events_year_calendar.json` from pipeline (cross-year Dec→Jan day dates restored where WSDC calendar has them).

## Test plan
- [ ] Open Events Calendar → year **2025** → Confirmed shows **172**
- [ ] Floorplay / Spotlight / etc. appear on **Jan** days only (not Dec 2024 cells in 2025 view)
- [ ] Gateway / Indy count in Confirmed but have no day pin (`stats_only`)
- [ ] Current year 2026 still shows remaining `of N` for Confirmed / Expected / Registry / Trial

Depends on pipeline: calendar build + `has_results` / `stats_only` flags.


Made with [Cursor](https://cursor.com)