### PR TITLE
Bust events calendar JSON cache

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="static/css/site-chrome.css">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
-    <link rel="preload" href="static/data/events_year_calendar.json" as="fetch" crossorigin>
+    <link rel="preload" href="static/data/events_year_calendar.json?v=20260804" as="fetch" crossorigin>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMLCY5PE8Z"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -1066,7 +1066,7 @@
   var params = new URLSearchParams(window.location.search);
   if (params.get("lang") && I18N[params.get("lang")]) state.lang = params.get("lang");
 
-  fetch("static/data/events_year_calendar.json")
+  fetch("static/data/events_year_calendar.json?v=20260804")
     .then(function (r) {
       if (!r.ok) throw new Error("Failed to load calendar data");
       return r.json();


### PR DESCRIPTION
## Summary
- Append `?v=20260804` to `events_year_calendar.json` preload and fetch URLs.
- Forces clients/CDN to request fresh JSON that includes `has_results` and updated 2025 counts.

## Test plan
- Open `events-calendar.html` on production
- Verify network request goes to `events_year_calendar.json?v=20260804`
- Verify year 2025 Confirmed shows 172

Made with [Cursor](https://cursor.com)