### PR TITLE
Hide 2024 from Events Calendar year filter

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -648,9 +648,15 @@
   }
 
   function renderYearSelect() {
-    var years = (state.data.years || []).map(function (y) {
+    var years = (state.data.years || []).filter(function (y) {
+      return Number(y) >= 2025;
+    }).map(function (y) {
       return { value: String(y), label: String(y) };
     });
+    if (!years.length) return;
+    if (!years.some(function (opt) { return Number(opt.value) === state.year; })) {
+      state.year = Number(years[0].value);
+    }
     fillDropdown(
       document.getElementById("yearSelectMenu"),
       document.getElementById("yearSelectValue"),


### PR DESCRIPTION
## Summary
- Filter year selector options to `>= 2025`.
- Keep payload unchanged; this is UI-only.
- Add guard to reset selected year if it is not in visible options.

## Test plan
- Open Events Calendar and verify year dropdown does not include 2024.
- Confirm 2025 is selectable and cards/grid still render normally.

Made with [Cursor](https://cursor.com)