### PR TITLE
L2 default top aligns with filters

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -990,14 +990,12 @@
       : stageEl().getBoundingClientRect();
     var pad = 10;
     var filterTop = filters ? filters.getBoundingClientRect().top : NaN;
-    // Default open: top edge flush with the filters row; bottom still tracks the month grid.
-    var top = Number.isFinite(filterTop) ? filterTop : target.top + pad;
-    var bottom = target.bottom - pad;
+    // Same size as the month-grid inset; only the top edge moves up to the filters row.
     return {
       left: target.left + pad,
-      top: top,
+      top: Number.isFinite(filterTop) ? filterTop : target.top + pad,
       width: Math.max(280, target.width - pad * 2),
-      height: Math.max(220, bottom - top)
+      height: Math.max(220, target.height - pad * 2)
     };
   }
 

--- a/events-calendar.html
+++ b/events-calendar.html
@@ -984,16 +984,20 @@
 
   function islandFinalRect() {
     var grid = gridEl();
+    var filters = document.querySelector(".filters");
     var target = grid && grid.getBoundingClientRect().width
       ? grid.getBoundingClientRect()
       : stageEl().getBoundingClientRect();
     var pad = 10;
-    // Open over the month grid; after that the user can drag anywhere on screen.
+    var filterTop = filters ? filters.getBoundingClientRect().top : NaN;
+    // Default open: top edge flush with the filters row; bottom still tracks the month grid.
+    var top = Number.isFinite(filterTop) ? filterTop : target.top + pad;
+    var bottom = target.bottom - pad;
     return {
       left: target.left + pad,
-      top: target.top + pad,
+      top: top,
       width: Math.max(280, target.width - pad * 2),
-      height: Math.max(220, target.height - pad * 2)
+      height: Math.max(220, bottom - top)
     };
   }
 


### PR DESCRIPTION
## Summary
- Default L2 open position: top edge flush with the filters toolbar
- Left/width/bottom still follow the month grid (island grows upward into the filter band)
- Dragged position behavior unchanged

## Test plan
- [ ] Open a day → L2 top lines up with the top of the year/continent filters
- [ ] Resize window with L2 open (not dragged) → top stays aligned to filters
- [ ] Drag L2, then resize → keeps offset as before


Made with [Cursor](https://cursor.com)