### PR TITLE
Events Calendar L2: day island instead of fullscreen panel

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -49,7 +49,7 @@
     <main id="main" class="container">
         <header class="page-head">
             <h1 data-i18n="title">Events Calendar</h1>
-            <p class="subtitle" data-i18n="subtitle">Year overview of WSDC registry and trial events. Day fill shows how many events overlap that date (1–2 / 3–4 / 5+). Click a day for the map and cards. Past years and past days are muted; today is outlined.</p>
+            <p class="subtitle" data-i18n="subtitle">Year overview of WSDC registry and trial events. Day fill shows how many events overlap that date (1–2 / 3–4 / 5+). Click a day for the map and event list. Past years and past days are muted; today is outlined.</p>
             <p class="disclaimer" id="disclaimer"></p>
             <div class="toolbar">
                 <div class="filters" role="toolbar" aria-label="Filters">
@@ -182,25 +182,34 @@
                 </div>
             </aside>
         </div>
-        <section class="panel" id="weekendPanel" aria-live="polite">
-            <div class="panel-inner">
-            <div class="panel-head">
-                <h2 id="weekendTitle"></h2>
-                <button type="button" class="panel-close" id="closePanel" data-i18n="close">Close</button>
-            </div>
-            <div class="panel-map-col">
-            <div id="noGeoNote" class="no-geo" hidden></div>
-            <div id="weekendMap" role="img" aria-label="Weekend events map"></div>
-            </div>
-            <div class="panel-list-col">
-            <div class="event-list" id="eventList"></div>
-            <div class="detail" id="eventDetail"></div>
-            </div>
-            </div>
-        </section>
     </main>
     </div>
     <div class="tooltip" id="tooltip" role="tooltip"></div>
+    <div class="day-layer" id="dayLayer" hidden aria-hidden="true">
+        <div class="day-layer__backdrop" id="dayLayerBackdrop"></div>
+        <div
+            class="day-island"
+            id="dayIsland"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="dayIslandTitle"
+        >
+            <div class="day-island__head">
+                <h2 id="dayIslandTitle"></h2>
+                <button type="button" class="day-island__close" id="closeDayIsland" data-i18n="close">Close</button>
+            </div>
+            <div class="day-island__body">
+                <div class="day-island__map-col">
+                    <div id="noGeoNote" class="no-geo" hidden></div>
+                    <div id="dayMap" role="img" aria-label="Day events map"></div>
+                </div>
+                <div class="day-island__list-col">
+                    <div class="day-island__list" id="eventList"></div>
+                    <div class="detail" id="eventDetail"></div>
+                </div>
+            </div>
+        </div>
+    </div>
     <script src="static/js/site-chrome.js"></script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
     <script>
