### PR TITLE
Events calendar: cream grouped day tooltip

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -783,18 +783,74 @@
     });
   }
 
+  function tipGroupKey(status) {
+    if (status === "expected") return "expected";
+    if (status === "hiatus" || status === "cancelled") return "paused";
+    return "confirmed";
+  }
+
+  function sortEventsByName(a, b) {
+    return String(a.name || "").localeCompare(String(b.name || ""), undefined, {
+      sensitivity: "base"
+    });
+  }
+
+  function tipKindLabel(kind) {
+    return kind === "trial" ? t("statTrial") : t("statRegistry");
+  }
+
+  function tipKindClass(kind) {
+    return kind === "trial" ? "trial" : "registry";
+  }
+
+  function buildDayTooltipHtml(list) {
+    var buckets = { confirmed: [], expected: [], paused: [] };
+    (list || []).forEach(function (e) {
+      buckets[tipGroupKey(e.status)].push(e);
+    });
+    ["confirmed", "expected", "paused"].forEach(function (key) {
+      buckets[key].sort(sortEventsByName);
+    });
+    var ordered = buckets.confirmed.concat(buckets.expected, buckets.paused);
+    var more = Math.max(0, ordered.length - 10);
+    ordered = ordered.slice(0, 10);
+
+    var shown = { confirmed: [], expected: [], paused: [] };
+    ordered.forEach(function (e) {
+      shown[tipGroupKey(e.status)].push(e);
+    });
+
+    var html = "";
+    ["confirmed", "expected", "paused"].forEach(function (key) {
+      var rows = shown[key];
+      if (!rows.length) return;
+      html += '<div class="tooltip-group tooltip-group--' + key + '">';
+      rows.forEach(function (e) {
+        var where = [e.city, e.country].filter(Boolean).join(", ");
+        html +=
+          '<div class="tooltip-row">' +
+          '<div class="tooltip-row__main">' +
+          '<div class="tooltip-row__name">' + esc(e.name) + "</div>" +
+          '<div class="tooltip-row__where">' + esc(where) + "</div>" +
+          "</div>" +
+          '<div class="tooltip-row__meta">' +
+          '<span class="badge ' + esc(e.status) + '">' + esc(statusLabel(e.status)) + "</span>" +
+          '<span class="badge ' + tipKindClass(e.kind) + '">' + esc(tipKindLabel(e.kind)) + "</span>" +
+          "</div></div>";
+      });
+      html += "</div>";
+    });
+    if (more > 0) {
+      html += '<div class="tooltip-more">… +' + more + "</div>";
+    }
+    return html;
+  }
+
   function showTooltip(ev, dayIso) {
     var tip = document.getElementById("tooltip");
     var list = state.byDay[dayIso] || [];
     if (!list.length) return;
-    tip.innerHTML = list.slice(0, 8).map(function (e) {
-      var where = [e.city, e.country].filter(Boolean).join(", ");
-      var span = esc(e.start_date) + (e.end_date && e.end_date !== e.start_date ? " - " + esc(e.end_date) : "");
-      return "<div><strong>" + esc(e.name) + "</strong>" +
-        (where ? " - " + esc(where) : "") +
-        '<div class="status-line">' + span + " · " + esc(e.status) + " · " + esc(e.kind) + "</div></div>";
-    }).join("");
-    if (list.length > 8) tip.innerHTML += "<div>… +" + (list.length - 8) + "</div>";
+    tip.innerHTML = buildDayTooltipHtml(list);
     tip.classList.add("is-visible");
     moveTooltip(ev);
   }
@@ -912,7 +968,7 @@
         '<div class="event-meta">' + span + (where ? " · " + esc(where) : "") + "</div>" +
         '<div class="badges">' +
         '<span class="badge ' + esc(e.status) + '">' + esc(statusLabel(e.status)) + "</span>" +
-        '<span class="badge ' + (e.kind === "trial" ? "trial" : "") + '">' +
+        '<span class="badge ' + (e.kind === "trial" ? "trial" : "registry") + '">' +
         esc(e.kind === "trial" ? t("trial") : t("registry")) + "</span>" +
         "</div></button>";
     }).join("");
@@ -943,7 +999,7 @@
     if (where) html += '<p class="event-meta">' + t("location") + ": " + esc(where) + "</p>";
     html += '<div class="badges">' +
       '<span class="badge ' + esc(e.status) + '">' + esc(statusLabel(e.status)) + "</span>" +
