### PR TITLE
L2 event card: series + last-edition tiers

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="static/css/site-chrome.css">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
-    <link rel="preload" href="static/data/events_year_calendar.json?v=20260805b" as="fetch" crossorigin>
+    <link rel="preload" href="static/data/events_year_calendar.json?v=20260806a" as="fetch" crossorigin>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMLCY5PE8Z"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -257,7 +257,17 @@
       continents: { America: "America", Europe: "Europe", Asia: "Asia", Australia: "Australia" },
       statuses: { confirmed: "Confirmed", expected: "Expected", hiatus: "Hiatus" },
       months: ["January","February","March","April","May","June","July","August","September","October","November","December"],
-      dow: ["M","T","W","T","F","S","S"]
+      dow: ["M","T","W","T","F","S","S"],
+      firstEdition: "First",
+      editionsCount: "Editions",
+      lastEdition: "Last edition",
+      metricDancers: "Dancers",
+      metricPoints: "Points",
+      metricNew: "New",
+      tierPrefix: "TIER",
+      colLeader: "L",
+      colFollower: "F",
+      tierTipAria: "About tiers"
     },
     ru: {
       title: "Календарь ивентов",
@@ -299,7 +309,17 @@
       continents: { America: "Америка", Europe: "Европа", Asia: "Азия", Australia: "Австралия" },
       statuses: { confirmed: "Подтверждён", expected: "Ожидается", hiatus: "Hiatus" },
       months: ["Январь","Февраль","Март","Апрель","Май","Июнь","Июль","Август","Сентябрь","Октябрь","Ноябрь","Декабрь"],
-      dow: ["П","В","С","Ч","П","С","В"]
+      dow: ["П","В","С","Ч","П","С","В"],
+      firstEdition: "Первый",
+      editionsCount: "Издания",
+      lastEdition: "Последний",
+      metricDancers: "Танцоры",
+      metricPoints: "Очки",
+      metricNew: "Новые",
+      tierPrefix: "ТИР",
+      colLeader: "L",
+      colFollower: "F",
+      tierTipAria: "О тирах"
     },
     es: {
       title: "Calendario de eventos",
@@ -341,7 +361,17 @@
       continents: { America: "América", Europe: "Europa", Asia: "Asia", Australia: "Australia" },
       statuses: { confirmed: "Confirmado", expected: "Previsto", hiatus: "Hiatus" },
       months: ["Enero","Febrero","Marzo","Abril","Mayo","Junio","Julio","Agosto","Septiembre","Octubre","Noviembre","Diciembre"],
-      dow: ["L","M","X","J","V","S","D"]
+      dow: ["L","M","X","J","V","S","D"],
+      firstEdition: "Primero",
+      editionsCount: "Ediciones",
+      lastEdition: "Última edición",
+      metricDancers: "Bailarines",
+      metricPoints: "Puntos",
+      metricNew: "Nuevos",
+      tierPrefix: "TIER",
+      colLeader: "L",
+      colFollower: "F",
+      tierTipAria: "Sobre tiers"
     }
   };
 
@@ -368,7 +398,8 @@
     l2Drag: null,
     map: null,
     markers: null,
-    markerById: {}
+    markerById: {},
+    eventCards: null
   };
 
   function t(key) {
@@ -1391,27 +1422,113 @@
     refreshDayMapSize(preferReducedMotion() ? 0 : 230);
   }
 
