### PR TITLE
Separate calendar stats into confirm status vs event type

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -114,6 +114,7 @@
                         <span class="cal-stats__tip-bubble" id="calStatsTipText" role="tooltip" data-i18n="statTip">For the current year, remaining counts with muted year totals; past and future years show full-year totals.</span>
                     </button>
                 </div>
+                <div class="cal-stats__group" aria-label="Confirm status">
                 <div class="cal-stats__item">
                     <span class="cal-stats__label" data-i18n="statConfirmed">Confirmed</span>
                     <span class="cal-stats__nums" data-stat="confirmed">
@@ -135,6 +136,8 @@
                         <span class="cal-stats__of" hidden></span>
                     </span>
                 </div>
+                </div>
+                <div class="cal-stats__group cal-stats__group--types" aria-label="Event type">
                 <div class="cal-stats__item">
                     <span class="cal-stats__label" data-i18n="statRegistry">Registry</span>
                     <span class="cal-stats__nums" data-stat="registry">
@@ -148,6 +151,7 @@
                         <span class="cal-stats__value">0</span>
                         <span class="cal-stats__of" hidden></span>
                     </span>
+                </div>
                 </div>
             </aside>
             <div id="calendarRoot"></div>

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -327,7 +327,7 @@ h1 {
   width: 108px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0;
   padding: 0;
   pointer-events: none;
 }
@@ -342,6 +342,18 @@ h1 {
   display: flex;
   justify-content: flex-start;
   min-height: 18px;
+  margin-bottom: 8px;
+}
+
+.cal-stats__group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Visual split: confirm status vs event type (no divider line) */
+.cal-stats__group--types {
+  margin-top: 60px;
 }
 
 .cal-stats__tip {
@@ -941,6 +953,18 @@ h1 {
   .cal-stats__head {
     width: 100%;
     min-height: 0;
+    margin-bottom: 0;
+  }
+  .cal-stats__group {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 8px 14px;
+  }
+  .cal-stats__group--types {
+    margin-top: 0;
+    width: 100%;
+    padding-top: 12px;
   }
   .cal-stats__tip-bubble {
     left: 0;


### PR DESCRIPTION
## Summary
- Group left-rail counters into confirm status (Confirmed / Expected / Hiatus) and event type (Registry / Trial).
- Add a 60px vertical gap between the groups; no divider line.

## Test plan
- Open Events Calendar on desktop and confirm a clear empty gap after Hiatus / Cancelled before Registry.
- Check mobile layout still stacks counters readably.

Made with [Cursor](https://cursor.com)