### PR TITLE
Trial yellow + confirmed tip sort Registry→Trial

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -795,6 +795,16 @@
     });
   }
 
+  function tipKindRank(kind) {
+    return kind === "trial" ? 1 : 0;
+  }
+
+  function sortConfirmedTipEvents(a, b) {
+    var kindDiff = tipKindRank(a.kind) - tipKindRank(b.kind);
+    if (kindDiff !== 0) return kindDiff;
+    return sortEventsByName(a, b);
+  }
+
   function tipKindLabel(kind) {
     return kind === "trial" ? t("statTrial") : t("statRegistry");
   }
@@ -820,9 +830,9 @@
     (list || []).forEach(function (e) {
       buckets[tipGroupKey(e.status)].push(e);
     });
-    ["confirmed", "expected", "paused"].forEach(function (key) {
-      buckets[key].sort(sortEventsByName);
-    });
+    buckets.confirmed.sort(sortConfirmedTipEvents);
+    buckets.expected.sort(sortEventsByName);
+    buckets.paused.sort(sortEventsByName);
     var ordered = buckets.confirmed.concat(buckets.expected, buckets.paused);
     var more = Math.max(0, ordered.length - 10);
     ordered = ordered.slice(0, 10);

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -823,7 +823,7 @@ h1 {
 .badge.cancelled { background: rgba(220, 38, 38, 0.12); color: #b91c1c; }
 .badge.hiatus { background: rgba(217, 119, 6, 0.15); color: #b45309; }
 .badge.registry { background: rgba(79, 70, 229, 0.12); color: #4338ca; }
-.badge.trial { background: rgba(37, 99, 235, 0.1); color: #1d4ed8; }
+.badge.trial { background: rgba(234, 179, 8, 0.18); color: #a16207; }
 
 .detail {
   margin-top: 8px;


### PR DESCRIPTION
## Summary
- Trial badge: blue → yellow/gold (`#a16207` on soft yellow tint), separate from Registry indigo and Hiatus amber.
- Confirmed tip group: sort **Registry first, then Trial** (A–Z within each kind). Expected / paused stay name-only.

## Test plan
- [ ] Tip / cards: Trial yellow, Registry indigo, Confirmed green
- [ ] Confirmed group with mixed kinds — all Registry rows above Trial rows
- [ ] Within Registry / Trial — still A–Z by name