+  function monthYearLabel(year, month) {
+    var months = (I18N[state.lang] || I18N.en).months || I18N.en.months;
+    var mi = Number(month) - 1;
+    var name = months[mi] != null ? months[mi] : String(month);
+    return name + " " + String(year);
+  }
+
+  function tierLabel(n) {
+    return t("tierPrefix") + "-" + String(n);
+  }
+
+  function eventCardPayload(e) {
+    if (!e || e.kind === "trial" || e.event_id == null) return null;
+    var cards = state.eventCards && state.eventCards.cards;
+    if (!cards) return null;
+    return cards[String(e.event_id)] || null;
+  }
+
+  function buildTierTableHtml(tiers) {
+    var order = ["Novice", "Intermediate", "Advanced", "All-Star", "Champions"];
+    var rows = order.filter(function (div) {
+      return tiers && tiers[div] && tiers[div].Leader != null && tiers[div].Follower != null;
+    });
+    if (!rows.length) return "";
+    var html = '<table class="l2-tier-table">' +
+      "<thead><tr>" +
+      "<th></th>" +
+      '<th class="is-lead">' + esc(t("colLeader")) + "</th>" +
+      '<th class="is-follow">' + esc(t("colFollower")) + "</th>" +
+      "</tr></thead><tbody>";
+    rows.forEach(function (div) {
+      html += "<tr>" +
+        "<th scope=\"row\">" + esc(div) + "</th>" +
+        '<td class="is-lead">' + esc(tierLabel(tiers[div].Leader)) + "</td>" +
+        '<td class="is-follow">' + esc(tierLabel(tiers[div].Follower)) + "</td>" +
+        "</tr>";
+    });
+    html += "</tbody></table>";
+    return html;
+  }
+
+  function tierTipText() {
+    var tips = state.eventCards && state.eventCards.tier_tip;
+    if (tips && tips[state.lang]) return tips[state.lang];
+    if (tips && tips.en) return tips.en;
+    return "";
+  }
+
   function showEventCard(e) {
     var detail = document.getElementById("eventDetail");
     var mapCol = document.getElementById("dayMapCol");
     var where = [e.city, e.country].filter(Boolean).join(", ");
-    var html = "<h3>" + esc(e.name) + "</h3>" +
-      '<p class="event-meta">' + t("starts") + ": " + esc(e.start_date) +
-      (e.end_date ? " · " + t("ends") + ": " + esc(e.end_date) : "") + "</p>";
-    if (where) html += '<p class="event-meta">' + t("location") + ": " + esc(where) + "</p>";
-    html += '<div class="badges">' +
+    var card = eventCardPayload(e);
+    var tip = tierTipText();
+
+    var left = '<div class="l2-event-card__series">' +
+      "<h3>" + esc(e.name) + "</h3>" +
+      '<div class="badges">' +
       '<span class="badge ' + esc(normalizeStatus(e.status)) + '">' + esc(statusLabel(e.status)) + "</span>" +
       '<span class="badge ' + (e.kind === "trial" ? "trial" : "registry") + '">' +
       esc(e.kind === "trial" ? t("trial") : t("registry")) + "</span></div>";
-    if (e.projected_from_year) {
-      html += '<p class="event-meta" style="margin-top:8px">' + t("projected") + " " +
-        esc(String(e.projected_from_year)) + " (" + esc(e.projected_from_start || "") + ")</p>";
-    }
+    if (where) left += '<p class="event-meta l2-event-card__where">' + esc(where) + "</p>";
     if (e.url) {
-      html += '<p style="margin-top:10px"><a href="' + esc(e.url) + '" target="_blank" rel="noopener noreferrer">' +
-        t("website") + "</a></p>";
+      left += '<p class="l2-event-card__link"><a href="' + esc(e.url) +
+        '" target="_blank" rel="noopener noreferrer">' + t("website") + "</a></p>";
     }
-    detail.innerHTML = html;
+    if (card && card.series) {
+      var first = card.series.first_edition;
+      if (first) {
+        left += '<p class="event-meta">' + esc(t("firstEdition")) + ": " +
+          esc(monthYearLabel(first.year, first.month)) + "</p>";
+      }
+      if (card.series.editions_with_results != null) {
+        left += '<p class="event-meta">' + esc(t("editionsCount")) + ": " +
+          esc(String(card.series.editions_with_results)) + "</p>";
+      }
+    }
+    left += "</div>";
+
+    var right = '<div class="l2-event-card__last">';
+    if (card && card.last_edition) {
+      var last = card.last_edition;
+      right += '<div class="l2-event-card__last-head">' +
+        '<span class="l2-event-card__last-label">' + esc(t("lastEdition")) + "</span>" +
+        '<span class="l2-event-card__last-date">' +
+        esc(monthYearLabel(last.year, last.month)) + "</span>";
+      if (tip) {
+        right += '<button type="button" class="l2-tier-tip" id="l2TierTip" aria-label="' +
+          esc(t("tierTipAria")) + '">' +
+          '<span class="l2-tier-tip__mark" aria-hidden="true">i</span>' +
+          '<span class="l2-tier-tip__bubble" role="tooltip">' + esc(tip) + "</span>" +
+          "</button>";
+      }
+      right += "</div>";
+      right += '<div class="l2-event-card__metrics">' +
+        '<div class="l2-metric"><span class="l2-metric__value">' + esc(String(last.unique_dancers)) +
+        '</span><span class="l2-metric__label">' + esc(t("metricDancers")) + "</span></div>" +
+        '<div class="l2-metric"><span class="l2-metric__value">' + esc(String(last.points)) +
+        '</span><span class="l2-metric__label">' + esc(t("metricPoints")) + "</span></div>" +
+        '<div class="l2-metric"><span class="l2-metric__value">' + esc(String(last.new_dancers)) +
+        '</span><span class="l2-metric__label">' + esc(t("metricNew")) + "</span></div>" +
+        "</div>";
+      right += buildTierTableHtml(last.tiers || {});
+    }
+    right += "</div>";
+
+    detail.innerHTML = '<div class="l2-event-card__grid">' + left + right + "</div>";
     detail.classList.add("is-open");
     if (mapCol) mapCol.classList.add("has-event");
     refreshDayMapSize(preferReducedMotion() ? 0 : 230);
@@ -1470,6 +1587,11 @@
     renderYearSelect();
     refreshFilterOptions();
     renderCalendar();
+  }
+
+  function bootAll(calendar, cards) {
+    state.eventCards = cards || null;
+    boot(calendar);
   }
 
   document.getElementById("yearSelectMenu").addEventListener("click", function (e) {
@@ -1651,12 +1773,22 @@
   var params = new URLSearchParams(window.location.search);
   if (params.get("lang") && I18N[params.get("lang")]) state.lang = params.get("lang");
 
-  fetch("static/data/events_year_calendar.json?v=20260805b")
+  fetch("static/data/events_year_calendar.json?v=20260806a")
     .then(function (r) {
       if (!r.ok) throw new Error("Failed to load calendar data");
       return r.json();
     })
-    .then(boot)
+    .then(function (calendar) {
+      return fetch("static/data/event_l2_cards.json?v=20260806a")
+        .then(function (r) {
+          if (!r.ok) return null;
+          return r.json();
+        })
+        .catch(function () { return null; })
+        .then(function (cards) {
+          bootAll(calendar, cards);
+        });
+    })
     .catch(function (err) {
       var el = document.createElement("div");
       el.className = "error";

--- a/scripts/validate_site_data.py
+++ b/scripts/validate_site_data.py
@@ -178,6 +178,35 @@ def validate_events_year_calendar() -> None:
     print("[OK] events_year_calendar.json")
 
 
+def validate_event_l2_cards() -> None:
+    path = DATA_DIR / "event_l2_cards.json"
+    if not path.exists():
+        print("[SKIP] event_l2_cards.json (optional)")
+        return
+    data = load_json(path)
+    if not isinstance(data, dict):
+        fail("event_l2_cards.json must be an object")
+    for field in ("as_of", "generated_at", "tier_tip", "cards"):
+        if field not in data:
+            fail(f"event_l2_cards.json missing field: {field}")
+    tip = data["tier_tip"]
+    if not isinstance(tip, dict):
+        fail("event_l2_cards.json.tier_tip must be an object")
+    for lang in ("en", "ru", "es"):
+        if lang not in tip or not str(tip[lang]).strip():
+            fail(f"event_l2_cards.json.tier_tip missing {lang}")
+    cards = data["cards"]
+    if not isinstance(cards, dict) or not cards:
+        fail("event_l2_cards.json.cards must be a non-empty object")
+    sample_key = next(iter(cards))
+    sample = cards[sample_key]
+    if not isinstance(sample, dict):
+        fail(f"event_l2_cards.json.cards[{sample_key}] must be an object")
+    if "series" not in sample:
+        fail(f"event_l2_cards.json.cards[{sample_key}] missing series")
+    print(f"[OK] event_l2_cards.json ({len(cards)} cards)")
+
+
 def validate_homepage_kpis() -> None:
     path = DATA_DIR / "homepage_kpis.json"
     data = load_json(path)
@@ -220,6 +249,7 @@ def main() -> None:
     validate_champion_news()
     validate_homepage_kpis()
     validate_events_year_calendar()
+    validate_event_l2_cards()
     print("[OK] Data validation passed.")
 
 if __name__ == "__main__":

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -935,12 +935,12 @@ h1 {
   height: 100%;
   opacity: 0;
   overflow: hidden;
-  padding: 0 12px;
+  padding: 0 8px;
   margin: 0;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
   background: #fff;
-  font-size: 13px;
+  font-size: 12px;
   pointer-events: none;
   transition:
     opacity 180ms var(--ease-out),
@@ -954,23 +954,226 @@ h1 {
 
 .l2-event-card.is-open {
   opacity: 1;
-  overflow: auto;
-  padding: 10px 12px;
+  overflow: hidden;
+  padding: 8px 10px;
   border-color: var(--border-color);
   pointer-events: auto;
 }
 
+.l2-event-card__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 8px 10px;
+  height: 100%;
+  min-height: 0;
+}
+
+.l2-event-card__series,
+.l2-event-card__last {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
 .l2-event-card h3 {
-  margin: 0 0 4px;
-  font-size: 14px;
+  margin: 0;
+  font-size: 13px;
   font-weight: 650;
   letter-spacing: -0.01em;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.l2-event-card .badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.l2-event-card .event-meta {
+  font-size: 10px;
   line-height: 1.25;
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.l2-event-card__where {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.l2-event-card__link {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.2;
 }
 
 .l2-event-card a { color: var(--color-accent); }
-.event-meta { font-size: 11px; color: var(--text-secondary); margin: 0 0 2px; }
-.badges { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+
+.l2-event-card__last-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.l2-event-card__last-label {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.l2-event-card__last-date {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.l2-tier-tip {
+  position: relative;
+  margin-left: auto;
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: #fff;
+  padding: 0;
+  cursor: help;
+  color: var(--text-secondary);
+}
+
+.l2-tier-tip__mark {
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 14px;
+}
+
+.l2-tier-tip__bubble {
+  position: absolute;
+  z-index: 5;
+  right: 0;
+  top: calc(100% + 6px);
+  width: min(260px, 70vw);
+  padding: 8px 9px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  background: #fff;
+  box-shadow: var(--shadow-tip);
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1.35;
+  text-align: left;
+  opacity: 0;
+  transform: scale(0.97);
+  transform-origin: top right;
+  pointer-events: none;
+  transition: opacity 125ms var(--ease-out), transform 125ms var(--ease-out);
+}
+
+.l2-tier-tip:hover .l2-tier-tip__bubble,
+.l2-tier-tip:focus-visible .l2-tier-tip__bubble {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.l2-event-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.l2-metric {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  min-width: 0;
+}
+
+.l2-metric__value {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+}
+
+.l2-metric__label {
+  font-size: 8px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.l2-tier-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 4px;
+  font-size: 9px;
+  line-height: 1.15;
+  table-layout: fixed;
+}
+
+.l2-tier-table th,
+.l2-tier-table td {
+  padding: 2px 4px;
+  text-align: center;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.l2-tier-table thead th {
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.l2-tier-table tbody th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--text-secondary);
+  width: 38%;
+}
+
+.l2-tier-table .is-lead {
+  background: rgba(79, 70, 229, 0.07);
+  color: #3730a3;
+}
+
+.l2-tier-table .is-follow {
+  background: rgba(217, 119, 6, 0.1);
+  color: #92400e;
+}
+
+.l2-tier-table thead .is-lead,
+.l2-tier-table thead .is-follow {
+  color: var(--text-tertiary);
+}
+
+@media (max-width: 900px) {
+  .l2-event-card__grid {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto;
+  }
+}
 
 .badge {
   font-size: 10px;

--- a/static/data/event_l2_cards.json
+++ b/static/data/event_l2_cards.json
@@ -1,0 +1,10881 @@
+{
+  "as_of": "2026-08-05",
+  "generated_at": "2026-08-05T22:00:07Z",
+  "tier_tip": {
+    "en": "Tier reflects field size for that role under the WSDC points chart. Larger fields award higher placement points. Current ranges (per role, from 5 competitors): Tier 1: 5–10 · Tier 2: 11–19 · Tier 3: 20–39 · Tier 4: 40–79 · Tier 5: 80–129 · Tier 6: 130+.",
+    "ru": "Тир отражает размер поля в роли по чарту очков WSDC. Чем больше поле, тем выше очки за места. Текущие диапазоны (на роль, от 5 участников): Тир 1: 5–10 · Тир 2: 11–19 · Тир 3: 20–39 · Тир 4: 40–79 · Тир 5: 80–129 · Тир 6: 130+.",
+    "es": "El tier refleja el tamaño del campo por rol según la tabla de puntos WSDC. Campos más grandes dan más puntos por plaza. Rangos actuales (por rol, desde 5 competidores): Tier 1: 5–10 · Tier 2: 11–19 · Tier 3: 20–39 · Tier 4: 40–79 · Tier 5: 80–129 · Tier 6: 130+."
+  },
+  "cards": {
+    "1": {
+      "event_id": 1,
+      "series": {
+        "first_edition": {
+          "year": 1991,
+          "month": 7
+        },
+        "editions_with_results": 34
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 111,
+        "points": 441,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "2": {
+      "event_id": 2,
+      "series": {
+        "first_edition": {
+          "year": 1997,
+          "month": 7
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 1997,
+        "month": 7,
+        "unique_dancers": 4,
+        "points": 40,
+        "new_dancers": 2,
+        "tiers": {}
+      }
+    },
+    "3": {
+      "event_id": 3,
+      "series": {
+        "first_edition": {
+          "year": 2000,
+          "month": 10
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2003,
+        "month": 10,
+        "unique_dancers": 49,
+        "points": 169,
+        "new_dancers": 20,
+        "tiers": {}
+      }
+    },
+    "4": {
+      "event_id": 4,
+      "series": {
+        "first_edition": {
+          "year": 1994,
+          "month": 10
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 1998,
+        "month": 10,
+        "unique_dancers": 47,
+        "points": 208,
+        "new_dancers": 11,
+        "tiers": {}
+      }
+    },
+    "5": {
+      "event_id": 5,
+      "series": {
+        "first_edition": {
+          "year": 1998,
+          "month": 8
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 1998,
+        "month": 8,
+        "unique_dancers": 38,
+        "points": 3,
+        "new_dancers": 8,
+        "tiers": {}
+      }
+    },
+    "6": {
+      "event_id": 6,
+      "series": {
+        "first_edition": {
+          "year": 1992,
+          "month": 2
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 1995,
+        "month": 2,
+        "unique_dancers": 10,
+        "points": 76,
+        "new_dancers": 6,
+        "tiers": {}
+      }
+    },
+    "7": {
+      "event_id": 7,
+      "series": {
+        "first_edition": {
+          "year": 1995,
+          "month": 10
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2003,
+        "month": 10,
+        "unique_dancers": 67,
+        "points": 236,
+        "new_dancers": 6,
+        "tiers": {}
+      }
+    },
+    "8": {
+      "event_id": 8,
+      "series": {
+        "first_edition": {
+          "year": 1993,
+          "month": 10
+        },
+        "editions_with_results": 31
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 158,
+        "points": 742,
+        "new_dancers": 22,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Champions": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "9": {
+      "event_id": 9,
+      "series": {
+        "first_edition": {
+          "year": 1997,
+          "month": 3
+        },
+        "editions_with_results": 26
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 94,
+        "points": 399,
+        "new_dancers": 11,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "10": {
+      "event_id": 10,
+      "series": {
+        "first_edition": {
+          "year": 2001,
+          "month": 9
+        },
+        "editions_with_results": 21
+      },
+      "last_edition": {
+        "year": 2023,
+        "month": 9,
+        "unique_dancers": 102,
+        "points": 372,
+        "new_dancers": 19,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "11": {
+      "event_id": 11,
+      "series": {
+        "first_edition": {
+          "year": 1997,
+          "month": 5
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 1999,
+        "month": 5,
+        "unique_dancers": 24,
+        "points": 160,
+        "new_dancers": 4,
+        "tiers": {}
+      }
+    },
+    "12": {
+      "event_id": 12,
+      "series": {
+        "first_edition": {
+          "year": 1993,
+          "month": 2
+        },
+        "editions_with_results": 32
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 2,
+        "unique_dancers": 121,
+        "points": 552,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "13": {
+      "event_id": 13,
+      "series": {
+        "first_edition": {
+          "year": 1997,
+          "month": 3
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2012,
+        "month": 3,
+        "unique_dancers": 134,
+        "points": 505,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "14": {
+      "event_id": 14,
+      "series": {
+        "first_edition": {
+          "year": 1994,
+          "month": 2
+        },
+        "editions_with_results": 6
+      },
+      "last_edition": {
+        "year": 1999,
+        "month": 2,
+        "unique_dancers": 22,
+        "points": 152,
+        "new_dancers": 4,
+        "tiers": {}
+      }
+    },
+    "15": {
+      "event_id": 15,
+      "series": {
+        "first_edition": {
+          "year": 1992,
+          "month": 9
+        },
+        "editions_with_results": 27
+      },
+      "last_edition": {
+        "year": 2018,
+        "month": 9,
+        "unique_dancers": 18,
+        "points": 46,
+        "new_dancers": 0,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "16": {
+      "event_id": 16,
+      "series": {
+        "first_edition": {
+          "year": 1992,
+          "month": 3
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2001,
+        "month": 3,
+        "unique_dancers": 52,
+        "points": 21,
+        "new_dancers": 7,
+        "tiers": {}
+      }
+    },
+    "17": {
+      "event_id": 17,
+      "series": {
+        "first_edition": {
+          "year": 1996,
+          "month": 7
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 1996,
+        "month": 7,
+        "unique_dancers": 6,
+        "points": 40,
+        "new_dancers": 2,
+        "tiers": {}
+      }
+    },
+    "18": {
+      "event_id": 18,
+      "series": {
+        "first_edition": {
+          "year": 1994,
+          "month": 4
+        },
+        "editions_with_results": 30
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 137,
+        "points": 677,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "19": {
+      "event_id": 19,
+      "series": {
+        "first_edition": {
+          "year": 2000,
+          "month": 5
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2010,
+        "month": 5,
+        "unique_dancers": 38,
+        "points": 117,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "20": {
+      "event_id": 20,
+      "series": {
+        "first_edition": {
+          "year": 1994,
+          "month": 5
+        },
+        "editions_with_results": 26
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 5,
+        "unique_dancers": 107,
+        "points": 369,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "21": {
+      "event_id": 21,
+      "series": {
+        "first_edition": {
+          "year": 1996,
+          "month": 4
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 1998,
+        "month": 4,
+        "unique_dancers": 30,
+        "points": 172,
+        "new_dancers": 8,
+        "tiers": {}
+      }
+    },
+    "22": {
+      "event_id": 22,
+      "series": {
+        "first_edition": {
+          "year": 1996,
+          "month": 5
+        },
+        "editions_with_results": 28
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 120,
+        "points": 518,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "23": {
+      "event_id": 23,
+      "series": {
+        "first_edition": {
+          "year": 1999,
+          "month": 8
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 1999,
+        "month": 8,
+        "unique_dancers": 38,
+        "points": 196,
+        "new_dancers": 6,
+        "tiers": {}
+      }
+    },
+    "24": {
+      "event_id": 24,
+      "series": {
+        "first_edition": {
+          "year": 1996,
+          "month": 8
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 1996,
+        "month": 8,
+        "unique_dancers": 37,
+        "points": 187,
+        "new_dancers": 9,
+        "tiers": {}
+      }
+    },
+    "25": {
+      "event_id": 25,
+      "series": {
+        "first_edition": {
+          "year": 1995,
+          "month": 6
+        },
+        "editions_with_results": 29
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 6,
+        "unique_dancers": 131,
+        "points": 701,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 6
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Champions": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "26": {
+      "event_id": 26,
+      "series": {
+        "first_edition": {
+          "year": 1999,
+          "month": 2
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 1999,
+        "month": 2,
+        "unique_dancers": 12,
+        "points": 80,
+        "new_dancers": 12,
+        "tiers": {}
+      }
+    },
+    "27": {
+      "event_id": 27,
+      "series": {
+        "first_edition": {
+          "year": 1994,
+          "month": 9
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 1997,
+        "month": 9,
+        "unique_dancers": 40,
+        "points": 200,
+        "new_dancers": 4,
+        "tiers": {}
+      }
+    },
+    "28": {
+      "event_id": 28,
+      "series": {
+        "first_edition": {
+          "year": 1992,
+          "month": 1
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2004,
+        "month": 1,
+        "unique_dancers": 26,
+        "points": 150,
+        "new_dancers": 2,
+        "tiers": {}
+      }
+    },
+    "29": {
+      "event_id": 29,
+      "series": {
+        "first_edition": {
+          "year": 1992,
+          "month": 8
+        },
+        "editions_with_results": 11
+      },
+      "last_edition": {
+        "year": 2003,
+        "month": 8,
+        "unique_dancers": 16,
+        "points": 92,
+        "new_dancers": 0,
+        "tiers": {}
+      }
+    },
+    "30": {
+      "event_id": 30,
+      "series": {
+        "first_edition": {
+          "year": 2002,
+          "month": 3
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2003,
+        "month": 3,
+        "unique_dancers": 18,
+        "points": 120,
+        "new_dancers": 6,
+        "tiers": {}
+      }
+    },
+    "31": {
+      "event_id": 31,
+      "series": {
+        "first_edition": {
+          "year": 1999,
+          "month": 11
+        },
+        "editions_with_results": 25
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 51,
+        "points": 177,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "32": {
+      "event_id": 32,
+      "series": {
+        "first_edition": {
+          "year": 2001,
+          "month": 7
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2007,
+        "month": 7,
+        "unique_dancers": 30,
+        "points": 126,
+        "new_dancers": 11,
+        "tiers": {}
+      }
+    },
+    "33": {
+      "event_id": 33,
+      "series": {
+        "first_edition": {
+          "year": 1994,
+          "month": 12
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 1995,
+        "month": 12,
+        "unique_dancers": 11,
+        "points": 76,
+        "new_dancers": 3,
+        "tiers": {}
+      }
+    },
+    "34": {
+      "event_id": 34,
+      "series": {
+        "first_edition": {
+          "year": 1998,
+          "month": 9
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2001,
+        "month": 9,
+        "unique_dancers": 40,
+        "points": 50,
+        "new_dancers": 8,
+        "tiers": {}
+      }
+    },
+    "35": {
+      "event_id": 35,
+      "series": {
+        "first_edition": {
+          "year": 1995,
+          "month": 11
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 1996,
+        "month": 11,
+        "unique_dancers": 17,
+        "points": 58,
+        "new_dancers": 10,
+        "tiers": {}
+      }
+    },
+    "36": {
+      "event_id": 36,
+      "series": {
+        "first_edition": {
+          "year": 1997,
+          "month": 12
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2000,
+        "month": 12,
+        "unique_dancers": 61,
+        "points": 27,
+        "new_dancers": 11,
+        "tiers": {}
+      }
+    },
+    "38": {
+      "event_id": 38,
+      "series": {
+        "first_edition": {
+          "year": 1999,
+          "month": 1
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2000,
+        "month": 1,
+        "unique_dancers": 58,
+        "points": 234,
+        "new_dancers": 8,
+        "tiers": {}
+      }
+    },
+    "40": {
+      "event_id": 40,
+      "series": {
+        "first_edition": {
+          "year": 1998,
+          "month": 4
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2004,
+        "month": 4,
+        "unique_dancers": 29,
+        "points": 106,
+        "new_dancers": 0,
+        "tiers": {}
+      }
+    },
+    "41": {
+      "event_id": 41,
+      "series": {
+        "first_edition": {
+          "year": 2000,
+          "month": 10
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2002,
+        "month": 10,
+        "unique_dancers": 46,
+        "points": 197,
+        "new_dancers": 9,
+        "tiers": {}
+      }
+    },
+    "42": {
+      "event_id": 42,
+      "series": {
+        "first_edition": {
+          "year": 2001,
+          "month": 12
+        },
+        "editions_with_results": 20
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 92,
+        "points": 351,
+        "new_dancers": 13,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "43": {
+      "event_id": 43,
+      "series": {
+        "first_edition": {
+          "year": 1995,
+          "month": 10
+        },
+        "editions_with_results": 23
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 78,
+        "points": 297,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "44": {
+      "event_id": 44,
+      "series": {
+        "first_edition": {
+          "year": 1997,
+          "month": 6
+        },
+        "editions_with_results": 16
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 7,
+        "unique_dancers": 69,
+        "points": 228,
+        "new_dancers": 2,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "45": {
+      "event_id": 45,
+      "series": {
+        "first_edition": {
+          "year": 1997,
+          "month": 10
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2000,
+        "month": 10,
+        "unique_dancers": 74,
+        "points": 234,
+        "new_dancers": 20,
+        "tiers": {}
+      }
+    },
+    "46": {
+      "event_id": 46,
+      "series": {
+        "first_edition": {
+          "year": 1996,
+          "month": 5
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 1996,
+        "month": 5,
+        "unique_dancers": 31,
+        "points": 108,
+        "new_dancers": 13,
+        "tiers": {}
+      }
+    },
+    "47": {
+      "event_id": 47,
+      "series": {
+        "first_edition": {
+          "year": 1992,
+          "month": 8
+        },
+        "editions_with_results": 32
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 129,
+        "points": 569,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "48": {
+      "event_id": 48,
+      "series": {
+        "first_edition": {
+          "year": 1997,
+          "month": 8
+        },
+        "editions_with_results": 24
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 69,
+        "points": 294,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "49": {
+      "event_id": 49,
+      "series": {
+        "first_edition": {
+          "year": 1991,
+          "month": 5
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 1998,
+        "month": 5,
+        "unique_dancers": 76,
+        "points": 281,
+        "new_dancers": 16,
+        "tiers": {}
+      }
+    },
+    "50": {
+      "event_id": 50,
+      "series": {
+        "first_edition": {
+          "year": 2002,
+          "month": 3
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2003,
+        "month": 3,
+        "unique_dancers": 75,
+        "points": 273,
+        "new_dancers": 4,
+        "tiers": {}
+      }
+    },
+    "51": {
+      "event_id": 51,
+      "series": {
+        "first_edition": {
+          "year": 1998,
+          "month": 9
+        },
+        "editions_with_results": 20
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 8,
+        "unique_dancers": 76,
+        "points": 248,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "52": {
+      "event_id": 52,
+      "series": {
+        "first_edition": {
+          "year": 1994,
+          "month": 7
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2003,
+        "month": 7,
+        "unique_dancers": 52,
+        "points": 212,
+        "new_dancers": 4,
+        "tiers": {}
+      }
+    },
+    "53": {
+      "event_id": 53,
+      "series": {
+        "first_edition": {
+          "year": 1997,
+          "month": 8
+        },
+        "editions_with_results": 25
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 123,
+        "points": 558,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "54": {
+      "event_id": 54,
+      "series": {
+        "first_edition": {
+          "year": 2001,
+          "month": 9
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2002,
+        "month": 9,
+        "unique_dancers": 28,
+        "points": 176,
+        "new_dancers": 14,
+        "tiers": {}
+      }
+    },
+    "55": {
+      "event_id": 55,
+      "series": {
+        "first_edition": {
+          "year": 1998,
+          "month": 9
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 1998,
+        "month": 9,
+        "unique_dancers": 62,
+        "points": 222,
+        "new_dancers": 13,
+        "tiers": {}
+      }
+    },
+    "56": {
+      "event_id": 56,
+      "series": {
+        "first_edition": {
+          "year": 1999,
+          "month": 4
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2000,
+        "month": 4,
+        "unique_dancers": 77,
+        "points": 34,
+        "new_dancers": 13,
+        "tiers": {}
+      }
+    },
+    "57": {
+      "event_id": 57,
+      "series": {
+        "first_edition": {
+          "year": 1996,
+          "month": 8
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 1998,
+        "month": 8,
+        "unique_dancers": 12,
+        "points": 80,
+        "new_dancers": 6,
+        "tiers": {}
+      }
+    },
+    "58": {
+      "event_id": 58,
+      "series": {
+        "first_edition": {
+          "year": 1993,
+          "month": 1
+        },
+        "editions_with_results": 11
+      },
+      "last_edition": {
+        "year": 2003,
+        "month": 1,
+        "unique_dancers": 52,
+        "points": 226,
+        "new_dancers": 6,
+        "tiers": {}
+      }
+    },
+    "59": {
+      "event_id": 59,
+      "series": {
+        "first_edition": {
+          "year": 1994,
+          "month": 7
+        },
+        "editions_with_results": 30
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 133,
+        "points": 618,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "60": {
+      "event_id": 60,
+      "series": {
+        "first_edition": {
+          "year": 1993,
+          "month": 4
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 1997,
+        "month": 4,
+        "unique_dancers": 25,
+        "points": 51,
+        "new_dancers": 4,
+        "tiers": {}
+      }
+    },
+    "61": {
+      "event_id": 61,
+      "series": {
+        "first_edition": {
+          "year": 2002,
+          "month": 1
+        },
+        "editions_with_results": 18
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 5,
+        "unique_dancers": 108,
+        "points": 403,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "62": {
+      "event_id": 62,
+      "series": {
+        "first_edition": {
+          "year": 1994,
+          "month": 1
+        },
+        "editions_with_results": 32
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 136,
+        "points": 582,
+        "new_dancers": 18,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "63": {
+      "event_id": 63,
+      "series": {
+        "first_edition": {
+          "year": 1999,
+          "month": 11
+        },
+        "editions_with_results": 20
+      },
+      "last_edition": {
+        "year": 2018,
+        "month": 11,
+        "unique_dancers": 86,
+        "points": 272,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "64": {
+      "event_id": 64,
+      "series": {
+        "first_edition": {
+          "year": 1997,
+          "month": 6
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 1999,
+        "month": 6,
+        "unique_dancers": 16,
+        "points": 112,
+        "new_dancers": 12,
+        "tiers": {}
+      }
+    },
+    "65": {
+      "event_id": 65,
+      "series": {
+        "first_edition": {
+          "year": 1994,
+          "month": 10
+        },
+        "editions_with_results": 30
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 104,
+        "points": 405,
+        "new_dancers": 10,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "67": {
+      "event_id": 67,
+      "series": {
+        "first_edition": {
+          "year": 1995,
+          "month": 5
+        },
+        "editions_with_results": 19
+      },
+      "last_edition": {
+        "year": 2014,
+        "month": 1,
+        "unique_dancers": 91,
+        "points": 374,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "68": {
+      "event_id": 68,
+      "series": {
+        "first_edition": {
+          "year": 1992,
+          "month": 11
+        },
+        "editions_with_results": 26
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 135,
+        "points": 626,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Champions": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "69": {
+      "event_id": 69,
+      "series": {
+        "first_edition": {
+          "year": 1999,
+          "month": 9
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 1999,
+        "month": 9,
+        "unique_dancers": 48,
+        "points": 0,
+        "new_dancers": 9,
+        "tiers": {}
+      }
+    },
+    "70": {
+      "event_id": 70,
+      "series": {
+        "first_edition": {
+          "year": 1993,
+          "month": 9
+        },
+        "editions_with_results": 17
+      },
+      "last_edition": {
+        "year": 2010,
+        "month": 11,
+        "unique_dancers": 60,
+        "points": 190,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "71": {
+      "event_id": 71,
+      "series": {
+        "first_edition": {
+          "year": 1997,
+          "month": 7
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2000,
+        "month": 7,
+        "unique_dancers": 56,
+        "points": 18,
+        "new_dancers": 4,
+        "tiers": {}
+      }
+    },
+    "72": {
+      "event_id": 72,
+      "series": {
+        "first_edition": {
+          "year": 1994,
+          "month": 7
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 1995,
+        "month": 7,
+        "unique_dancers": 26,
+        "points": 132,
+        "new_dancers": 14,
+        "tiers": {}
+      }
+    },
+    "73": {
+      "event_id": 73,
+      "series": {
+        "first_edition": {
+          "year": 1993,
+          "month": 5
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2011,
+        "month": 7,
+        "unique_dancers": 23,
+        "points": 89,
+        "new_dancers": 4,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "75": {
+      "event_id": 75,
+      "series": {
+        "first_edition": {
+          "year": 1995,
+          "month": 12
+        },
+        "editions_with_results": 18
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 69,
+        "points": 271,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "76": {
+      "event_id": 76,
+      "series": {
+        "first_edition": {
+          "year": 2002,
+          "month": 7
+        },
+        "editions_with_results": 18
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 88,
+        "points": 367,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "77": {
+      "event_id": 77,
+      "series": {
+        "first_edition": {
+          "year": 2002,
+          "month": 8
+        },
+        "editions_with_results": 19
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 57,
+        "points": 177,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "78": {
+      "event_id": 78,
+      "series": {
+        "first_edition": {
+          "year": 2002,
+          "month": 9
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2004,
+        "month": 9,
+        "unique_dancers": 54,
+        "points": 174,
+        "new_dancers": 4,
+        "tiers": {}
+      }
+    },
+    "79": {
+      "event_id": 79,
+      "series": {
+        "first_edition": {
+          "year": 2002,
+          "month": 9
+        },
+        "editions_with_results": 17
+      },
+      "last_edition": {
+        "year": 2024,
+        "month": 11,
+        "unique_dancers": 121,
+        "points": 498,
+        "new_dancers": 20,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "80": {
+      "event_id": 80,
+      "series": {
+        "first_edition": {
+          "year": 2002,
+          "month": 11
+        },
+        "editions_with_results": 6
+      },
+      "last_edition": {
+        "year": 2007,
+        "month": 11,
+        "unique_dancers": 29,
+        "points": 108,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "81": {
+      "event_id": 81,
+      "series": {
+        "first_edition": {
+          "year": 2002,
+          "month": 10
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2006,
+        "month": 10,
+        "unique_dancers": 73,
+        "points": 275,
+        "new_dancers": 7,
+        "tiers": {}
+      }
+    },
+    "82": {
+      "event_id": 82,
+      "series": {
+        "first_edition": {
+          "year": 2003,
+          "month": 2
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2007,
+        "month": 2,
+        "unique_dancers": 5,
+        "points": 32,
+        "new_dancers": 2,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "83": {
+      "event_id": 83,
+      "series": {
+        "first_edition": {
+          "year": 2003,
+          "month": 5
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2003,
+        "month": 5,
+        "unique_dancers": 34,
+        "points": 154,
+        "new_dancers": 10,
+        "tiers": {}
+      }
+    },
+    "84": {
+      "event_id": 84,
+      "series": {
+        "first_edition": {
+          "year": 2003,
+          "month": 7
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2012,
+        "month": 7,
+        "unique_dancers": 60,
+        "points": 209,
+        "new_dancers": 4,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "85": {
+      "event_id": 85,
+      "series": {
+        "first_edition": {
+          "year": 2003,
+          "month": 6
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2006,
+        "month": 6,
+        "unique_dancers": 40,
+        "points": 160,
+        "new_dancers": 6,
+        "tiers": {}
+      }
+    },
+    "86": {
+      "event_id": 86,
+      "series": {
+        "first_edition": {
+          "year": 2003,
+          "month": 7
+        },
+        "editions_with_results": 6
+      },
+      "last_edition": {
+        "year": 2009,
+        "month": 7,
+        "unique_dancers": 19,
+        "points": 58,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "87": {
+      "event_id": 87,
+      "series": {
+        "first_edition": {
+          "year": 2003,
+          "month": 11
+        },
+        "editions_with_results": 21
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 50,
+        "points": 165,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "88": {
+      "event_id": 88,
+      "series": {
+        "first_edition": {
+          "year": 2003,
+          "month": 11
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2003,
+        "month": 11,
+        "unique_dancers": 51,
+        "points": 211,
+        "new_dancers": 17,
+        "tiers": {}
+      }
+    },
+    "89": {
+      "event_id": 89,
+      "series": {
+        "first_edition": {
+          "year": 2003,
+          "month": 10
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2005,
+        "month": 10,
+        "unique_dancers": 49,
+        "points": 206,
+        "new_dancers": 5,
+        "tiers": {}
+      }
+    },
+    "90": {
+      "event_id": 90,
+      "series": {
+        "first_edition": {
+          "year": 2003,
+          "month": 4
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2003,
+        "month": 4,
+        "unique_dancers": 38,
+        "points": 158,
+        "new_dancers": 20,
+        "tiers": {}
+      }
+    },
+    "91": {
+      "event_id": 91,
+      "series": {
+        "first_edition": {
+          "year": 2004,
+          "month": 3
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2011,
+        "month": 4,
+        "unique_dancers": 93,
+        "points": 335,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "92": {
+      "event_id": 92,
+      "series": {
+        "first_edition": {
+          "year": 2004,
+          "month": 3
+        },
+        "editions_with_results": 21
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 180,
+        "points": 974,
+        "new_dancers": 23,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 6
+          },
+          "Intermediate": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "All-Star": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Champions": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "93": {
+      "event_id": 93,
+      "series": {
+        "first_edition": {
+          "year": 2004,
+          "month": 5
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2007,
+        "month": 5,
+        "unique_dancers": 10,
+        "points": 56,
+        "new_dancers": 0,
+        "tiers": {
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "94": {
+      "event_id": 94,
+      "series": {
+        "first_edition": {
+          "year": 2004,
+          "month": 6
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2004,
+        "month": 6,
+        "unique_dancers": 10,
+        "points": 50,
+        "new_dancers": 7,
+        "tiers": {}
+      }
+    },
+    "95": {
+      "event_id": 95,
+      "series": {
+        "first_edition": {
+          "year": 2004,
+          "month": 6
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2012,
+        "month": 9,
+        "unique_dancers": 82,
+        "points": 288,
+        "new_dancers": 10,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "96": {
+      "event_id": 96,
+      "series": {
+        "first_edition": {
+          "year": 2004,
+          "month": 6
+        },
+        "editions_with_results": 21
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 6,
+        "unique_dancers": 132,
+        "points": 581,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "97": {
+      "event_id": 97,
+      "series": {
+        "first_edition": {
+          "year": 2004,
+          "month": 7
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2011,
+        "month": 8,
+        "unique_dancers": 48,
+        "points": 155,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "98": {
+      "event_id": 98,
+      "series": {
+        "first_edition": {
+          "year": 2004,
+          "month": 8
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2004,
+        "month": 8,
+        "unique_dancers": 28,
+        "points": 141,
+        "new_dancers": 14,
+        "tiers": {}
+      }
+    },
+    "100": {
+      "event_id": 100,
+      "series": {
+        "first_edition": {
+          "year": 2004,
+          "month": 9
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2014,
+        "month": 9,
+        "unique_dancers": 24,
+        "points": 79,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "101": {
+      "event_id": 101,
+      "series": {
+        "first_edition": {
+          "year": 2004,
+          "month": 1
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2004,
+        "month": 1,
+        "unique_dancers": 10,
+        "points": 50,
+        "new_dancers": 0,
+        "tiers": {}
+      }
+    },
+    "102": {
+      "event_id": 102,
+      "series": {
+        "first_edition": {
+          "year": 2005,
+          "month": 1
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2005,
+        "month": 1,
+        "unique_dancers": 30,
+        "points": 110,
+        "new_dancers": 9,
+        "tiers": {}
+      }
+    },
+    "103": {
+      "event_id": 103,
+      "series": {
+        "first_edition": {
+          "year": 2005,
+          "month": 2
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2005,
+        "month": 2,
+        "unique_dancers": 36,
+        "points": 156,
+        "new_dancers": 16,
+        "tiers": {}
+      }
+    },
+    "104": {
+      "event_id": 104,
+      "series": {
+        "first_edition": {
+          "year": 2005,
+          "month": 4
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2011,
+        "month": 4,
+        "unique_dancers": 58,
+        "points": 190,
+        "new_dancers": 3,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "105": {
+      "event_id": 105,
+      "series": {
+        "first_edition": {
+          "year": 2005,
+          "month": 5
+        },
+        "editions_with_results": 18
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 53,
+        "points": 180,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "106": {
+      "event_id": 106,
+      "series": {
+        "first_edition": {
+          "year": 2005,
+          "month": 4
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2006,
+        "month": 4,
+        "unique_dancers": 28,
+        "points": 145,
+        "new_dancers": 5,
+        "tiers": {}
+      }
+    },
+    "107": {
+      "event_id": 107,
+      "series": {
+        "first_edition": {
+          "year": 2005,
+          "month": 4
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2007,
+        "month": 4,
+        "unique_dancers": 40,
+        "points": 154,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "108": {
+      "event_id": 108,
+      "series": {
+        "first_edition": {
+          "year": 2005,
+          "month": 5
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2006,
+        "month": 5,
+        "unique_dancers": 10,
+        "points": 50,
+        "new_dancers": 4,
+        "tiers": {}
+      }
+    },
+    "109": {
+      "event_id": 109,
+      "series": {
+        "first_edition": {
+          "year": 2005,
+          "month": 6
+        },
+        "editions_with_results": 18
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 6,
+        "unique_dancers": 67,
+        "points": 230,
+        "new_dancers": 13,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "110": {
+      "event_id": 110,
+      "series": {
+        "first_edition": {
+          "year": 2005,
+          "month": 7
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2007,
+        "month": 7,
+        "unique_dancers": 18,
+        "points": 84,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "111": {
+      "event_id": 111,
+      "series": {
+        "first_edition": {
+          "year": 2005,
+          "month": 8
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2006,
+        "month": 8,
+        "unique_dancers": 51,
+        "points": 212,
+        "new_dancers": 7,
+        "tiers": {}
+      }
+    },
+    "112": {
+      "event_id": 112,
+      "series": {
+        "first_edition": {
+          "year": 2005,
+          "month": 10
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2006,
+        "month": 10,
+        "unique_dancers": 9,
+        "points": 46,
+        "new_dancers": 2,
+        "tiers": {}
+      }
+    },
+    "113": {
+      "event_id": 113,
+      "series": {
+        "first_edition": {
+          "year": 2005,
+          "month": 11
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2006,
+        "month": 11,
+        "unique_dancers": 20,
+        "points": 100,
+        "new_dancers": 3,
+        "tiers": {}
+      }
+    },
+    "114": {
+      "event_id": 114,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 3
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2007,
+        "month": 3,
+        "unique_dancers": 39,
+        "points": 169,
+        "new_dancers": 1,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "115": {
+      "event_id": 115,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 2
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2010,
+        "month": 2,
+        "unique_dancers": 29,
+        "points": 87,
+        "new_dancers": 12,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "116": {
+      "event_id": 116,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 4
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 67,
+        "points": 264,
+        "new_dancers": 13,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "117": {
+      "event_id": 117,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 6
+        },
+        "editions_with_results": 20
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 6,
+        "unique_dancers": 48,
+        "points": 173,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "119": {
+      "event_id": 119,
+      "series": {
+        "first_edition": {
+          "year": 2004,
+          "month": 8
+        },
+        "editions_with_results": 21
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 65,
+        "points": 208,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "120": {
+      "event_id": 120,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 8
+        },
+        "editions_with_results": 19
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 23,
+        "points": 73,
+        "new_dancers": 4,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "121": {
+      "event_id": 121,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 5
+        },
+        "editions_with_results": 18
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 41,
+        "points": 129,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "122": {
+      "event_id": 122,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 8
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2008,
+        "month": 8,
+        "unique_dancers": 18,
+        "points": 79,
+        "new_dancers": 2,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "123": {
+      "event_id": 123,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 7
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2007,
+        "month": 7,
+        "unique_dancers": 30,
+        "points": 126,
+        "new_dancers": 4,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "124": {
+      "event_id": 124,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 10
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2006,
+        "month": 10,
+        "unique_dancers": 39,
+        "points": 139,
+        "new_dancers": 10,
+        "tiers": {}
+      }
+    },
+    "125": {
+      "event_id": 125,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 10
+        },
+        "editions_with_results": 18
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 122,
+        "points": 544,
+        "new_dancers": 22,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "126": {
+      "event_id": 126,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 10
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2012,
+        "month": 12,
+        "unique_dancers": 97,
+        "points": 378,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "127": {
+      "event_id": 127,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 10
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2008,
+        "month": 10,
+        "unique_dancers": 30,
+        "points": 126,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "128": {
+      "event_id": 128,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 10
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2006,
+        "month": 10,
+        "unique_dancers": 18,
+        "points": 58,
+        "new_dancers": 7,
+        "tiers": {}
+      }
+    },
+    "129": {
+      "event_id": 129,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 11
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2009,
+        "month": 11,
+        "unique_dancers": 38,
+        "points": 126,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "130": {
+      "event_id": 130,
+      "series": {
+        "first_edition": {
+          "year": 2006,
+          "month": 9
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2010,
+        "month": 9,
+        "unique_dancers": 10,
+        "points": 30,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "131": {
+      "event_id": 131,
+      "series": {
+        "first_edition": {
+          "year": 2007,
+          "month": 9
+        },
+        "editions_with_results": 17
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 101,
+        "points": 431,
+        "new_dancers": 11,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "132": {
+      "event_id": 132,
+      "series": {
+        "first_edition": {
+          "year": 2007,
+          "month": 3
+        },
+        "editions_with_results": 15
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 73,
+        "points": 284,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "134": {
+      "event_id": 134,
+      "series": {
+        "first_edition": {
+          "year": 2007,
+          "month": 4
+        },
+        "editions_with_results": 16
+      },
+      "last_edition": {
+        "year": 2024,
+        "month": 5,
+        "unique_dancers": 58,
+        "points": 189,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "135": {
+      "event_id": 135,
+      "series": {
+        "first_edition": {
+          "year": 2007,
+          "month": 9
+        },
+        "editions_with_results": 18
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 128,
+        "points": 635,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 3,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "136": {
+      "event_id": 136,
+      "series": {
+        "first_edition": {
+          "year": 2007,
+          "month": 10
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2009,
+        "month": 10,
+        "unique_dancers": 8,
+        "points": 27,
+        "new_dancers": 2,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "137": {
+      "event_id": 137,
+      "series": {
+        "first_edition": {
+          "year": 2007,
+          "month": 11
+        },
+        "editions_with_results": 15
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 83,
+        "points": 347,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "138": {
+      "event_id": 138,
+      "series": {
+        "first_edition": {
+          "year": 2007,
+          "month": 11
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2008,
+        "month": 11,
+        "unique_dancers": 27,
+        "points": 122,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "139": {
+      "event_id": 139,
+      "series": {
+        "first_edition": {
+          "year": 2007,
+          "month": 12
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2011,
+        "month": 1,
+        "unique_dancers": 69,
+        "points": 257,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "140": {
+      "event_id": 140,
+      "series": {
+        "first_edition": {
+          "year": 2007,
+          "month": 12
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2007,
+        "month": 12,
+        "unique_dancers": 20,
+        "points": 84,
+        "new_dancers": 12,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "141": {
+      "event_id": 141,
+      "series": {
+        "first_edition": {
+          "year": 2007,
+          "month": 12
+        },
+        "editions_with_results": 15
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 142,
+        "points": 618,
+        "new_dancers": 19,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "142": {
+      "event_id": 142,
+      "series": {
+        "first_edition": {
+          "year": 2008,
+          "month": 3
+        },
+        "editions_with_results": 14
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 154,
+        "points": 732,
+        "new_dancers": 20,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "143": {
+      "event_id": 143,
+      "series": {
+        "first_edition": {
+          "year": 2008,
+          "month": 3
+        },
+        "editions_with_results": 15
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 83,
+        "points": 317,
+        "new_dancers": 11,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "144": {
+      "event_id": 144,
+      "series": {
+        "first_edition": {
+          "year": 2008,
+          "month": 5
+        },
+        "editions_with_results": 16
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 51,
+        "points": 228,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "145": {
+      "event_id": 145,
+      "series": {
+        "first_edition": {
+          "year": 2008,
+          "month": 5
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2010,
+        "month": 5,
+        "unique_dancers": 40,
+        "points": 130,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "146": {
+      "event_id": 146,
+      "series": {
+        "first_edition": {
+          "year": 2008,
+          "month": 7
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2012,
+        "month": 7,
+        "unique_dancers": 60,
+        "points": 226,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "147": {
+      "event_id": 147,
+      "series": {
+        "first_edition": {
+          "year": 2008,
+          "month": 7
+        },
+        "editions_with_results": 14
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 7,
+        "unique_dancers": 78,
+        "points": 321,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "148": {
+      "event_id": 148,
+      "series": {
+        "first_edition": {
+          "year": 2008,
+          "month": 7
+        },
+        "editions_with_results": 14
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 7,
+        "unique_dancers": 37,
+        "points": 141,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "149": {
+      "event_id": 149,
+      "series": {
+        "first_edition": {
+          "year": 2008,
+          "month": 7
+        },
+        "editions_with_results": 16
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 99,
+        "points": 413,
+        "new_dancers": 21,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "150": {
+      "event_id": 150,
+      "series": {
+        "first_edition": {
+          "year": 2008,
+          "month": 10
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2008,
+        "month": 10,
+        "unique_dancers": 34,
+        "points": 145,
+        "new_dancers": 1,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "151": {
+      "event_id": 151,
+      "series": {
+        "first_edition": {
+          "year": 2008,
+          "month": 11
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2011,
+        "month": 11,
+        "unique_dancers": 36,
+        "points": 112,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "152": {
+      "event_id": 152,
+      "series": {
+        "first_edition": {
+          "year": 2009,
+          "month": 12
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2015,
+        "month": 1,
+        "unique_dancers": 45,
+        "points": 150,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "153": {
+      "event_id": 153,
+      "series": {
+        "first_edition": {
+          "year": 2009,
+          "month": 3
+        },
+        "editions_with_results": 16
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 101,
+        "points": 389,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "154": {
+      "event_id": 154,
+      "series": {
+        "first_edition": {
+          "year": 2009,
+          "month": 4
+        },
+        "editions_with_results": 13
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 154,
+        "points": 755,
+        "new_dancers": 19,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "155": {
+      "event_id": 155,
+      "series": {
+        "first_edition": {
+          "year": 2009,
+          "month": 7
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2011,
+        "month": 7,
+        "unique_dancers": 30,
+        "points": 100,
+        "new_dancers": 10,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "156": {
+      "event_id": 156,
+      "series": {
+        "first_edition": {
+          "year": 2009,
+          "month": 7
+        },
+        "editions_with_results": 16
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 47,
+        "points": 171,
+        "new_dancers": 4,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "157": {
+      "event_id": 157,
+      "series": {
+        "first_edition": {
+          "year": 2009,
+          "month": 8
+        },
+        "editions_with_results": 15
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 75,
+        "points": 273,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "159": {
+      "event_id": 159,
+      "series": {
+        "first_edition": {
+          "year": 2009,
+          "month": 8
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2015,
+        "month": 8,
+        "unique_dancers": 19,
+        "points": 56,
+        "new_dancers": 3,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "160": {
+      "event_id": 160,
+      "series": {
+        "first_edition": {
+          "year": 2008,
+          "month": 7
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2009,
+        "month": 7,
+        "unique_dancers": 33,
+        "points": 120,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "161": {
+      "event_id": 161,
+      "series": {
+        "first_edition": {
+          "year": 2010,
+          "month": 4
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2011,
+        "month": 4,
+        "unique_dancers": 39,
+        "points": 129,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "162": {
+      "event_id": 162,
+      "series": {
+        "first_edition": {
+          "year": 2010,
+          "month": 5
+        },
+        "editions_with_results": 15
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 6,
+        "unique_dancers": 86,
+        "points": 360,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "163": {
+      "event_id": 163,
+      "series": {
+        "first_edition": {
+          "year": 2010,
+          "month": 5
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2014,
+        "month": 5,
+        "unique_dancers": 49,
+        "points": 157,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "164": {
+      "event_id": 164,
+      "series": {
+        "first_edition": {
+          "year": 2010,
+          "month": 8
+        },
+        "editions_with_results": 11
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 8,
+        "unique_dancers": 73,
+        "points": 293,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "165": {
+      "event_id": 165,
+      "series": {
+        "first_edition": {
+          "year": 2010,
+          "month": 9
+        },
+        "editions_with_results": 15
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 123,
+        "points": 538,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "166": {
+      "event_id": 166,
+      "series": {
+        "first_edition": {
+          "year": 2010,
+          "month": 11
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 11,
+        "unique_dancers": 49,
+        "points": 149,
+        "new_dancers": 3,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "167": {
+      "event_id": 167,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 2
+        },
+        "editions_with_results": 13
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 64,
+        "points": 260,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "168": {
+      "event_id": 168,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 2
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2014,
+        "month": 2,
+        "unique_dancers": 52,
+        "points": 162,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "169": {
+      "event_id": 169,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 2
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 2,
+        "unique_dancers": 63,
+        "points": 196,
+        "new_dancers": 4,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "170": {
+      "event_id": 170,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 4
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2021,
+        "month": 4,
+        "unique_dancers": 65,
+        "points": 206,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "171": {
+      "event_id": 171,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 2
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2011,
+        "month": 2,
+        "unique_dancers": 37,
+        "points": 127,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "172": {
+      "event_id": 172,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 4
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2014,
+        "month": 5,
+        "unique_dancers": 19,
+        "points": 58,
+        "new_dancers": 3,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "173": {
+      "event_id": 173,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 5
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2011,
+        "month": 5,
+        "unique_dancers": 30,
+        "points": 90,
+        "new_dancers": 23,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "174": {
+      "event_id": 174,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 5
+        },
+        "editions_with_results": 14
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 54,
+        "points": 230,
+        "new_dancers": 2,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "175": {
+      "event_id": 175,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 6
+        },
+        "editions_with_results": 14
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 140,
+        "points": 648,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 4,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "177": {
+      "event_id": 177,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 9
+        },
+        "editions_with_results": 12
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 74,
+        "points": 279,
+        "new_dancers": 11,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "178": {
+      "event_id": 178,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 10
+        },
+        "editions_with_results": 11
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 92,
+        "points": 395,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "179": {
+      "event_id": 179,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 10
+        },
+        "editions_with_results": 14
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 57,
+        "points": 230,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "180": {
+      "event_id": 180,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 10
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2015,
+        "month": 10,
+        "unique_dancers": 50,
+        "points": 191,
+        "new_dancers": 4,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "181": {
+      "event_id": 181,
+      "series": {
+        "first_edition": {
+          "year": 2011,
+          "month": 11
+        },
+        "editions_with_results": 13
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 142,
+        "points": 688,
+        "new_dancers": 21,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "183": {
+      "event_id": 183,
+      "series": {
+        "first_edition": {
+          "year": 2012,
+          "month": 1
+        },
+        "editions_with_results": 14
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 94,
+        "points": 364,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "184": {
+      "event_id": 184,
+      "series": {
+        "first_edition": {
+          "year": 2012,
+          "month": 1
+        },
+        "editions_with_results": 14
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 161,
+        "points": 903,
+        "new_dancers": 19,
+        "tiers": {
+          "Novice": {
+            "Leader": 6,
+            "Follower": 6
+          },
+          "Intermediate": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Advanced": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "All-Star": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "185": {
+      "event_id": 185,
+      "series": {
+        "first_edition": {
+          "year": 2012,
+          "month": 2
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2018,
+        "month": 2,
+        "unique_dancers": 74,
+        "points": 241,
+        "new_dancers": 0,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "186": {
+      "event_id": 186,
+      "series": {
+        "first_edition": {
+          "year": 2012,
+          "month": 3
+        },
+        "editions_with_results": 13
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 133,
+        "points": 597,
+        "new_dancers": 25,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "187": {
+      "event_id": 187,
+      "series": {
+        "first_edition": {
+          "year": 2012,
+          "month": 4
+        },
+        "editions_with_results": 13
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 115,
+        "points": 444,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "188": {
+      "event_id": 188,
+      "series": {
+        "first_edition": {
+          "year": 2012,
+          "month": 6
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 6,
+        "unique_dancers": 42,
+        "points": 128,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "189": {
+      "event_id": 189,
+      "series": {
+        "first_edition": {
+          "year": 2012,
+          "month": 7
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2012,
+        "month": 7,
+        "unique_dancers": 20,
+        "points": 70,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "190": {
+      "event_id": 190,
+      "series": {
+        "first_edition": {
+          "year": 2012,
+          "month": 9
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2015,
+        "month": 9,
+        "unique_dancers": 79,
+        "points": 260,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "191": {
+      "event_id": 191,
+      "series": {
+        "first_edition": {
+          "year": 2012,
+          "month": 9
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2013,
+        "month": 9,
+        "unique_dancers": 50,
+        "points": 182,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "192": {
+      "event_id": 192,
+      "series": {
+        "first_edition": {
+          "year": 2012,
+          "month": 10
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2013,
+        "month": 10,
+        "unique_dancers": 69,
+        "points": 251,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "194": {
+      "event_id": 194,
+      "series": {
+        "first_edition": {
+          "year": 2012,
+          "month": 11
+        },
+        "editions_with_results": 13
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 85,
+        "points": 397,
+        "new_dancers": 10,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "195": {
+      "event_id": 195,
+      "series": {
+        "first_edition": {
+          "year": 2001,
+          "month": 12
+        },
+        "editions_with_results": 19
+      },
+      "last_edition": {
+        "year": 2020,
+        "month": 1,
+        "unique_dancers": 46,
+        "points": 139,
+        "new_dancers": 2,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "196": {
+      "event_id": 196,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 1
+        },
+        "editions_with_results": 12
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 109,
+        "points": 431,
+        "new_dancers": 22,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "197": {
+      "event_id": 197,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 3
+        },
+        "editions_with_results": 13
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 58,
+        "points": 213,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "199": {
+      "event_id": 199,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 4
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2013,
+        "month": 4,
+        "unique_dancers": 88,
+        "points": 324,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "200": {
+      "event_id": 200,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 4
+        },
+        "editions_with_results": 11
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 100,
+        "points": 426,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "201": {
+      "event_id": 201,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 4
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2016,
+        "month": 5,
+        "unique_dancers": 30,
+        "points": 90,
+        "new_dancers": 1,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "203": {
+      "event_id": 203,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 4
+        },
+        "editions_with_results": 12
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 91,
+        "points": 414,
+        "new_dancers": 13,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "204": {
+      "event_id": 204,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 5
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2014,
+        "month": 5,
+        "unique_dancers": 60,
+        "points": 222,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "205": {
+      "event_id": 205,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 5
+        },
+        "editions_with_results": 11
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 98,
+        "points": 451,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "206": {
+      "event_id": 206,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 6
+        },
+        "editions_with_results": 11
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 89,
+        "points": 370,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "207": {
+      "event_id": 207,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 6
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 6,
+        "unique_dancers": 51,
+        "points": 160,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "208": {
+      "event_id": 208,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 7
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2013,
+        "month": 7,
+        "unique_dancers": 44,
+        "points": 176,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "209": {
+      "event_id": 209,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 7
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2015,
+        "month": 7,
+        "unique_dancers": 69,
+        "points": 284,
+        "new_dancers": 4,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "210": {
+      "event_id": 210,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 10
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 115,
+        "points": 486,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "211": {
+      "event_id": 211,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 10
+        },
+        "editions_with_results": 12
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 138,
+        "points": 683,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "212": {
+      "event_id": 212,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 12
+        },
+        "editions_with_results": 12
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 12,
+        "unique_dancers": 113,
+        "points": 598,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Advanced": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "All-Star": {
+            "Leader": 4,
+            "Follower": 4
+          }
+        }
+      }
+    },
+    "213": {
+      "event_id": 213,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 12
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2022,
+        "month": 12,
+        "unique_dancers": 32,
+        "points": 97,
+        "new_dancers": 3,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "214": {
+      "event_id": 214,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 1
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2020,
+        "month": 1,
+        "unique_dancers": 105,
+        "points": 375,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "215": {
+      "event_id": 215,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 2
+        },
+        "editions_with_results": 13
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 2,
+        "unique_dancers": 91,
+        "points": 403,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "216": {
+      "event_id": 216,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 3
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 9,
+        "unique_dancers": 24,
+        "points": 66,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "217": {
+      "event_id": 217,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 4
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2024,
+        "month": 3,
+        "unique_dancers": 51,
+        "points": 177,
+        "new_dancers": 3,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "218": {
+      "event_id": 218,
+      "series": {
+        "first_edition": {
+          "year": 2013,
+          "month": 4
+        },
+        "editions_with_results": 11
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 115,
+        "points": 556,
+        "new_dancers": 18,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "219": {
+      "event_id": 219,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 4
+        },
+        "editions_with_results": 6
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 5,
+        "unique_dancers": 69,
+        "points": 224,
+        "new_dancers": 11,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "220": {
+      "event_id": 220,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 5
+        },
+        "editions_with_results": 11
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 6,
+        "unique_dancers": 108,
+        "points": 482,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "221": {
+      "event_id": 221,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 5
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 78,
+        "points": 305,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "222": {
+      "event_id": 222,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 6
+        },
+        "editions_with_results": 11
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 6,
+        "unique_dancers": 115,
+        "points": 489,
+        "new_dancers": 19,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "223": {
+      "event_id": 223,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 6
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2016,
+        "month": 6,
+        "unique_dancers": 54,
+        "points": 179,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "224": {
+      "event_id": 224,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 6
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 103,
+        "points": 427,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "225": {
+      "event_id": 225,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 7
+        },
+        "editions_with_results": 12
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 146,
+        "points": 732,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Champions": {
+            "Leader": 3,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "226": {
+      "event_id": 226,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 7
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2018,
+        "month": 7,
+        "unique_dancers": 17,
+        "points": 35,
+        "new_dancers": 1,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "227": {
+      "event_id": 227,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 8
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 116,
+        "points": 652,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 6
+          },
+          "Intermediate": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 4,
+            "Follower": 4
+          }
+        }
+      }
+    },
+    "228": {
+      "event_id": 228,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 8
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2015,
+        "month": 8,
+        "unique_dancers": 65,
+        "points": 218,
+        "new_dancers": 13,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "229": {
+      "event_id": 229,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 8
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 140,
+        "points": 715,
+        "new_dancers": 22,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 6
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "230": {
+      "event_id": 230,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 9
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2016,
+        "month": 9,
+        "unique_dancers": 40,
+        "points": 130,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "231": {
+      "event_id": 231,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 9
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 136,
+        "points": 620,
+        "new_dancers": 22,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "232": {
+      "event_id": 232,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 9
+        },
+        "editions_with_results": 6
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 9,
+        "unique_dancers": 48,
+        "points": 140,
+        "new_dancers": 10,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "233": {
+      "event_id": 233,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 9
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 136,
+        "points": 607,
+        "new_dancers": 13,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "234": {
+      "event_id": 234,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 9
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 60,
+        "points": 207,
+        "new_dancers": 2,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "236": {
+      "event_id": 236,
+      "series": {
+        "first_edition": {
+          "year": 2012,
+          "month": 10
+        },
+        "editions_with_results": 13
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 133,
+        "points": 638,
+        "new_dancers": 20,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "237": {
+      "event_id": 237,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 10
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2017,
+        "month": 11,
+        "unique_dancers": 29,
+        "points": 97,
+        "new_dancers": 4,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "238": {
+      "event_id": 238,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 12
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 12,
+        "unique_dancers": 99,
+        "points": 462,
+        "new_dancers": 18,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "239": {
+      "event_id": 239,
+      "series": {
+        "first_edition": {
+          "year": 2014,
+          "month": 12
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2015,
+        "month": 12,
+        "unique_dancers": 113,
+        "points": 432,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "240": {
+      "event_id": 240,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 1
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 104,
+        "points": 483,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "241": {
+      "event_id": 241,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 1
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2017,
+        "month": 1,
+        "unique_dancers": 54,
+        "points": 195,
+        "new_dancers": 3,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "242": {
+      "event_id": 242,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 2
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 72,
+        "points": 286,
+        "new_dancers": 12,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "243": {
+      "event_id": 243,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 2
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2015,
+        "month": 2,
+        "unique_dancers": 39,
+        "points": 129,
+        "new_dancers": 18,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "244": {
+      "event_id": 244,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 3
+        },
+        "editions_with_results": 11
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 125,
+        "points": 581,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "245": {
+      "event_id": 245,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 3
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2016,
+        "month": 2,
+        "unique_dancers": 49,
+        "points": 157,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "246": {
+      "event_id": 246,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 3
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 3,
+        "unique_dancers": 46,
+        "points": 130,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "247": {
+      "event_id": 247,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 4
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2017,
+        "month": 3,
+        "unique_dancers": 40,
+        "points": 130,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "253": {
+      "event_id": 253,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 5
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 134,
+        "points": 686,
+        "new_dancers": 20,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 6
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "254": {
+      "event_id": 254,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 6
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 119,
+        "points": 630,
+        "new_dancers": 21,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "255": {
+      "event_id": 255,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 7
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 6,
+        "unique_dancers": 17,
+        "points": 54,
+        "new_dancers": 1,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "256": {
+      "event_id": 256,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 7
+        },
+        "editions_with_results": 10
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 90,
+        "points": 391,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "257": {
+      "event_id": 257,
+      "series": {
+        "first_edition": {
+          "year": 2015,
+          "month": 10
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2017,
+        "month": 10,
+        "unique_dancers": 89,
+        "points": 321,
+        "new_dancers": 24,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "258": {
+      "event_id": 258,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 2
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 2,
+        "unique_dancers": 64,
+        "points": 246,
+        "new_dancers": 2,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "259": {
+      "event_id": 259,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 3
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 136,
+        "points": 621,
+        "new_dancers": 13,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "260": {
+      "event_id": 260,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 7
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2016,
+        "month": 7,
+        "unique_dancers": 39,
+        "points": 128,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "261": {
+      "event_id": 261,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 6
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 6,
+        "unique_dancers": 75,
+        "points": 309,
+        "new_dancers": 13,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "262": {
+      "event_id": 262,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 7
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2018,
+        "month": 7,
+        "unique_dancers": 43,
+        "points": 119,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "263": {
+      "event_id": 263,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 8
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2024,
+        "month": 7,
+        "unique_dancers": 79,
+        "points": 294,
+        "new_dancers": 21,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "264": {
+      "event_id": 264,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 8
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 102,
+        "points": 504,
+        "new_dancers": 10,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "265": {
+      "event_id": 265,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 9
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 12,
+        "unique_dancers": 40,
+        "points": 111,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "266": {
+      "event_id": 266,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 9
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2018,
+        "month": 9,
+        "unique_dancers": 33,
+        "points": 88,
+        "new_dancers": 1,
+        "tiers": {
+          "Novice": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "267": {
+      "event_id": 267,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 10
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 67,
+        "points": 257,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "268": {
+      "event_id": 268,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 10
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 81,
+        "points": 332,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "269": {
+      "event_id": 269,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 11
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 112,
+        "points": 482,
+        "new_dancers": 19,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "270": {
+      "event_id": 270,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 11
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 100,
+        "points": 442,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "271": {
+      "event_id": 271,
+      "series": {
+        "first_edition": {
+          "year": 2016,
+          "month": 12
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 12,
+        "unique_dancers": 60,
+        "points": 207,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "272": {
+      "event_id": 272,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 1
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 145,
+        "points": 726,
+        "new_dancers": 26,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "273": {
+      "event_id": 273,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 2
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 2,
+        "unique_dancers": 128,
+        "points": 623,
+        "new_dancers": 19,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "274": {
+      "event_id": 274,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 2
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2017,
+        "month": 2,
+        "unique_dancers": 50,
+        "points": 170,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "275": {
+      "event_id": 275,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 3
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 60,
+        "points": 248,
+        "new_dancers": 10,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "276": {
+      "event_id": 276,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 4
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 3,
+        "unique_dancers": 80,
+        "points": 257,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "277": {
+      "event_id": 277,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 5
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 5,
+        "unique_dancers": 56,
+        "points": 173,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "278": {
+      "event_id": 278,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 7
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 73,
+        "points": 299,
+        "new_dancers": 12,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "280": {
+      "event_id": 280,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 7
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 91,
+        "points": 380,
+        "new_dancers": 21,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "281": {
+      "event_id": 281,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 7
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2017,
+        "month": 7,
+        "unique_dancers": 77,
+        "points": 269,
+        "new_dancers": 10,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "282": {
+      "event_id": 282,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 8
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 157,
+        "points": 774,
+        "new_dancers": 19,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 6
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "283": {
+      "event_id": 283,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 6
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2023,
+        "month": 8,
+        "unique_dancers": 51,
+        "points": 178,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "284": {
+      "event_id": 284,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 9
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 9,
+        "unique_dancers": 96,
+        "points": 324,
+        "new_dancers": 21,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "285": {
+      "event_id": 285,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 10
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2018,
+        "month": 10,
+        "unique_dancers": 63,
+        "points": 183,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "286": {
+      "event_id": 286,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 10
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 96,
+        "points": 445,
+        "new_dancers": 22,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "287": {
+      "event_id": 287,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 11
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2018,
+        "month": 11,
+        "unique_dancers": 49,
+        "points": 168,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "288": {
+      "event_id": 288,
+      "series": {
+        "first_edition": {
+          "year": 2017,
+          "month": 11
+        },
+        "editions_with_results": 8
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 137,
+        "points": 591,
+        "new_dancers": 25,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "289": {
+      "event_id": 289,
+      "series": {
+        "first_edition": {
+          "year": 2018,
+          "month": 1
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 154,
+        "points": 748,
+        "new_dancers": 18,
+        "tiers": {
+          "Novice": {
+            "Leader": 6,
+            "Follower": 6
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "290": {
+      "event_id": 290,
+      "series": {
+        "first_edition": {
+          "year": 2018,
+          "month": 1
+        },
+        "editions_with_results": 9
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 12,
+        "unique_dancers": 92,
+        "points": 398,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "291": {
+      "event_id": 291,
+      "series": {
+        "first_edition": {
+          "year": 2018,
+          "month": 1
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2020,
+        "month": 1,
+        "unique_dancers": 54,
+        "points": 152,
+        "new_dancers": 11,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "292": {
+      "event_id": 292,
+      "series": {
+        "first_edition": {
+          "year": 2018,
+          "month": 3
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 114,
+        "points": 580,
+        "new_dancers": 25,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 6
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "293": {
+      "event_id": 293,
+      "series": {
+        "first_edition": {
+          "year": 2018,
+          "month": 4
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 107,
+        "points": 482,
+        "new_dancers": 23,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "294": {
+      "event_id": 294,
+      "series": {
+        "first_edition": {
+          "year": 2018,
+          "month": 10
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 10,
+        "unique_dancers": 41,
+        "points": 133,
+        "new_dancers": 0,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "296": {
+      "event_id": 296,
+      "series": {
+        "first_edition": {
+          "year": 2018,
+          "month": 9
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2018,
+        "month": 9,
+        "unique_dancers": 37,
+        "points": 107,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "297": {
+      "event_id": 297,
+      "series": {
+        "first_edition": {
+          "year": 2019,
+          "month": 2
+        },
+        "editions_with_results": 6
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 2,
+        "unique_dancers": 79,
+        "points": 331,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "298": {
+      "event_id": 298,
+      "series": {
+        "first_edition": {
+          "year": 2018,
+          "month": 8
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 37,
+        "points": 137,
+        "new_dancers": 7,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "299": {
+      "event_id": 299,
+      "series": {
+        "first_edition": {
+          "year": 2018,
+          "month": 9
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 8,
+        "unique_dancers": 52,
+        "points": 171,
+        "new_dancers": 6,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "300": {
+      "event_id": 300,
+      "series": {
+        "first_edition": {
+          "year": 2018,
+          "month": 9
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 121,
+        "points": 499,
+        "new_dancers": 24,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "301": {
+      "event_id": 301,
+      "series": {
+        "first_edition": {
+          "year": 2019,
+          "month": 1
+        },
+        "editions_with_results": 6
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 89,
+        "points": 393,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "302": {
+      "event_id": 302,
+      "series": {
+        "first_edition": {
+          "year": 2019,
+          "month": 2
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 2,
+        "unique_dancers": 40,
+        "points": 136,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "303": {
+      "event_id": 303,
+      "series": {
+        "first_edition": {
+          "year": 2018,
+          "month": 7
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2024,
+        "month": 7,
+        "unique_dancers": 52,
+        "points": 206,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "304": {
+      "event_id": 304,
+      "series": {
+        "first_edition": {
+          "year": 2019,
+          "month": 4
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 108,
+        "points": 467,
+        "new_dancers": 18,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "306": {
+      "event_id": 306,
+      "series": {
+        "first_edition": {
+          "year": 2019,
+          "month": 4
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2019,
+        "month": 4,
+        "unique_dancers": 31,
+        "points": 94,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "309": {
+      "event_id": 309,
+      "series": {
+        "first_edition": {
+          "year": 2020,
+          "month": 1
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 99,
+        "points": 417,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "310": {
+      "event_id": 310,
+      "series": {
+        "first_edition": {
+          "year": 2019,
+          "month": 2
+        },
+        "editions_with_results": 6
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 2,
+        "unique_dancers": 81,
+        "points": 332,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "311": {
+      "event_id": 311,
+      "series": {
+        "first_edition": {
+          "year": 2019,
+          "month": 5
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2023,
+        "month": 5,
+        "unique_dancers": 65,
+        "points": 201,
+        "new_dancers": 13,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "312": {
+      "event_id": 312,
+      "series": {
+        "first_edition": {
+          "year": 2018,
+          "month": 11
+        },
+        "editions_with_results": 7
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 94,
+        "points": 383,
+        "new_dancers": 10,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "313": {
+      "event_id": 313,
+      "series": {
+        "first_edition": {
+          "year": 2019,
+          "month": 9
+        },
+        "editions_with_results": 6
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 106,
+        "points": 505,
+        "new_dancers": 11,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "314": {
+      "event_id": 314,
+      "series": {
+        "first_edition": {
+          "year": 2019,
+          "month": 3
+        },
+        "editions_with_results": 6
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 122,
+        "points": 573,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "318": {
+      "event_id": 318,
+      "series": {
+        "first_edition": {
+          "year": 2022,
+          "month": 3
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 81,
+        "points": 339,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "322": {
+      "event_id": 322,
+      "series": {
+        "first_edition": {
+          "year": 2019,
+          "month": 10
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 150,
+        "points": 708,
+        "new_dancers": 19,
+        "tiers": {
+          "Novice": {
+            "Leader": 5,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "323": {
+      "event_id": 323,
+      "series": {
+        "first_edition": {
+          "year": 2021,
+          "month": 11
+        },
+        "editions_with_results": 5
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 66,
+        "points": 235,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "324": {
+      "event_id": 324,
+      "series": {
+        "first_edition": {
+          "year": 2023,
+          "month": 4
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 3,
+        "unique_dancers": 82,
+        "points": 335,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "330": {
+      "event_id": 330,
+      "series": {
+        "first_edition": {
+          "year": 2020,
+          "month": 11
+        },
+        "editions_with_results": 6
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 69,
+        "points": 282,
+        "new_dancers": 13,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "331": {
+      "event_id": 331,
+      "series": {
+        "first_edition": {
+          "year": 2023,
+          "month": 7
+        },
+        "editions_with_results": 4
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 6,
+        "unique_dancers": 88,
+        "points": 339,
+        "new_dancers": 21,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "333": {
+      "event_id": 333,
+      "series": {
+        "first_edition": {
+          "year": 2024,
+          "month": 3
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 41,
+        "points": 166,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "334": {
+      "event_id": 334,
+      "series": {
+        "first_edition": {
+          "year": 1995,
+          "month": 1
+        },
+        "editions_with_results": 23
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 1,
+        "unique_dancers": 87,
+        "points": 364,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "336": {
+      "event_id": 336,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 5
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 86,
+        "points": 344,
+        "new_dancers": 20,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "338": {
+      "event_id": 338,
+      "series": {
+        "first_edition": {
+          "year": 2024,
+          "month": 9
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 64,
+        "points": 237,
+        "new_dancers": 8,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "339": {
+      "event_id": 339,
+      "series": {
+        "first_edition": {
+          "year": 2024,
+          "month": 8
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 75,
+        "points": 352,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "340": {
+      "event_id": 340,
+      "series": {
+        "first_edition": {
+          "year": 2024,
+          "month": 11
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 52,
+        "points": 181,
+        "new_dancers": 12,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "342": {
+      "event_id": 342,
+      "series": {
+        "first_edition": {
+          "year": 2023,
+          "month": 12
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 12,
+        "unique_dancers": 104,
+        "points": 413,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "343": {
+      "event_id": 343,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 2
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 2,
+        "unique_dancers": 97,
+        "points": 392,
+        "new_dancers": 12,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "344": {
+      "event_id": 344,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 2
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 2,
+        "unique_dancers": 75,
+        "points": 354,
+        "new_dancers": 11,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "345": {
+      "event_id": 345,
+      "series": {
+        "first_edition": {
+          "year": 2024,
+          "month": 4
+        },
+        "editions_with_results": 3
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 77,
+        "points": 303,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "346": {
+      "event_id": 346,
+      "series": {
+        "first_edition": {
+          "year": 2024,
+          "month": 10
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 99,
+        "points": 414,
+        "new_dancers": 23,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "347": {
+      "event_id": 347,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 5
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 72,
+        "points": 280,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "348": {
+      "event_id": 348,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 3
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 2,
+        "unique_dancers": 114,
+        "points": 506,
+        "new_dancers": 23,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "350": {
+      "event_id": 350,
+      "series": {
+        "first_edition": {
+          "year": 2024,
+          "month": 10
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 96,
+        "points": 374,
+        "new_dancers": 11,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "352": {
+      "event_id": 352,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 4
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 101,
+        "points": 442,
+        "new_dancers": 18,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "354": {
+      "event_id": 354,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 5
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 116,
+        "points": 475,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "355": {
+      "event_id": 355,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 10
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 39,
+        "points": 119,
+        "new_dancers": 4,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "356": {
+      "event_id": 356,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 8
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 65,
+        "points": 240,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "357": {
+      "event_id": 357,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 9
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 105,
+        "points": 430,
+        "new_dancers": 19,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "359": {
+      "event_id": 359,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 9
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 90,
+        "points": 355,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "360": {
+      "event_id": 360,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 7
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 81,
+        "points": 324,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "361": {
+      "event_id": 361,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 9
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 9,
+        "unique_dancers": 66,
+        "points": 261,
+        "new_dancers": 12,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "362": {
+      "event_id": 362,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 7
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 94,
+        "points": 405,
+        "new_dancers": 27,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "363": {
+      "event_id": 363,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 2
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 2,
+        "unique_dancers": 61,
+        "points": 232,
+        "new_dancers": 11,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "364": {
+      "event_id": 364,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 5
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 54,
+        "points": 197,
+        "new_dancers": 12,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "365": {
+      "event_id": 365,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 11
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 55,
+        "points": 215,
+        "new_dancers": 13,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "367": {
+      "event_id": 367,
+      "series": {
+        "first_edition": {
+          "year": 2024,
+          "month": 10
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 30,
+        "points": 127,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "368": {
+      "event_id": 368,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 6
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 6,
+        "unique_dancers": 66,
+        "points": 264,
+        "new_dancers": 21,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "369": {
+      "event_id": 369,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 6
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 106,
+        "points": 405,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "370": {
+      "event_id": 370,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 4
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 103,
+        "points": 458,
+        "new_dancers": 21,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "371": {
+      "event_id": 371,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 6
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 6,
+        "unique_dancers": 48,
+        "points": 188,
+        "new_dancers": 5,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "372": {
+      "event_id": 372,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 5
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 81,
+        "points": 310,
+        "new_dancers": 10,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "373": {
+      "event_id": 373,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 7
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 111,
+        "points": 495,
+        "new_dancers": 9,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Champions": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "374": {
+      "event_id": 374,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 6
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 6,
+        "unique_dancers": 84,
+        "points": 374,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "375": {
+      "event_id": 375,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 7
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 99,
+        "points": 465,
+        "new_dancers": 22,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "376": {
+      "event_id": 376,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 11
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 11,
+        "unique_dancers": 93,
+        "points": 410,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "377": {
+      "event_id": 377,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 12
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 12,
+        "unique_dancers": 96,
+        "points": 415,
+        "new_dancers": 19,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "378": {
+      "event_id": 378,
+      "series": {
+        "first_edition": {
+          "year": 2026,
+          "month": 3
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 78,
+        "points": 264,
+        "new_dancers": 11,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "379": {
+      "event_id": 379,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 5
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 5,
+        "unique_dancers": 128,
+        "points": 601,
+        "new_dancers": 22,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 3,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "380": {
+      "event_id": 380,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 10
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 58,
+        "points": 209,
+        "new_dancers": 10,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "381": {
+      "event_id": 381,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 1
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 1,
+        "unique_dancers": 35,
+        "points": 158,
+        "new_dancers": 4,
+        "tiers": {
+          "Novice": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "382": {
+      "event_id": 382,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 8
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 8,
+        "unique_dancers": 96,
+        "points": 463,
+        "new_dancers": 10,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "383": {
+      "event_id": 383,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 8
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 8,
+        "unique_dancers": 100,
+        "points": 461,
+        "new_dancers": 21,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "384": {
+      "event_id": 384,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 8
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 69,
+        "points": 241,
+        "new_dancers": 18,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "385": {
+      "event_id": 385,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 7
+        },
+        "editions_with_results": 2
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 72,
+        "points": 305,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "386": {
+      "event_id": 386,
+      "series": {
+        "first_edition": {
+          "year": 2026,
+          "month": 2
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 2,
+        "unique_dancers": 105,
+        "points": 512,
+        "new_dancers": 15,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "387": {
+      "event_id": 387,
+      "series": {
+        "first_edition": {
+          "year": 2026,
+          "month": 2
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 2,
+        "unique_dancers": 72,
+        "points": 270,
+        "new_dancers": 19,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "388": {
+      "event_id": 388,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 10
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 10,
+        "unique_dancers": 75,
+        "points": 280,
+        "new_dancers": 20,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "389": {
+      "event_id": 389,
+      "series": {
+        "first_edition": {
+          "year": 2026,
+          "month": 7
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 106,
+        "points": 512,
+        "new_dancers": 17,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 5
+          },
+          "Intermediate": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Advanced": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "All-Star": {
+            "Leader": 2,
+            "Follower": 2
+          }
+        }
+      }
+    },
+    "391": {
+      "event_id": 391,
+      "series": {
+        "first_edition": {
+          "year": 2025,
+          "month": 8
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2025,
+        "month": 8,
+        "unique_dancers": 70,
+        "points": 262,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "393": {
+      "event_id": 393,
+      "series": {
+        "first_edition": {
+          "year": 2026,
+          "month": 4
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 4,
+        "unique_dancers": 81,
+        "points": 321,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "394": {
+      "event_id": 394,
+      "series": {
+        "first_edition": {
+          "year": 2026,
+          "month": 3
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 3,
+        "unique_dancers": 60,
+        "points": 266,
+        "new_dancers": 12,
+        "tiers": {
+          "Novice": {
+            "Leader": 4,
+            "Follower": 4
+          },
+          "Intermediate": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 2
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    },
+    "404": {
+      "event_id": 404,
+      "series": {
+        "first_edition": {
+          "year": 2026,
+          "month": 7
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 7,
+        "unique_dancers": 76,
+        "points": 307,
+        "new_dancers": 16,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 2
+          },
+          "Advanced": {
+            "Leader": 2,
+            "Follower": 3
+          }
+        }
+      }
+    },
+    "405": {
+      "event_id": 405,
+      "series": {
+        "first_edition": {
+          "year": 2026,
+          "month": 6
+        },
+        "editions_with_results": 1
+      },
+      "last_edition": {
+        "year": 2026,
+        "month": 6,
+        "unique_dancers": 80,
+        "points": 298,
+        "new_dancers": 14,
+        "tiers": {
+          "Novice": {
+            "Leader": 3,
+            "Follower": 3
+          },
+          "Intermediate": {
+            "Leader": 2,
+            "Follower": 3
+          },
+          "Advanced": {
+            "Leader": 1,
+            "Follower": 1
+          },
+          "All-Star": {
+            "Leader": 1,
+            "Follower": 1
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Replace the sparse L2 event panel with a 50/50 series / last-edition card (metrics + L/F tier table + tip).
- Load companion `event_l2_cards.json`; trial / no-points leave the right side empty.
- Soft-validate the new JSON in `validate_site_data.py`.

## Test plan
- [ ] `python3 scripts/validate_site_data.py`
- [ ] Open Events Calendar, select a registry event → series left, last edition right
- [ ] Select a trial event → left only, empty right
- [ ] Hover `i` tip; check mobile stacks series above last edition
- [ ] Switch EN/RU/ES labels on the card


Made with [Cursor](https://cursor.com)