### PR TITLE
L2: event card above map on select

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -199,13 +199,13 @@
                 <button type="button" class="day-island__close" id="closeDayIsland" data-i18n="close">Close</button>
             </div>
             <div class="day-island__body">
-                <div class="day-island__map-col">
+                <div class="day-island__map-col" id="dayMapCol">
                     <div id="noGeoNote" class="no-geo" hidden></div>
+                    <article class="l2-event-card" id="eventDetail" aria-live="polite"></article>
                     <div id="dayMap" role="img" aria-label="Day events map"></div>
                 </div>
                 <div class="day-island__list-col">
                     <div class="day-island__list" id="eventList"></div>
-                    <div class="detail" id="eventDetail"></div>
                 </div>
             </div>
         </div>
@@ -1265,6 +1265,8 @@
     wireL2ListInteractions();
     document.getElementById("eventDetail").classList.remove("is-open");
     document.getElementById("eventDetail").innerHTML = "";
+    var mapCol = document.getElementById("dayMapCol");
+    if (mapCol) mapCol.classList.remove("has-event");
     state.selectedEventId = null;
     state.hoverEventId = null;
   }
@@ -1340,6 +1342,8 @@
     state.hoverEventId = null;
     document.getElementById("eventDetail").classList.remove("is-open");
     document.getElementById("eventDetail").innerHTML = "";
+    var mapCol = document.getElementById("dayMapCol");
+    if (mapCol) mapCol.classList.remove("has-event");
   }
 
   function closeDayIsland() {
@@ -1352,32 +1356,26 @@
     }, preferReducedMotion() ? 0 : 160);
   }
 
