### PR TITLE
Calendar tooltip: use --bg-tertiary surface

### DIFF
--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -4,7 +4,6 @@
   --color-accent: #2563eb;
   --bg-secondary: #FFFFFF;
   --bg-tertiary: #f7fafc;
-  --tip-bg: #F8F5F0;
   --text-primary: #0B1221;
   --text-secondary: #4a5568;
   --text-tertiary: #6B7280;
@@ -851,7 +850,7 @@ h1 {
   position: fixed;
   z-index: 80;
   max-width: min(360px, calc(100vw - 16px));
-  background: var(--tip-bg);
+  background: var(--bg-tertiary);
   color: var(--text-primary);
   border: 1px solid rgba(15, 23, 42, 0.08);
   box-shadow: var(--shadow-tip);


### PR DESCRIPTION
## Summary
- Day tooltip background switches from cream `#F8F5F0` to `--bg-tertiary` (`#f7fafc`), matching filters/panels.
- Removes unused `--tip-bg` token.

## Test plan
- [ ] Hover a calendar day — tip reads cool light gray, not cream
- [ ] Text/pills contrast still readable on the new surface


Made with [Cursor](https://cursor.com)