### PR TITLE
Publish Soul Flow 2026 hiatus on Events Calendar

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="static/css/site-chrome.css">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
-    <link rel="preload" href="static/data/events_year_calendar.json?v=20260804b" as="fetch" crossorigin>
+    <link rel="preload" href="static/data/events_year_calendar.json?v=20260804c" as="fetch" crossorigin>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMLCY5PE8Z"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -1072,7 +1072,7 @@
   var params = new URLSearchParams(window.location.search);
   if (params.get("lang") && I18N[params.get("lang")]) state.lang = params.get("lang");
 
-  fetch("static/data/events_year_calendar.json?v=20260804b")
+  fetch("static/data/events_year_calendar.json?v=20260804c")
     .then(function (r) {
       if (!r.ok) throw new Error("Failed to load calendar data");
       return r.json();

--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-04",
-  "generated_at": "2026-08-04T08:57:37Z",
+  "generated_at": "2026-08-04T12:26:31Z",
   "years": [
     2024,
     2025,
@@ -24,8 +24,8 @@
   "counts_by_year": {
     "2024": 139,
     "2025": 179,
-    "2026": 190,
-    "2027": 188,
+    "2026": 191,
+    "2027": 189,
     "2028": 184
   },
   "disclaimer": {
@@ -9071,7 +9071,7 @@
     {
       "id": "hiatus:148:2026-07-24",
       "event_id": 148,
-      "name": "Dance Mardi Gras (Hiatus -- 2026)",
+      "name": "Dance Mardi Gras",
       "start_date": "2026-07-24",
       "end_date": "2026-07-27",
       "weekend_start": "2026-07-23",
@@ -9086,7 +9086,7 @@
       "lon": -90.0758356,
       "url": "https://dancemardigras.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "operator_override"
     },
     {
       "id": "confirmed:164:2026-07-25",
@@ -10740,6 +10740,26 @@
       "url": "https://www.santaswing.pl/",
       "year": 2026,
       "source": "scheduled_events"
+    },
+    {
+      "id": "hiatus:990001:2026-12-11",
+      "event_id": 990001,
+      "name": "Soul Flow - West Coast Swing Festival (Hiatus -- 2026)",
+      "start_date": "2026-12-11",
+      "end_date": "2026-12-13",
+      "weekend_start": "2026-12-10",
+      "weekend_end": "2026-12-13",
+      "weekend_key": "2026-12-10",
+      "status": "hiatus",
+      "kind": "registry",
+      "city": "Toulouse",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 43.6048462,
+      "lon": 1.442848,
+      "url": "https://www.globalgrandprixwcs.com/",
+      "year": 2026,
+      "source": "operator_override"
     },
     {
       "id": "confirmed:x:2026-12-18",
@@ -14759,6 +14779,26 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-12-10"
+    },
+    {
+      "id": "expected:990001:2027-12-10",
+      "event_id": 990001,
+      "name": "Soul Flow - West Coast Swing Festival",
+      "start_date": "2027-12-10",
+      "end_date": "2027-12-12",
+      "weekend_start": "2027-12-09",
+      "weekend_end": "2027-12-12",
+      "weekend_key": "2027-12-09",
+      "status": "expected",
+      "kind": "registry",
+      "city": "Toulouse",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 43.6048462,
+      "lon": 1.442848,
+      "url": "https://www.globalgrandprixwcs.com/",
+      "year": 2027,
+      "source": "operator_override"
     },
     {
       "id": "expected:75:2028-01-01",


### PR DESCRIPTION
## Summary
- Refresh `events_year_calendar.json` after pipeline Soul Flow provisional override.
- 2026: hiatus Soul Flow (provisional id 990001); 2027: expected return.
- Cache-bust fetch URL to `?v=20260804c`.

## Test plan
- Open Events Calendar 2026 → December → Soul Flow hiatus visible
- Confirm Global Grand Prix 2026 still only September confirmed
- 2027 shows Soul Flow as expected

Made with [Cursor](https://cursor.com)