-  function clearEventSelection() {
-    state.selectedEventId = null;
-    paintRowHighlights();
-    paintMarkerStyles();
-    var detail = document.getElementById("eventDetail");
-    detail.classList.remove("is-open");
-    detail.innerHTML = "";
-    fitDayMap(dayMapBounds(), { animate: true });
+  function refreshDayMapSize(afterMs) {
+    var delay = afterMs == null ? 0 : afterMs;
+    window.setTimeout(function () {
+      if (!state.map) return;
+      state.map.invalidateSize({ animate: false });
+    }, delay);
   }
 
-  function selectEvent(id) {
-    if (state.selectedEventId != null && String(state.selectedEventId) === String(id)) {
-      clearEventSelection();
-      return;
-    }
-    var events = eventsForYear(state.year);
-    var e = events.find(function (x) { return String(x.id) === String(id); });
-    if (!e) {
-      e = eventsInYearRaw(state.year).find(function (x) { return String(x.id) === String(id); });
-    }
-    if (!e) return;
-    state.selectedEventId = id;
-    paintRowHighlights();
-    paintMarkerStyles();
-    focusMapOnEvent(e);
+  function hideEventCard() {
     var detail = document.getElementById("eventDetail");
+    var mapCol = document.getElementById("dayMapCol");
+    detail.classList.remove("is-open");
+    detail.innerHTML = "";
+    if (mapCol) mapCol.classList.remove("has-event");
+    refreshDayMapSize(preferReducedMotion() ? 0 : 230);
+  }
+
+  function showEventCard(e) {
+    var detail = document.getElementById("eventDetail");
+    var mapCol = document.getElementById("dayMapCol");
     var where = [e.city, e.country].filter(Boolean).join(", ");
     var html = "<h3>" + esc(e.name) + "</h3>" +
       '<p class="event-meta">' + t("starts") + ": " + esc(e.start_date) +
@@ -1397,6 +1395,34 @@
     }
     detail.innerHTML = html;
     detail.classList.add("is-open");
+    if (mapCol) mapCol.classList.add("has-event");
+    refreshDayMapSize(preferReducedMotion() ? 0 : 230);
+  }
+
+  function clearEventSelection() {
+    state.selectedEventId = null;
+    paintRowHighlights();
+    paintMarkerStyles();
+    hideEventCard();
+    fitDayMap(dayMapBounds(), { animate: true });
+  }
+
+  function selectEvent(id) {
+    if (state.selectedEventId != null && String(state.selectedEventId) === String(id)) {
+      clearEventSelection();
+      return;
+    }
+    var events = eventsForYear(state.year);
+    var e = events.find(function (x) { return String(x.id) === String(id); });
+    if (!e) {
+      e = eventsInYearRaw(state.year).find(function (x) { return String(x.id) === String(id); });
+    }
+    if (!e) return;
+    state.selectedEventId = id;
+    paintRowHighlights();
+    paintMarkerStyles();
+    showEventCard(e);
+    focusMapOnEvent(e);
   }
 
   function setYear(y) {

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -811,22 +811,29 @@ h1 {
 }
 
 .day-island__map-col {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
+  gap: 8px;
 }
 
 #dayMap {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
   width: 100%;
-  height: 220px;
+  min-height: 160px;
+  height: 100%;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-color);
   background: #fff;
+  transition: min-height 220ms var(--ease-out);
+}
+
+.day-island__map-col.has-event #dayMap {
+  flex: 1 1 0;
+  min-height: 120px;
 }
 
 .no-geo {
   font-size: 11px;
   color: var(--text-tertiary);
-  margin-bottom: 4px;
 }
 
 .day-island__list {
@@ -910,18 +917,44 @@ h1 {
   color: #be123c;
 }
 
-.detail {
+.l2-event-card {
   flex: 0 0 auto;
-  margin-top: 8px;
-  padding-top: 8px;
-  border-top: 1px solid var(--border-color);
-  display: none;
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0 12px;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: #fff;
   font-size: 13px;
+  pointer-events: none;
+  transition:
+    max-height 220ms var(--ease-out),
+    opacity 180ms var(--ease-out),
+    padding 220ms var(--ease-out),
+    border-color 180ms var(--ease-out);
 }
-.detail.is-open { display: block; }
-.detail a { color: var(--color-accent); }
-.event-meta { font-size: 11px; color: var(--text-secondary); }
-.badges { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 5px; }
+
+.l2-event-card.is-open {
+  max-height: 240px;
+  opacity: 1;
+  padding: 10px 12px;
+  border-color: var(--border-color);
+  pointer-events: auto;
+}
+
+.l2-event-card h3 {
+  margin: 0 0 4px;
+  font-size: 14px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+
+.l2-event-card a { color: var(--color-accent); }
+.event-meta { font-size: 11px; color: var(--text-secondary); margin: 0 0 2px; }
+.badges { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
 
 .badge {
   font-size: 10px;
@@ -1090,7 +1123,8 @@ h1 {
     font-size: 9px;
   }
   .day-island__body { grid-template-columns: 1fr; }
-  #dayMap { height: 180px; min-height: 160px; }
+  #dayMap { min-height: 140px; }
+  .day-island__map-col.has-event #dayMap { min-height: 110px; }
   .day-island__list { max-height: none; }
 }
 
@@ -1222,6 +1256,8 @@ h1 {
   .day,
   .day-island__close,
   .l2-row,
+  .l2-event-card,
+  #dayMap,
   .tooltip,
   .cal-dd__btn,
   .cal-dd__menu,


### PR DESCRIPTION
## Summary
- Clicking a map marker or list event opens a brief event card **above** the map (map shrinks down)
- Clearing selection (click again / close day) hides the card and restores map space
- Removes the old detail block under the event list — this card is the future expansion surface (possible L3-in-L2)

## Test plan
- [ ] Open a day → map fills the left column; list only on the right
- [ ] Click an event in the list → card appears above map; map shrinks and flies to location
- [ ] Click a map marker → same card + map behavior
- [ ] Click the same event again → card closes; map expands and refits all markers
- [ ] Mobile stack: card still above map


Made with [Cursor](https://cursor.com)