### PR TITLE
Fix duplicate calendar IDs for same-day trials

### DIFF
--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-05",
-  "generated_at": "2026-08-05T14:03:56Z",
+  "generated_at": "2026-08-05T14:11:27Z",
   "years": [
     2024,
     2025,
@@ -9313,7 +9313,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:x:2026-08-20",
+      "id": "confirmed:swing-creation-hamburg-hamburg-germany:2026-08-20",
       "event_id": null,
       "name": "Swing Creation Hamburg",
       "start_date": "2026-08-20",
@@ -9373,7 +9373,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:x:2026-08-21",
+      "id": "confirmed:manneken-swing-bruxelles-belgium:2026-08-21",
       "event_id": null,
       "name": "Manneken Swing",
       "start_date": "2026-08-21",
@@ -9416,7 +9416,7 @@
       "has_results": true
     },
     {
-      "id": "confirmed:x:2026-08-21",
+      "id": "confirmed:westie-joy-bucharest-romania:2026-08-21",
       "event_id": null,
       "name": "Westie Joy",
       "start_date": "2026-08-21",
@@ -9916,7 +9916,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:x:2026-10-01",
+      "id": "confirmed:riverswingnights-dresden-germany:2026-10-01",
       "event_id": null,
       "name": "RiverSwingNights",
       "start_date": "2026-10-01",
@@ -9936,7 +9936,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:x:2026-10-01",
+      "id": "confirmed:westie-harbor-gothenburg-sweden:2026-10-01",
       "event_id": null,
       "name": "Westie Harbor",
       "start_date": "2026-10-01",
@@ -9956,7 +9956,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:x:2026-10-02",
+      "id": "confirmed:autumn-beat-riga-latvia:2026-10-02",
       "event_id": null,
       "name": "Autumn Beat",
       "start_date": "2026-10-02",
@@ -10722,7 +10722,7 @@
       "source": "operator_override"
     },
     {
-      "id": "confirmed:x:2026-12-18",
+      "id": "confirmed:swiss-open-wcs-geneva-switzerland:2026-12-18",
       "event_id": null,
       "name": "Swiss Open WCS",
       "start_date": "2026-12-18",
@@ -10942,7 +10942,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:x:2027-01-14",
+      "id": "confirmed:cologne-calling-wcs-k-ln-germany:2027-01-14",
       "event_id": null,
       "name": "Cologne Calling WCS",
       "start_date": "2027-01-14",
@@ -11084,7 +11084,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:x:2027-01-22",
+      "id": "confirmed:swing-in-paris-paris-france:2027-01-22",
       "event_id": null,
       "name": "Swing In Paris",
       "start_date": "2027-01-22",
@@ -11769,7 +11769,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:x:2027-04-08",
+      "id": "confirmed:franconian-swing-project-n-rnberg-germany:2027-04-08",
       "event_id": null,
       "name": "Franconian Swing Project",
       "start_date": "2027-04-08",
@@ -12731,7 +12731,7 @@
       "source": "edition_calendar_dates"
     },
     {
-      "id": "confirmed:x:2027-07-01",
+      "id": "confirmed:swing-valley-bad-hofgastein-austria:2027-07-01",
       "event_id": null,
       "name": "Swing Valley",
       "start_date": "2027-07-01",

--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-05",
-  "generated_at": "2026-08-05T14:11:27Z",
+  "generated_at": "2026-08-05T14:16:56Z",
   "years": [
     2024,
     2025,
@@ -9313,7 +9313,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:swing-creation-hamburg-hamburg-germany:2026-08-20",
+      "id": "confirmed:t-swing-creation-hamburg-hamburg-germany:2026-08-20",
       "event_id": null,
       "name": "Swing Creation Hamburg",
       "start_date": "2026-08-20",
@@ -9373,7 +9373,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:manneken-swing-bruxelles-belgium:2026-08-21",
+      "id": "confirmed:t-manneken-swing-bruxelles-belgium:2026-08-21",
       "event_id": null,
       "name": "Manneken Swing",
       "start_date": "2026-08-21",
@@ -9416,7 +9416,7 @@
       "has_results": true
     },
     {
-      "id": "confirmed:westie-joy-bucharest-romania:2026-08-21",
+      "id": "confirmed:t-westie-joy-bucharest-romania:2026-08-21",
       "event_id": null,
       "name": "Westie Joy",
       "start_date": "2026-08-21",
@@ -9916,7 +9916,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:riverswingnights-dresden-germany:2026-10-01",
+      "id": "confirmed:t-riverswingnights-dresden-germany:2026-10-01",
       "event_id": null,
       "name": "RiverSwingNights",
       "start_date": "2026-10-01",
@@ -9936,7 +9936,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:westie-harbor-gothenburg-sweden:2026-10-01",
+      "id": "confirmed:t-westie-harbor-gothenburg-sweden:2026-10-01",
       "event_id": null,
       "name": "Westie Harbor",
       "start_date": "2026-10-01",
@@ -9956,7 +9956,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:autumn-beat-riga-latvia:2026-10-02",
+      "id": "confirmed:t-autumn-beat-riga-latvia:2026-10-02",
       "event_id": null,
       "name": "Autumn Beat",
       "start_date": "2026-10-02",
@@ -10722,7 +10722,7 @@
       "source": "operator_override"
     },
     {
-      "id": "confirmed:swiss-open-wcs-geneva-switzerland:2026-12-18",
+      "id": "confirmed:t-swiss-open-wcs-geneva-switzerland:2026-12-18",
       "event_id": null,
       "name": "Swiss Open WCS",
       "start_date": "2026-12-18",
@@ -10942,7 +10942,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:cologne-calling-wcs-k-ln-germany:2027-01-14",
+      "id": "confirmed:t-cologne-calling-wcs-koln-germany:2027-01-14",
       "event_id": null,
       "name": "Cologne Calling WCS",
       "start_date": "2027-01-14",
@@ -11084,7 +11084,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:swing-in-paris-paris-france:2027-01-22",
+      "id": "confirmed:t-swing-in-paris-paris-france:2027-01-22",
       "event_id": null,
       "name": "Swing In Paris",
       "start_date": "2027-01-22",
@@ -11769,7 +11769,7 @@
       "source": "scheduled_events"
     },
     {
-      "id": "confirmed:franconian-swing-project-n-rnberg-germany:2027-04-08",
+      "id": "confirmed:t-franconian-swing-project-nurnberg-germany:2027-04-08",
       "event_id": null,
       "name": "Franconian Swing Project",
       "start_date": "2027-04-08",
@@ -12731,7 +12731,7 @@
       "source": "edition_calendar_dates"
     },
     {
-      "id": "confirmed:swing-valley-bad-hofgastein-austria:2027-07-01",
+      "id": "confirmed:t-swing-valley-bad-hofgastein-austria:2027-07-01",
       "event_id": null,
       "name": "Swing Valley",
       "start_date": "2027-07-01",


### PR DESCRIPTION
## Summary
- Rebuild `events_year_calendar.json` with unique IDs for unlinked trials
- Fixes L2: hovering Brussels no longer highlights Bucharest; selecting Bucharest flies to Romania

Pipeline: https://github.com/zlat1109/wsdc-data-pipeline/pull/98

## Test plan
- [ ] Open 22 Aug 2026 → hover Manneken Swing → only that row highlights
- [ ] Click Westie Joy → map flies to Bucharest
- [ ] Same for RiverSwingNights / Westie Harbor on 1 Oct 2026


Made with [Cursor](https://cursor.com)