### PR TITLE
L2 fills calendar stage with thin visible rim

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -989,18 +989,12 @@
   function islandFinalRect() {
     var stage = stageEl().getBoundingClientRect();
     var pad = 10;
-    var availW = Math.max(0, stage.width - pad * 2);
-    var availH = Math.max(0, stage.height - pad * 2);
-    // Compact magnifier: stay inside the calendar stage, leave filters visible.
-    var width = Math.min(560, availW);
-    var height = Math.min(320, Math.max(240, Math.round(availH * 0.78)));
-    width = Math.max(280, Math.min(width, availW));
-    height = Math.max(220, Math.min(height, availH));
+    // Nearly fill the calendar stage; leave a thin rim of the grid visible.
     return {
-      left: pad + (availW - width) / 2,
-      top: pad + (availH - height) / 2,
-      width: width,
-      height: height
+      left: pad,
+      top: pad,
+      width: Math.max(280, stage.width - pad * 2),
+      height: Math.max(220, stage.height - pad * 2)
     };
   }
 

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -717,12 +717,8 @@ h1 {
 .day-layer__backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(15, 23, 42, 0.28);
-  opacity: 0;
-  transition: opacity 220ms var(--ease-out);
-}
-
-.day-layer.is-open .day-layer__backdrop {
+  /* Hit-area for click-outside only — no gray wash over the calendar. */
+  background: transparent;
   opacity: 1;
 }
 
@@ -738,7 +734,7 @@ h1 {
   box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18);
   overflow: hidden;
   opacity: 0;
-  transform: scale(0.97);
+  transform: scale(0.985);
   transform-origin: center center;
   transition: opacity 180ms var(--ease-out), transform 180ms var(--ease-out);
 }
@@ -808,7 +804,7 @@ h1 {
 #dayMap {
   flex: 0 0 auto;
   width: 100%;
-  height: 158px;
+  height: 220px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-color);
   background: #fff;
@@ -1064,7 +1060,7 @@ h1 {
     font-size: 9px;
   }
   .day-island__body { grid-template-columns: 1fr; }
-  #dayMap { height: 140px; }
+  #dayMap { height: 180px; min-height: 160px; }
   .day-island__list { max-height: none; }
 }
 


### PR DESCRIPTION
## Summary
- Remove gray L2 backdrop (transparent click-outside hit area only)
- Size island to `calendar-stage − 10px` on each side so the calendar rim stays visible
- Bump map height for the larger panel

## Test plan
- [ ] Open a day → L2 almost covers the calendar grid, ~10px rim visible
- [ ] No gray overlay wash
- [ ] Filters above the stage still visible
- [ ] Close via backdrop rim / Close / Esc


Made with [Cursor](https://cursor.com)