-      '<span class="badge ' + (e.kind === "trial" ? "trial" : "") + '">' +
+      '<span class="badge ' + (e.kind === "trial" ? "trial" : "registry") + '">' +
       esc(e.kind === "trial" ? t("trial") : t("registry")) + "</span></div>";
     if (e.projected_from_year) {
       html += '<p class="event-meta" style="margin-top:8px">' + t("projected") + " " +

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -4,6 +4,7 @@
   --color-accent: #2563eb;
   --bg-secondary: #FFFFFF;
   --bg-tertiary: #f7fafc;
+  --tip-bg: #F8F5F0;
   --text-primary: #0B1221;
   --text-secondary: #4a5568;
   --text-tertiary: #6B7280;
@@ -12,10 +13,12 @@
   --status-expected: #9ca3af;
   --status-cancelled: #dc2626;
   --status-hiatus: #d97706;
+  --status-paused: #e11d48;
   --radius: 8px;
   --radius-sm: 5px;
   --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
   --shadow-soft: 0 4px 14px rgba(15, 23, 42, 0.07);
+  --shadow-tip: 0 8px 24px rgba(15, 23, 42, 0.12);
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -820,6 +823,7 @@ h1 {
 .badge.expected { background: rgba(156, 163, 175, 0.25); color: #4b5563; }
 .badge.cancelled { background: rgba(220, 38, 38, 0.12); color: #b91c1c; }
 .badge.hiatus { background: rgba(217, 119, 6, 0.15); color: #b45309; }
+.badge.registry { background: rgba(15, 118, 110, 0.1); color: #0f766e; }
 .badge.trial { background: rgba(37, 99, 235, 0.1); color: #1d4ed8; }
 
 .detail {
@@ -846,14 +850,14 @@ h1 {
 .tooltip {
   position: fixed;
   z-index: 80;
-  max-width: min(280px, calc(100vw - 16px));
-  max-height: min(50vh, calc(100dvh - 16px));
-  overflow: auto;
-  background: #0B1221;
-  color: #fff;
+  max-width: min(360px, calc(100vw - 16px));
+  background: var(--tip-bg);
+  color: var(--text-primary);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: var(--shadow-tip);
   font-size: 11px;
   line-height: 1.35;
-  padding: 7px 9px;
+  padding: 8px 10px;
   border-radius: var(--radius-sm);
   pointer-events: none;
   opacity: 0;
@@ -866,7 +870,87 @@ h1 {
   transform: scale(1);
 }
 
-.status-line { margin-top: 3px; font-size: 10px; opacity: 0.85; }
+.tooltip-group + .tooltip-group {
+  margin-top: 10px;
+}
+
+.tooltip-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  column-gap: 10px;
+  align-items: start;
+}
+
+.tooltip-row + .tooltip-row {
+  margin-top: 8px;
+}
+
+.tooltip-row__main {
+  min-width: 0;
+}
+
+.tooltip-row__name {
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 1.3;
+  color: var(--text-primary);
+}
+
+.tooltip-row__where {
+  margin-top: 2px;
+  font-size: 11px;
+  line-height: 1.3;
+  color: var(--text-secondary);
+}
+
+.tooltip-row__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.tooltip-row__meta .badge {
+  font-size: 9px;
+  padding: 1px 6px;
+  white-space: nowrap;
+}
+
+/* Tip: one rose token for hiatus + cancelled pills */
+.tooltip .badge.hiatus,
+.tooltip .badge.cancelled {
+  background: rgba(225, 29, 72, 0.12);
+  color: #be123c;
+}
+
+.tooltip-group--confirmed .tooltip-row__name {
+  color: var(--text-primary);
+}
+.tooltip-group--confirmed .tooltip-row__where {
+  color: var(--text-secondary);
+}
+
+.tooltip-group--expected .tooltip-row__name {
+  color: #6b7280;
+}
+.tooltip-group--expected .tooltip-row__where {
+  color: #9ca3af;
+}
+
+.tooltip-group--paused .tooltip-row__name {
+  color: #9f1239;
+}
+.tooltip-group--paused .tooltip-row__where {
+  color: #fb7185;
+}
+
+.tooltip-more {
+  margin-top: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+}
 
 .error {
   padding: 14px;


### PR DESCRIPTION
## Summary
- Cream tip surface (`#F8F5F0`) with dark text; remove white-on-black.
- Group day events Confirmed → Expected → Hiatus/Cancelled (gap only, no section titles).
- Two-column row: name + location | stacked status + kind pills (`Registry` / `Trial` short labels).
- Text tint by group; one rose token for paused pills (label still Hiatus or Cancelled).
- Cap 10 + overflow count; no tip scroll; width ~360px. Counters unchanged.

## Test plan
- [ ] Hover a dense day with mixed statuses — groups order + A→Z within group
- [ ] Expected rows look gray; paused rows rose-muted; confirmed dark
- [ ] Pills: status + kind stacked right; no dates on tip
- [ ] >10 events shows `… +N` without scrollbar
- [ ] EN/RU/ES status labels on pills; Registry/Trial from stat labels
- [ ] Click day still opens map panel as before


Made with [Cursor](https://cursor.com)