### PR TITLE
Center calendar filters

### DIFF
--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -111,7 +111,7 @@ h1 {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
-  justify-content: flex-start;
+  justify-content: center;
   gap: 10px 16px;
   padding-top: 4px;
   min-width: 0;
@@ -121,6 +121,7 @@ h1 {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
+  justify-content: center;
   gap: 8px 10px;
   min-width: 0;
 }


### PR DESCRIPTION
## Summary
- Center the filter toolbar (year / continent / country / status / type) in the page header

## Test plan
- [ ] Desktop: filters sit centered under the title/subtitle
- [ ] Narrow width: wrapped filters still center as a group


Made with [Cursor](https://cursor.com)