### PR TITLE
Refresh calendar JSON after Swedish/UpTown series fix

### DIFF
--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-04",
-  "generated_at": "2026-08-04T08:29:01Z",
+  "generated_at": "2026-08-04T08:57:37Z",
   "years": [
     2024,
     2025,
@@ -24,7 +24,7 @@
   "counts_by_year": {
     "2024": 139,
     "2025": 179,
-    "2026": 191,
+    "2026": 190,
     "2027": 188,
     "2028": 184
   },
@@ -9311,29 +9311,6 @@
       "url": "http://www.uptownswing.se/",
       "year": 2026,
       "source": "scheduled_events"
-    },
-    {
-      "id": "expected:264:2026-08-15",
-      "event_id": 264,
-      "name": "Swedish Swing Summer Camp",
-      "start_date": "2026-08-15",
-      "end_date": "2026-08-18",
-      "weekend_start": "2026-08-13",
-      "weekend_end": "2026-08-16",
-      "weekend_key": "2026-08-13",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Stockholm",
-      "country": "Sweden",
-      "continent": "Europe",
-      "lat": 59.3251172,
-      "lon": 18.0710935,
-      "url": "http://www.uptownswing.se/",
-      "year": 2026,
-      "source": "expected_yoy",
-      "projected_from_year": 2025,
-      "projected_from_start": "2025-08-15",
-      "has_results": true
     },
     {
       "id": "confirmed:298:2026-08-20",


### PR DESCRIPTION
## Summary
- Rebuilt `static/data/events_year_calendar.json` from latest pipeline `main`.
- Applies series successor suppression logic (`264` legacy Swedish suppressed when `493` UpTown is published in target year).

## Validation
- 2026 Swedish/UpTown rows now: only `confirmed 493 UpTown Swing`.
- 2025 results-backed Confirmed count remains consistent.

Made with [Cursor](https://cursor.com)