### PR TITLE
Bump calendar JSON cache key to 20260804b

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="static/css/site-chrome.css">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
-    <link rel="preload" href="static/data/events_year_calendar.json?v=20260804" as="fetch" crossorigin>
+    <link rel="preload" href="static/data/events_year_calendar.json?v=20260804b" as="fetch" crossorigin>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMLCY5PE8Z"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -1072,7 +1072,7 @@
   var params = new URLSearchParams(window.location.search);
   if (params.get("lang") && I18N[params.get("lang")]) state.lang = params.get("lang");
 
-  fetch("static/data/events_year_calendar.json?v=20260804")
+  fetch("static/data/events_year_calendar.json?v=20260804b")
     .then(function (r) {
       if (!r.ok) throw new Error("Failed to load calendar data");
       return r.json();


### PR DESCRIPTION
## Summary
- Change Events Calendar preload/fetch URL to `events_year_calendar.json?v=20260804b`.
- Forces clients to bypass stale CDN/browser cache and load latest JSON.

## Test plan
- Open production Events Calendar
- Verify network request uses `?v=20260804b`
- Verify 2026 no longer shows `expected Swedish Swing Summer Camp`

Made with [Cursor](https://cursor.com)