### PR TITLE
Calendar tooltip: status as group label pill

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -803,6 +803,18 @@
     return kind === "trial" ? "trial" : "registry";
   }
 
+  function tipGroupLabel(key) {
+    if (key === "expected") return t("statExpected");
+    if (key === "paused") return t("statPaused");
+    return t("statConfirmed");
+  }
+
+  function tipGroupBadgeClass(key) {
+    if (key === "expected") return "expected";
+    if (key === "paused") return "paused";
+    return "confirmed";
+  }
+
   function buildDayTooltipHtml(list) {
     var buckets = { confirmed: [], expected: [], paused: [] };
     (list || []).forEach(function (e) {
@@ -825,6 +837,11 @@
       var rows = shown[key];
       if (!rows.length) return;
       html += '<div class="tooltip-group tooltip-group--' + key + '">';
+      html +=
+        '<div class="tooltip-group__label">' +
+        '<span class="badge ' + tipGroupBadgeClass(key) + '">' +
+        esc(tipGroupLabel(key)) +
+        "</span></div>";
       rows.forEach(function (e) {
         var where = [e.city, e.country].filter(Boolean).join(", ");
         html +=
@@ -834,8 +851,9 @@
           '<div class="tooltip-row__where">' + esc(where) + "</div>" +
           "</div>" +
           '<div class="tooltip-row__meta">' +
-          '<span class="badge ' + esc(e.status) + '">' + esc(statusLabel(e.status)) + "</span>" +
-          '<span class="badge ' + tipKindClass(e.kind) + '">' + esc(tipKindLabel(e.kind)) + "</span>" +
+          '<span class="badge ' + tipKindClass(e.kind) + '">' +
+          esc(tipKindLabel(e.kind)) +
+          "</span>" +
           "</div></div>";
       });
       html += "</div>";

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -873,6 +873,16 @@ h1 {
   margin-top: 10px;
 }
 
+.tooltip-group__label {
+  margin-bottom: 6px;
+}
+
+.tooltip-group__label .badge {
+  font-size: 9px;
+  padding: 1px 6px;
+  white-space: nowrap;
+}
+
 .tooltip-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -906,7 +916,6 @@ h1 {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 3px;
   flex-shrink: 0;
 }
 
@@ -916,9 +925,7 @@ h1 {
   white-space: nowrap;
 }
 
-/* Tip: one rose token for hiatus + cancelled pills */
-.tooltip .badge.hiatus,
-.tooltip .badge.cancelled {
+.badge.paused {
   background: rgba(225, 29, 72, 0.12);
   color: #be123c;
 }


### PR DESCRIPTION
## Summary
- Confirm status is a group badge above the first event in each tip section (`Confirmed` / `Expected` / `Hiatus / Cancelled`).
- Event type (`Registry` / `Trial`) stays on each event row.
- Per-event status pills removed from the tip.

## Test plan
- [ ] Hover a day with confirmed + expected — two group pills, kind on each row
- [ ] Day with hiatus/cancelled — one rose `Hiatus / Cancelled` group pill
- [ ] Single-status day — one group pill only
- [ ] Kind pills still Registry/Trial on the right


Made with [Cursor](https://cursor.com)