### PR TITLE
Tooltip colors: Registry indigo, no paused text tint

### DIFF
--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -822,7 +822,7 @@ h1 {
 .badge.expected { background: rgba(156, 163, 175, 0.25); color: #4b5563; }
 .badge.cancelled { background: rgba(220, 38, 38, 0.12); color: #b91c1c; }
 .badge.hiatus { background: rgba(217, 119, 6, 0.15); color: #b45309; }
-.badge.registry { background: rgba(15, 118, 110, 0.1); color: #0f766e; }
+.badge.registry { background: rgba(79, 70, 229, 0.12); color: #4338ca; }
 .badge.trial { background: rgba(37, 99, 235, 0.1); color: #1d4ed8; }
 
 .detail {
@@ -942,13 +942,6 @@ h1 {
 }
 .tooltip-group--expected .tooltip-row__where {
   color: #9ca3af;
-}
-
-.tooltip-group--paused .tooltip-row__name {
-  color: #9f1239;
-}
-.tooltip-group--paused .tooltip-row__where {
-  color: #fb7185;
 }
 
 .tooltip-more {


### PR DESCRIPTION
## Summary
- Registry badge: teal → indigo (`#4338ca`) so it no longer blends with Confirmed green.
- Tip hiatus/cancelled rows: remove rose text tint; keep normal primary/secondary text (paused group pill stays rose).

## Test plan
- [ ] Tip with Registry + Confirmed — pills clearly different colors
- [ ] Tip with Trial still blue; Registry indigo
- [ ] Hiatus / Cancelled group: rose group pill, dark/normal event name + place text


Made with [Cursor](https://cursor.com)