### PR TITLE
Calendar: trial event geo pins

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="static/css/site-chrome.css">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
-    <link rel="preload" href="static/data/events_year_calendar.json?v=20260805a" as="fetch" crossorigin>
+    <link rel="preload" href="static/data/events_year_calendar.json?v=20260805b" as="fetch" crossorigin>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMLCY5PE8Z"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -1615,7 +1615,7 @@
   var params = new URLSearchParams(window.location.search);
   if (params.get("lang") && I18N[params.get("lang")]) state.lang = params.get("lang");
 
-  fetch("static/data/events_year_calendar.json?v=20260805a")
+  fetch("static/data/events_year_calendar.json?v=20260805b")
     .then(function (r) {
       if (!r.ok) throw new Error("Failed to load calendar data");
       return r.json();

--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-05",
-  "generated_at": "2026-08-05T08:33:31Z",
+  "generated_at": "2026-08-05T14:03:56Z",
   "years": [
     2024,
     2025,
@@ -9386,8 +9386,8 @@
       "city": "Bruxelles",
       "country": "Belgium",
       "continent": "Europe",
-      "lat": null,
-      "lon": null,
+      "lat": 50.84770289999999,
+      "lon": 4.357200100000001,
       "url": "https://www.mannekenswing.com/",
       "year": 2026,
       "source": "scheduled_events"
@@ -9429,8 +9429,8 @@
       "city": "Bucharest",
       "country": "Romania",
       "continent": "Europe",
-      "lat": null,
-      "lon": null,
+      "lat": 44.4267674,
+      "lon": 26.1025384,
       "url": "https://www.westiejoy.com/",
       "year": 2026,
       "source": "scheduled_events"
@@ -9929,8 +9929,8 @@
       "city": "Dresden",
       "country": "Germany",
       "continent": "Europe",
-      "lat": null,
-      "lon": null,
+      "lat": 51.0504088,
+      "lon": 13.7372621,
       "url": "http://www.riverswingnights.com/",
       "year": 2026,
       "source": "scheduled_events"
@@ -10735,8 +10735,8 @@
       "city": "Geneva",
       "country": "Switzerland",
       "continent": "Europe",
-      "lat": null,
-      "lon": null,
+      "lat": 46.2043907,
+      "lon": 6.1431577,
       "url": "http://www.swissopenwcs.ch/",
       "year": 2026,
       "source": "scheduled_events"
@@ -10955,8 +10955,8 @@
       "city": "Köln",
       "country": "Germany",
       "continent": "Europe",
-      "lat": null,
-      "lon": null,
+      "lat": 50.937531,
+      "lon": 6.9602786,
       "url": "https://colognecallingwcs.com/",
       "year": 2027,
       "source": "scheduled_events"
@@ -11782,8 +11782,8 @@
       "city": "Nürnberg",
       "country": "Germany",
       "continent": "Europe",
-      "lat": null,
-      "lon": null,
+      "lat": 49.45428810000001,
+      "lon": 11.0745641,
       "url": "https://franconian-swing-project.de/",
       "year": 2027,
       "source": "scheduled_events"
@@ -12744,8 +12744,8 @@
       "city": "Bad Hofgastein",
       "country": "Austria",
       "continent": "Europe",
-      "lat": null,
-      "lon": null,
+      "lat": 47.1725556,
+      "lon": 13.0987448,
       "url": "http://swing-valley.com/",
       "year": 2027,
       "source": "scheduled_events"


### PR DESCRIPTION
## Summary
- Rebuild `events_year_calendar.json` after pipeline list sync assigned location_id + coords to all 13 active Trial events.
- Cache buster `?v=20260805b`.

## Test plan
- [x] Trial-name calendar rows: 16/16 with lat/lon (was 9/16)


Made with [Cursor](https://cursor.com)