@@ -210,7 +219,7 @@
   var I18N = {
     en: {
       title: "Events Calendar",
-      subtitle: "Year overview of WSDC registry and trial events. Day fill shows how many events overlap that date (1–2 / 3–4 / 5+). Click a day for the map and cards. Past years and past days are muted; today is outlined.",
+      subtitle: "Year overview of WSDC registry and trial events. Day fill shows how many events overlap that date (1–2 / 3–4 / 5+). Click a day for the map and event list. Past years and past days are muted; today is outlined.",
       year: "Year",
       continent: "Continent",
       country: "Country",
@@ -252,7 +261,7 @@
     },
     ru: {
       title: "Календарь ивентов",
-      subtitle: "Годовой обзор registry и trial ивентов WSDC. Заливка дня = сколько ивентов пересекаются с датой (1–2 / 3–4 / 5+). Клик открывает карту и карточки. Прошлые годы и прошедшие дни приглушены, сегодня — обведено.",
+      subtitle: "Годовой обзор registry и trial ивентов WSDC. Заливка дня = сколько ивентов пересекаются с датой (1–2 / 3–4 / 5+). Клик открывает карту и список. Прошлые годы и прошедшие дни приглушены, сегодня — обведено.",
       year: "Год",
       continent: "Континент",
       country: "Страна",
@@ -294,7 +303,7 @@
     },
     es: {
       title: "Calendario de eventos",
-      subtitle: "Vista anual de eventos registry y trial de WSDC. El color del dia indica cuantos eventos coinciden (1–2 / 3–4 / 5+). Haz clic para el mapa y las fichas. Los años y dias pasados se atenúan; hoy va marcado.",
+      subtitle: "Vista anual de eventos registry y trial de WSDC. El color del dia indica cuantos eventos coinciden (1–2 / 3–4 / 5+). Haz clic para el mapa y la lista. Los años y dias pasados se atenúan; hoy va marcado.",
       year: "Año",
       continent: "Continente",
       country: "País",
@@ -350,8 +359,13 @@
     kind: "",
     byDay: {},
     selectedDay: null,
+    selectedEventId: null,
+    hoverEventId: null,
+    l2Open: false,
+    l2Origin: null,
     map: null,
-    markers: null
+    markers: null,
+    markerById: {}
   };
 
   function t(key) {
@@ -875,6 +889,7 @@
   }
 
   function showTooltip(ev, dayIso) {
+    if (state.l2Open) return;
     var tip = document.getElementById("tooltip");
     var list = state.byDay[dayIso] || [];
     if (!list.length) return;
@@ -926,9 +941,74 @@
     return state.byDay[iso] || [];
   }
 
+  function localeTag() {
+    if (state.lang === "ru") return "ru-RU";
+    if (state.lang === "es") return "es-ES";
+    return "en-US";
+  }
+
+  function formatDayHeading(iso) {
+    if (!iso || !/^\d{4}-\d{2}-\d{2}$/.test(iso)) return iso || "";
+    var d = new Date(iso + "T12:00:00");
+    return d.toLocaleDateString(localeTag(), {
+      weekday: "short",
+      day: "numeric",
+      month: "short",
+      year: "numeric"
+    });
+  }
+
+  function formatEventDateRange(e) {
+    if (!e || !e.start_date) return "";
+    var opts = { day: "numeric", month: "short", year: "numeric" };
+    var start = new Date(e.start_date + "T12:00:00");
+    var a = start.toLocaleDateString(localeTag(), opts);
+    if (!e.end_date || e.end_date === e.start_date) return a;
+    var end = new Date(e.end_date + "T12:00:00");
+    return a + " – " + end.toLocaleDateString(localeTag(), opts);
+  }
+
+  function preferReducedMotion() {
+    return window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }
+
+  function islandFinalRect() {
+    var marginX = Math.max(16, Math.round(window.innerWidth * 0.04));
+    var marginY = Math.max(16, Math.round(window.innerHeight * 0.04));
+    return {
+      left: marginX,
+      top: marginY,
+      width: Math.max(280, window.innerWidth - marginX * 2),
+      height: Math.max(320, window.innerHeight - marginY * 2)
+    };
+  }
+
+  function applyIslandRect(el, rect) {
+    el.style.left = Math.round(rect.left) + "px";
+    el.style.top = Math.round(rect.top) + "px";
+    el.style.width = Math.round(rect.width) + "px";
+    el.style.height = Math.round(rect.height) + "px";
+  }
+
+  function captureL2Origin(iso) {
+    var tip = document.getElementById("tooltip");
+    if (tip && tip.classList.contains("is-visible") && tip.offsetWidth > 0) {
+      return tip.getBoundingClientRect();
+    }
+    var btn = document.querySelector('.day.has-events[data-date="' + iso + '"]');
+    if (btn) return btn.getBoundingClientRect();
+    var fin = islandFinalRect();
+    return {
+      left: fin.left + fin.width * 0.35,
+      top: fin.top + fin.height * 0.35,
+      width: fin.width * 0.3,
+      height: fin.height * 0.3
+    };
+  }
+
   function ensureMap() {
     if (state.map) return;
-    state.map = L.map("weekendMap", { scrollWheelZoom: false });
+    state.map = L.map("dayMap", { scrollWheelZoom: false });
     L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
       attribution: "&copy; OpenStreetMap",
       maxZoom: 18
@@ -944,18 +1024,102 @@
     return "#64748b";
   }
 
-  function openDay(iso) {
-    hideTooltip();
-    state.selectedDay = iso;
-    renderCalendar();
-    var events = eventsForDay(iso);
-    var panel = document.getElementById("weekendPanel");
-    panel.classList.add("is-open");
-    document.body.classList.add("panel-open");
-    document.getElementById("weekendTitle").textContent = t("day") + " " + iso;
+  function markerStyleFor(e, mode) {
+    var active = mode === "selected" || mode === "hover";
+    return {
+      radius: mode === "selected" ? 11 : mode === "hover" ? 10 : 8,
+      color: mode === "selected" ? "#2563eb" : "#fff",
+      weight: mode === "selected" ? 2 : 1,
+      fillColor: statusColor(e.status),
+      fillOpacity: active ? 1 : 0.9
+    };
+  }
 
+  function eventMode(id) {
+    if (state.selectedEventId && String(state.selectedEventId) === String(id)) return "selected";
+    if (state.hoverEventId && String(state.hoverEventId) === String(id)) return "hover";
+    return "base";
+  }
+
+  function paintMarkerStyles() {
+    Object.keys(state.markerById).forEach(function (id) {
+      var entry = state.markerById[id];
+      if (!entry || !entry.marker || !entry.event) return;
+      entry.marker.setStyle(markerStyleFor(entry.event, eventMode(id)));
+    });
+  }
+
+  function paintRowHighlights() {
+    document.querySelectorAll(".l2-row").forEach(function (row) {
+      var id = row.getAttribute("data-id");
+      row.classList.toggle("is-selected", !!state.selectedEventId && String(state.selectedEventId) === String(id));
+      row.classList.toggle("is-hover", !!state.hoverEventId && String(state.hoverEventId) === String(id));
+    });
+  }
+
+  function setHoverEvent(id) {
+    state.hoverEventId = id || null;
+    paintRowHighlights();
+    paintMarkerStyles();
+  }
+
+  function buildL2ListHtml(list) {
+    var buckets = { confirmed: [], expected: [], paused: [] };
+    (list || []).forEach(function (e) {
+      buckets[tipGroupKey(e.status)].push(e);
+    });
+    buckets.confirmed.sort(sortConfirmedTipEvents);
+    buckets.expected.sort(sortEventsByName);
+    buckets.paused.sort(sortEventsByName);
+
+    var html = "";
+    ["confirmed", "expected", "paused"].forEach(function (key) {
+      var rows = buckets[key];
+      if (!rows.length) return;
+      html += '<div class="tooltip-group tooltip-group--' + key + '">';
+      html +=
+        '<div class="tooltip-group__label">' +
+        '<span class="badge ' + tipGroupBadgeClass(key) + '">' +
+        esc(tipGroupLabel(key)) +
+        "</span></div>";
+      rows.forEach(function (e) {
+        var where = [e.city, e.country].filter(Boolean).join(", ");
+        var dates = formatEventDateRange(e);
+        html +=
+          '<button type="button" class="l2-row" data-id="' + esc(e.id) + '">' +
+          '<div class="tooltip-row__main">' +
+          '<div class="tooltip-row__name">' + esc(e.name) + "</div>" +
+          (where ? '<div class="tooltip-row__where">' + esc(where) + "</div>" : "") +
+          (dates ? '<div class="l2-row__dates">' + esc(dates) + "</div>" : "") +
+          "</div>" +
+          '<div class="tooltip-row__meta">' +
+          '<span class="badge ' + tipKindClass(e.kind) + '">' +
+          esc(tipKindLabel(e.kind)) +
+          "</span>" +
+          "</div></button>";
+      });
+      html += "</div>";
+    });
+    return html;
+  }
+
+  function wireL2ListInteractions() {
+    document.querySelectorAll(".l2-row").forEach(function (row) {
+      var id = row.getAttribute("data-id");
+      row.addEventListener("mouseenter", function () { setHoverEvent(id); });
+      row.addEventListener("mouseleave", function () { setHoverEvent(null); });
+      row.addEventListener("focus", function () { setHoverEvent(id); });
+      row.addEventListener("blur", function () { setHoverEvent(null); });
+      row.addEventListener("click", function () { selectEvent(id); });
+    });
+  }
+
+  function populateDayIsland(iso) {
+    var events = eventsForDay(iso);
+    document.getElementById("dayIslandTitle").textContent = formatDayHeading(iso);
     ensureMap();
     state.markers.clearLayers();
+    state.markerById = {};
     var withGeo = events.filter(function (e) {
       return typeof e.lat === "number" && typeof e.lon === "number";
     });
@@ -969,56 +1133,142 @@
     if (withGeo.length) {
       var bounds = [];
       withGeo.forEach(function (e) {
-        var m = L.circleMarker([e.lat, e.lon], {
-          radius: 8,
-          color: "#fff",
-          weight: 1,
-          fillColor: statusColor(e.status),
-          fillOpacity: 0.9
-        });
+        var m = L.circleMarker([e.lat, e.lon], markerStyleFor(e, "base"));
         m.bindPopup(esc(e.name));
+        m.on("mouseover", function () { setHoverEvent(e.id); });
+        m.on("mouseout", function () { setHoverEvent(null); });
         m.on("click", function () { selectEvent(e.id); });
         state.markers.addLayer(m);
+        state.markerById[String(e.id)] = { marker: m, event: e };
         bounds.push([e.lat, e.lon]);
       });
       state.map.fitBounds(bounds, { padding: [28, 28], maxZoom: 5 });
     } else {
       state.map.setView([20, 0], 1);
     }
-    setTimeout(function () { state.map.invalidateSize(); }, 50);
+    setTimeout(function () { state.map.invalidateSize(); }, 60);
 
     var list = document.getElementById("eventList");
-    list.innerHTML = events.map(function (e) {
-      var where = [e.city, e.country].filter(Boolean).join(", ");
-      var span = esc(e.start_date) + (e.end_date && e.end_date !== e.start_date ? " - " + esc(e.end_date) : "");
-      return '<button type="button" class="event-card" data-id="' + esc(e.id) + '">' +
-        "<h3>" + esc(e.name) + "</h3>" +
-        '<div class="event-meta">' + span + (where ? " · " + esc(where) : "") + "</div>" +
-        '<div class="badges">' +
-        '<span class="badge ' + esc(e.status) + '">' + esc(statusLabel(e.status)) + "</span>" +
-        '<span class="badge ' + (e.kind === "trial" ? "trial" : "registry") + '">' +
-        esc(e.kind === "trial" ? t("trial") : t("registry")) + "</span>" +
-        "</div></button>";
-    }).join("");
-    list.querySelectorAll(".event-card").forEach(function (btn) {
-      btn.addEventListener("click", function () {
-        selectEvent(btn.getAttribute("data-id"));
+    list.innerHTML = buildL2ListHtml(events);
+    wireL2ListInteractions();
+    document.getElementById("eventDetail").classList.remove("is-open");
+    document.getElementById("eventDetail").innerHTML = "";
+    state.selectedEventId = null;
+    state.hoverEventId = null;
+  }
+
+  function openDay(iso) {
+    if (state.l2Open) {
+      hideTooltip();
+      state.selectedDay = iso;
+      state.l2Origin = captureL2Origin(iso);
+      renderCalendar();
+      populateDayIsland(iso);
+      applyIslandRect(document.getElementById("dayIsland"), islandFinalRect());
+      document.getElementById("dayIsland").classList.add("is-settled");
+      setTimeout(function () { if (state.map) state.map.invalidateSize(); }, 40);
+      return;
+    }
+
+    var origin = captureL2Origin(iso);
+    hideTooltip();
+    state.selectedDay = iso;
+    state.l2Open = true;
+    state.l2Origin = origin;
+    renderCalendar();
+
+    var layer = document.getElementById("dayLayer");
+    var island = document.getElementById("dayIsland");
+    layer.hidden = false;
+    layer.setAttribute("aria-hidden", "false");
+    layer.classList.add("is-open");
+    document.body.classList.add("day-layer-open");
+
+    populateDayIsland(iso);
+
+    var finalRect = islandFinalRect();
+    island.classList.remove("is-settled");
+    if (preferReducedMotion()) {
+      applyIslandRect(island, finalRect);
+      island.classList.add("is-settled");
+      setTimeout(function () { if (state.map) state.map.invalidateSize(); }, 40);
+      return;
+    }
+
+    applyIslandRect(island, {
+      left: origin.left,
+      top: origin.top,
+      width: Math.max(40, origin.width),
+      height: Math.max(40, origin.height)
+    });
+    island.style.transition = "none";
+    void island.offsetWidth;
+    island.style.transition = "";
+    requestAnimationFrame(function () {
+      requestAnimationFrame(function () {
+        applyIslandRect(island, finalRect);
+        island.classList.add("is-settled");
+        setTimeout(function () { if (state.map) state.map.invalidateSize(); }, 300);
       });
     });
+  }
+
+  function forceCloseDayIsland() {
+    var layer = document.getElementById("dayLayer");
+    var island = document.getElementById("dayIsland");
+    layer.classList.remove("is-open");
+    layer.hidden = true;
+    layer.setAttribute("aria-hidden", "true");
+    island.classList.remove("is-settled");
+    document.body.classList.remove("day-layer-open");
+    state.l2Open = false;
+    state.l2Origin = null;
+    state.selectedDay = null;
+    state.selectedEventId = null;
+    state.hoverEventId = null;
     document.getElementById("eventDetail").classList.remove("is-open");
     document.getElementById("eventDetail").innerHTML = "";
   }
 
+  function closeDayIsland() {
+    if (!state.l2Open) return;
+    var island = document.getElementById("dayIsland");
+    var origin = state.l2Origin;
+    var finish = function () {
+      forceCloseDayIsland();
+      renderCalendar();
+    };
+
+    if (preferReducedMotion() || !origin) {
+      finish();
+      return;
+    }
+
+    island.classList.remove("is-settled");
+    applyIslandRect(island, {
+      left: origin.left,
+      top: origin.top,
+      width: Math.max(40, origin.width),
+      height: Math.max(40, origin.height)
+    });
+    window.setTimeout(finish, 260);
+  }
+
   function selectEvent(id) {
     var events = eventsForYear(state.year);
-    var e = events.find(function (x) { return x.id === id; });
+    var e = events.find(function (x) { return String(x.id) === String(id); });
     if (!e) {
-      e = eventsInYearRaw(state.year).find(function (x) { return x.id === id; });
+      e = eventsInYearRaw(state.year).find(function (x) { return String(x.id) === String(id); });
     }
     if (!e) return;
-    document.querySelectorAll(".event-card").forEach(function (c) {
-      c.classList.toggle("is-active", c.getAttribute("data-id") === id);
-    });
+    state.selectedEventId = id;
+    paintRowHighlights();
+    paintMarkerStyles();
+    var entry = state.markerById[String(id)];
+    if (entry && entry.marker && state.map) {
+      entry.marker.openPopup();
+      state.map.panTo(entry.marker.getLatLng(), { animate: true });
+    }
     var detail = document.getElementById("eventDetail");
     var where = [e.city, e.country].filter(Boolean).join(", ");
     var html = "<h3>" + esc(e.name) + "</h3>" +
@@ -1043,21 +1293,17 @@
 
   function setYear(y) {
     state.year = y;
-    state.selectedDay = null;
+    forceCloseDayIsland();
     state.country = "";
     state.status = "";
     state.kind = "";
-    document.getElementById("weekendPanel").classList.remove("is-open");
-    document.body.classList.remove("panel-open");
     renderYearSelect();
     refreshFilterOptions();
     renderCalendar();
   }
 
   function applyFiltersAndRender() {
-    state.selectedDay = null;
-    document.getElementById("weekendPanel").classList.remove("is-open");
-    document.body.classList.remove("panel-open");
+    forceCloseDayIsland();
     refreshFilterOptions();
     renderCalendar();
   }
@@ -1143,16 +1389,22 @@
     closeAllFilterDropdowns();
   });
   document.addEventListener("keydown", function (e) {
-    if (e.key === "Escape") closeAllFilterDropdowns();
+    if (e.key === "Escape") {
+      if (state.l2Open) {
+        e.preventDefault();
+        closeDayIsland();
+        return;
+      }
+      closeAllFilterDropdowns();
+    }
   });
 
-  document.getElementById("closePanel").addEventListener("click", function () {
-    document.getElementById("weekendPanel").classList.remove("is-open");
-    document.body.classList.remove("panel-open");
-    state.selectedDay = null;
-    renderCalendar();
+  document.getElementById("closeDayIsland").addEventListener("click", function () {
+    closeDayIsland();
   });
-
+  document.getElementById("dayLayerBackdrop").addEventListener("click", function () {
+    closeDayIsland();
+  });
   window.WsdcChrome = window.WsdcChrome || {};
   window.WsdcChrome.onLangChange = function (lang) {
     state.lang = lang;

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -698,51 +698,74 @@ h1 {
   }
 }
 
-/* —— Weekend overlay panel —— */
-.panel {
+/* —— Day L2 island (replaces fullscreen weekend panel) —— */
+.day-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  display: none;
+  pointer-events: none;
+}
+
+.day-layer.is-open {
+  display: block;
+  pointer-events: auto;
+}
+
+.day-layer__backdrop {
   position: absolute;
   inset: 0;
-  z-index: 40;
-  background: rgba(255, 255, 255, 0.98);
-  border: none;
-  border-radius: 0;
-  padding: 10px 14px 14px;
-  display: none;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
+  background: rgba(15, 23, 42, 0.38);
+  opacity: 0;
+  transition: opacity 240ms var(--ease-out);
 }
 
-.panel.is-open {
-  display: block;
-  animation: panelIn 180ms var(--ease-out);
+.day-layer.is-open .day-layer__backdrop {
+  opacity: 1;
 }
 
-@keyframes panelIn {
-  from { opacity: 0; transform: scale(0.98); }
-  to { opacity: 1; transform: scale(1); }
+.day-island {
+  position: fixed;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.22);
+  overflow: hidden;
+  transition:
+    left 280ms var(--ease-out),
+    top 280ms var(--ease-out),
+    width 280ms var(--ease-out),
+    height 280ms var(--ease-out),
+    border-radius 280ms var(--ease-out);
 }
 
-.panel-inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
-  gap: 12px;
-  align-items: start;
+.day-island.is-settled {
+  border-radius: var(--radius);
 }
 
-.panel-head {
-  grid-column: 1 / -1;
+.day-island__head {
+  flex: 0 0 auto;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   gap: 8px;
   align-items: center;
+  padding: 12px 14px 8px;
+  border-bottom: 1px solid var(--border-color);
+  background: #fff;
 }
 
-.panel-head h2 { font-size: 15px; font-weight: 600; letter-spacing: -0.01em; }
+.day-island__head h2 {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
 
-.panel-close {
+.day-island__close {
   border: 1px solid var(--border-color);
   background: #fff;
   border-radius: var(--radius-sm);
@@ -753,19 +776,36 @@ h1 {
   transition: transform 140ms var(--ease-out), background 140ms var(--ease-out);
 }
 
-.panel-close:active { transform: scale(0.97); }
+.day-island__close:active { transform: scale(0.97); }
 
 @media (hover: hover) and (pointer: fine) {
-  .panel-close:hover { background: var(--bg-tertiary); }
+  .day-island__close:hover { background: var(--bg-tertiary); }
 }
 
-.panel-map-col { min-width: 0; }
+.day-island__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+  gap: 12px;
+  padding: 10px 14px 14px;
+  align-items: stretch;
+}
 
-#weekendMap {
-  height: min(40vh, 320px);
+.day-island__map-col,
+.day-island__list-col {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+#dayMap {
+  flex: 1 1 auto;
+  min-height: 180px;
   border-radius: var(--radius);
   border: 1px solid var(--border-color);
-  margin-bottom: 6px;
+  background: #fff;
 }
 
 .no-geo {
@@ -774,39 +814,80 @@ h1 {
   margin-bottom: 6px;
 }
 
-.event-list {
-  display: grid;
-  gap: 6px;
-  max-height: min(68vh, 500px);
+.day-island__list {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-right: 2px;
 }
 
-.event-card {
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius);
-  padding: 8px 10px;
+.l2-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  column-gap: 10px;
+  align-items: start;
+  width: 100%;
+  margin: 0;
+  padding: 6px 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
   text-align: left;
-  background: var(--bg-tertiary);
+  font: inherit;
+  color: inherit;
   cursor: pointer;
-  transition: border-color 140ms var(--ease-out), background 140ms var(--ease-out), transform 140ms var(--ease-out);
+  transition: background 120ms var(--ease-out), border-color 120ms var(--ease-out);
 }
 
-.event-card:active { transform: scale(0.98); }
+.l2-row + .l2-row {
+  margin-top: 4px;
+}
+
+.day-island .tooltip-group .l2-row:first-of-type {
+  margin-top: 0;
+}
 
 @media (hover: hover) and (pointer: fine) {
-  .event-card:hover {
-    border-color: #cbd5e1;
+  .l2-row:hover,
+  .l2-row.is-hover {
     background: #fff;
+    border-color: rgba(15, 23, 42, 0.08);
   }
 }
 
-.event-card.is-active {
-  border-color: var(--color-accent);
+.l2-row.is-selected {
   background: #fff;
+  border-color: rgba(37, 99, 235, 0.35);
   box-shadow: var(--shadow-soft);
 }
 
-.event-card h3 { font-size: 13px; margin-bottom: 2px; }
+.l2-row__dates {
+  margin-top: 3px;
+  font-size: 11px;
+  line-height: 1.3;
+  color: var(--text-tertiary);
+}
+
+.tooltip-group--expected .l2-row__dates {
+  color: #9ca3af;
+}
+
+.badge.paused {
+  background: rgba(225, 29, 72, 0.12);
+  color: #be123c;
+}
+
+.detail {
+  flex: 0 0 auto;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-color);
+  display: none;
+  font-size: 13px;
+}
+.detail.is-open { display: block; }
+.detail a { color: var(--color-accent); }
 .event-meta { font-size: 11px; color: var(--text-secondary); }
 .badges { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 5px; }
 
@@ -825,16 +906,6 @@ h1 {
 .badge.registry { background: rgba(79, 70, 229, 0.12); color: #4338ca; }
 .badge.trial { background: rgba(234, 179, 8, 0.18); color: #a16207; }
 
-.detail {
-  margin-top: 8px;
-  padding-top: 8px;
-  border-top: 1px solid var(--border-color);
-  display: none;
-  font-size: 13px;
-}
-.detail.is-open { display: block; }
-.detail a { color: var(--color-accent); }
-
 .empty-year {
   padding: 20px;
   text-align: center;
@@ -844,6 +915,10 @@ h1 {
   width: 100%;
   align-self: center;
   font-size: 13px;
+}
+
+body.day-layer-open {
+  overflow: hidden;
 }
 
 .tooltip {
@@ -925,11 +1000,6 @@ h1 {
   white-space: nowrap;
 }
 
-.badge.paused {
-  background: rgba(225, 29, 72, 0.12);
-  color: #be123c;
-}
-
 .tooltip-group--confirmed .tooltip-row__name {
   color: var(--text-primary);
 }
@@ -991,9 +1061,9 @@ h1 {
     height: auto;
     font-size: 9px;
   }
-  .panel-inner { grid-template-columns: 1fr; }
-  #weekendMap { height: 26vh; }
-  .event-list { max-height: none; }
+  .day-island__body { grid-template-columns: 1fr; }
+  #dayMap { min-height: 200px; height: 28vh; flex: 0 0 auto; }
+  .day-island__list { max-height: min(42vh, 360px); }
 }
 
 @media (max-width: 700px) {
@@ -1108,7 +1178,6 @@ h1 {
   .month { padding: 5px 5px 6px; }
   .month h2 { font-size: 11px; }
   .day { font-size: 10px; }
-  .panel { position: fixed; inset: 0; }
 }
 
 @media (max-width: 420px) {
@@ -1116,12 +1185,15 @@ h1 {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .panel.is-open {
-    animation: none;
+  .day-island {
+    transition: none;
+  }
+  .day-layer__backdrop {
+    transition: none;
   }
   .day,
-  .event-card,
-  .panel-close,
+  .day-island__close,
+  .l2-row,
   .tooltip,
   .cal-dd__btn,
   .cal-dd__menu,


### PR DESCRIPTION
## Summary
- Remove `#weekendPanel` fullscreen overlay
- Day click opens a centered floating **L2 island** (morph from tip): map left / tip-style list right
- List shows all day events with group pills, kind badges, and full date range under location
- Close via Close / backdrop / Esc; hover syncs list ↔ markers; click sticky-selects + temporary `#eventDetail`

## Test plan
- [ ] Hover a day → L1 tip still works
- [ ] Click a day → island morphs open; header is localized day only
- [ ] Map + grouped list; dates under where; scroll if many events
- [ ] Hover row ↔ marker; click row → sticky highlight + detail under list
- [ ] Close / Esc / backdrop dismisses; calendar remains on same page
- [ ] Narrow viewport stacks map above list


Made with [Cursor](https://cursor.com)