### PR TITLE
Calendar data refresh: restore 2026/2027 Trial events

### DIFF
--- a/static/data/event_l2_cards.json
+++ b/static/data/event_l2_cards.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-05",
-  "generated_at": "2026-08-05T22:00:07Z",
+  "generated_at": "2026-08-06T09:05:36Z",
   "tier_tip": {
     "en": "Tier reflects field size for that role under the WSDC points chart. Larger fields award higher placement points. Current ranges (per role, from 5 competitors): Tier 1: 5–10 · Tier 2: 11–19 · Tier 3: 20–39 · Tier 4: 40–79 · Tier 5: 80–129 · Tier 6: 130+.",
     "ru": "Тир отражает размер поля в роли по чарту очков WSDC. Чем больше поле, тем выше очки за места. Текущие диапазоны (на роль, от 5 участников): Тир 1: 5–10 · Тир 2: 11–19 · Тир 3: 20–39 · Тир 4: 40–79 · Тир 5: 80–129 · Тир 6: 130+.",

--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-05",
-  "generated_at": "2026-08-05T20:54:50Z",
+  "generated_at": "2026-08-06T09:05:33Z",
   "years": [
     2024,
     2025,
@@ -24,8 +24,8 @@
   "counts_by_year": {
     "2024": 139,
     "2025": 177,
-    "2026": 184,
-    "2027": 184,
+    "2026": 192,
+    "2027": 191,
     "2028": 183
   },
   "disclaimer": {
@@ -1211,11 +1211,11 @@
       "weekend_key": "2024-04-25",
       "status": "confirmed",
       "kind": "registry",
-      "city": "St. Petersburg",
-      "country": "Russia",
-      "continent": "Europe",
-      "lat": 59.9310584,
-      "lon": 30.3609097,
+      "city": "Gold Coast",
+      "country": "Australia",
+      "continent": "Australia",
+      "lat": -27.9769248,
+      "lon": 153.380936,
       "url": "https://rawconnection.com.au/swingsation/",
       "year": 2024,
       "source": "event_editions_month_only",
@@ -4381,11 +4381,11 @@
       "weekend_key": "2025-05-08",
       "status": "confirmed",
       "kind": "registry",
-      "city": "St. Petersburg",
-      "country": "Russia",
-      "continent": "Europe",
-      "lat": 59.9310584,
-      "lon": 30.3609097,
+      "city": "Gold Coast",
+      "country": "Australia",
+      "continent": "Australia",
+      "lat": -27.9769248,
+      "lon": 153.380936,
       "url": "https://rawconnection.com.au/swingsation/",
       "year": 2025,
       "source": "edition_calendar_dates",
@@ -8284,11 +8284,11 @@
       "weekend_key": "2026-05-14",
       "status": "confirmed",
       "kind": "registry",
-      "city": "St. Petersburg",
-      "country": "Russia",
-      "continent": "Europe",
-      "lat": 59.9310584,
-      "lon": 30.3609097,
+      "city": "Gold Coast",
+      "country": "Australia",
+      "continent": "Australia",
+      "lat": -27.9769248,
+      "lon": 153.380936,
       "url": "https://rawconnection.com.au/swingsation/",
       "year": 2026,
       "source": "edition_calendar_dates",
@@ -9133,7 +9133,7 @@
     {
       "id": "confirmed:282:2026-08-05",
       "event_id": 282,
-      "name": "German Open WCS",
+      "name": "German Open",
       "start_date": "2026-08-05",
       "end_date": "2026-08-09",
       "weekend_start": "2026-07-30",
@@ -9146,9 +9146,9 @@
       "continent": "Europe",
       "lat": 47.9990077,
       "lon": 7.842104299999999,
-      "url": "http://www.go-wcs.com",
+      "url": "http://www.go-wcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:157:2026-08-06",
@@ -9166,9 +9166,9 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://www.nedancefestival.com",
+      "url": "http://www.nedancefestival.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:59:2026-08-06",
@@ -9181,14 +9181,14 @@
       "weekend_key": "2026-08-06",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Herndon",
+      "city": "Washington",
       "country": "United States",
       "continent": "America",
       "lat": 38.9695545,
       "lon": -77.3860976,
-      "url": "http://www.swingfling.com",
+      "url": "http://www.swingfling.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:227:2026-08-06",
@@ -9206,9 +9206,9 @@
       "continent": "America",
       "lat": 37.7749295,
       "lon": -122.4194155,
-      "url": "http://www.DanceGeekProductions.Art",
+      "url": "http://www.dancegeekproductions.art/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:120:2026-08-07",
@@ -9251,7 +9251,7 @@
       "lon": 23.3218675,
       "url": "https://wcs-gps.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:264:2026-08-14",
@@ -9269,9 +9269,9 @@
       "continent": "Europe",
       "lat": 59.3251172,
       "lon": 18.0710935,
-      "url": "http://www.uptownswing.se",
+      "url": "http://www.uptownswing.se/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:298:2026-08-20",
@@ -9284,14 +9284,14 @@
       "weekend_key": "2026-08-20",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Perth",
-      "country": "Australia",
+      "city": "Christchurch",
+      "country": "New Zealand",
       "continent": "Australia",
       "lat": -31.9513993,
       "lon": 115.8616783,
       "url": "http://www.code03swing.com/shakedown",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:53:2026-08-20",
@@ -9309,9 +9309,29 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://Summerhummerboston.com",
+      "url": "http://summerhummerboston.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:t-swing-creation-hamburg-hamburg-germany:2026-08-20",
+      "event_id": null,
+      "name": "Swing Creation Hamburg",
+      "start_date": "2026-08-20",
+      "end_date": "2026-08-23",
+      "weekend_start": "2026-08-20",
+      "weekend_end": "2026-08-23",
+      "weekend_key": "2026-08-20",
+      "status": "confirmed",
+      "kind": "trial",
+      "city": "Hamburg",
+      "country": "Germany",
+      "continent": "Europe",
+      "lat": 53.5488282,
+      "lon": 9.9871703,
+      "url": "http://hamburgswing.dance/",
+      "year": 2026,
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:356:2026-08-20",
@@ -9329,9 +9349,9 @@
       "continent": "America",
       "lat": 44.0581728,
       "lon": -121.3153096,
-      "url": "http://thebendconnection.com",
+      "url": "http://thebendconnection.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:119:2026-08-21",
@@ -9349,9 +9369,29 @@
       "continent": "America",
       "lat": 41.88325,
       "lon": -87.6323879,
-      "url": "http://www.chicagolanddancefestival.com",
+      "url": "http://www.chicagolanddancefestival.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:t-manneken-swing-bruxelles-belgium:2026-08-21",
+      "event_id": null,
+      "name": "Manneken Swing",
+      "start_date": "2026-08-21",
+      "end_date": "2026-08-23",
+      "weekend_start": "2026-08-20",
+      "weekend_end": "2026-08-23",
+      "weekend_key": "2026-08-20",
+      "status": "confirmed",
+      "kind": "trial",
+      "city": "Bruxelles",
+      "country": "Belgium",
+      "continent": "Europe",
+      "lat": 50.84770289999999,
+      "lon": 4.357200100000001,
+      "url": "https://www.mannekenswing.com/",
+      "year": 2026,
+      "source": "events_list_current"
     },
     {
       "id": "expected:391:2026-08-21",
@@ -9377,6 +9417,26 @@
       "has_results": true
     },
     {
+      "id": "confirmed:t-westie-joy-bucharest-romania:2026-08-21",
+      "event_id": null,
+      "name": "Westie Joy",
+      "start_date": "2026-08-21",
+      "end_date": "2026-08-23",
+      "weekend_start": "2026-08-20",
+      "weekend_end": "2026-08-23",
+      "weekend_key": "2026-08-20",
+      "status": "confirmed",
+      "kind": "trial",
+      "city": "Bucharest",
+      "country": "Romania",
+      "continent": "Europe",
+      "lat": null,
+      "lon": null,
+      "url": "https://www.westiejoy.com/",
+      "year": 2026,
+      "source": "events_list_current"
+    },
+    {
       "id": "confirmed:135:2026-08-27",
       "event_id": 135,
       "name": "Desert City Swing",
@@ -9392,9 +9452,9 @@
       "continent": "America",
       "lat": 33.4482948,
       "lon": -112.0725488,
-      "url": "http://www.desertcityswing.com",
+      "url": "http://www.desertcityswing.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:313:2026-08-27",
@@ -9407,14 +9467,14 @@
       "weekend_key": "2026-08-27",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Lyon",
+      "city": "LYON",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
-      "url": "http://www.frenchywesty.com",
+      "url": "http://www.frenchywesty.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:339:2026-08-28",
@@ -9434,7 +9494,7 @@
       "lon": -2.58791,
       "url": "https://www.bristolcityswing.com/bsf",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:268:2026-09-03",
@@ -9452,9 +9512,9 @@
       "continent": "Asia",
       "lat": 33.5042779,
       "lon": 126.519838,
-      "url": "http://koreawestival.com",
+      "url": "http://koreawestival.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:48:2026-09-03",
@@ -9474,7 +9534,7 @@
       "lon": -121.8852525,
       "url": "https://sbdf.dance/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:177:2026-09-04",
@@ -9492,9 +9552,9 @@
       "continent": "America",
       "lat": 30.3297566,
       "lon": -81.6591529,
-      "url": "http://www.jaxwestiefest.com",
+      "url": "http://www.jaxwestiefest.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:233:2026-09-10",
@@ -9512,14 +9572,14 @@
       "continent": "Europe",
       "lat": 48.1351253,
       "lon": 11.5819806,
-      "url": "https://bavarianopen.com",
+      "url": "https://bavarianopen.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:47:2026-09-10",
       "event_id": 47,
-      "name": "SwingTime Denver",
+      "name": "Swingtime in the Rockies",
       "start_date": "2026-09-10",
       "end_date": "2026-09-13",
       "weekend_start": "2026-09-10",
@@ -9532,9 +9592,9 @@
       "continent": "America",
       "lat": 39.7392358,
       "lon": -104.990251,
-      "url": "http://www.swingtimewcs.com",
+      "url": "http://www.swingtimewcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:231:2026-09-10",
@@ -9554,7 +9614,7 @@
       "lon": -78.6381787,
       "url": "https://trilogywcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:338:2026-09-11",
@@ -9574,7 +9634,7 @@
       "lon": 37.6150527,
       "url": "https://vk.com/seadancefest",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:359:2026-09-17",
@@ -9592,14 +9652,14 @@
       "continent": "America",
       "lat": 47.6061389,
       "lon": -122.3328481,
-      "url": "https://www.retaliationswing.com",
+      "url": "https://www.retaliationswing.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:357:2026-09-17",
       "event_id": 357,
-      "name": "WCS Party in Vienna",
+      "name": "WCS Party",
       "start_date": "2026-09-17",
       "end_date": "2026-09-21",
       "weekend_start": "2026-09-17",
@@ -9614,7 +9674,7 @@
       "lon": 16.3713095,
       "url": "https://www.wcsparty.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:300:2026-09-18",
@@ -9634,7 +9694,7 @@
       "lon": -97.7430608,
       "url": "https://atxrox.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:254:2026-09-18",
@@ -9652,29 +9712,29 @@
       "continent": "Europe",
       "lat": 60.16985569999999,
       "lon": 24.938379,
-      "url": "http://www.finnfest.fi",
+      "url": "http://www.finnfest.fi/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:342:2026-09-18",
       "event_id": 342,
-      "name": "Global Grand Prix -- West Coast Swing Championships",
+      "name": "Global Grand Prix - West Coast Swing Reunion",
       "start_date": "2026-09-18",
       "end_date": "2026-09-21",
       "weekend_start": "2026-09-17",
       "weekend_end": "2026-09-20",
       "weekend_key": "2026-09-17",
       "status": "confirmed",
-      "kind": "registry",
-      "city": "Toulouse",
+      "kind": "trial",
+      "city": "Paris",
       "country": "France",
       "continent": "Europe",
-      "lat": 43.6048462,
-      "lon": 1.442848,
+      "lat": 48.8575475,
+      "lon": 2.3513765,
       "url": "https://www.globalgrandprixwcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:355:2026-09-23",
@@ -9692,9 +9752,9 @@
       "continent": "America",
       "lat": 20.6871826,
       "lon": -156.4391668,
-      "url": "http://www.alohaopenwcs.com",
+      "url": "http://www.alohaopenwcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:167:2026-09-24",
@@ -9714,7 +9774,27 @@
       "lon": 151.2057136,
       "url": "https://www.bestofthebestwcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:t-calgary-town-open-calgary-canada:2026-09-24",
+      "event_id": null,
+      "name": "Calgary Town Open",
+      "start_date": "2026-09-24",
+      "end_date": "2026-09-27",
+      "weekend_start": "2026-09-24",
+      "weekend_end": "2026-09-27",
+      "weekend_key": "2026-09-24",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Calgary",
+      "country": "Canada",
+      "continent": "America",
+      "lat": 51.04473309999999,
+      "lon": -114.0718831,
+      "url": "https://ctodance.ca/",
+      "year": 2026,
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:131:2026-09-24",
@@ -9732,9 +9812,9 @@
       "continent": "America",
       "lat": 38.62742799999999,
       "lon": -90.1982439,
-      "url": "http://Www.mmisl.com",
+      "url": "http://www.mmisl.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:165:2026-09-24",
@@ -9752,14 +9832,14 @@
       "continent": "Europe",
       "lat": 51.5072178,
       "lon": -0.1275862,
-      "url": "http://www.MidlandSwingOpen.com",
+      "url": "http://www.midlandswingopen.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:361:2026-09-24",
       "event_id": 361,
-      "name": "Mooseland Swing 2026",
+      "name": "Mooseland Swing",
       "start_date": "2026-09-24",
       "end_date": "2026-09-28",
       "weekend_start": "2026-09-24",
@@ -9774,7 +9854,7 @@
       "lon": 14.6360681,
       "url": "https://mooselandswing.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:234:2026-09-25",
@@ -9787,14 +9867,14 @@
       "weekend_key": "2026-09-24",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Wilmington",
+      "city": "WILMINGTON",
       "country": "United States",
       "continent": "America",
       "lat": 39.744655,
       "lon": -75.5483909,
       "url": "https://phillyswing.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:211:2026-10-01",
@@ -9814,7 +9894,7 @@
       "lon": -84.3885209,
       "url": "https://www.atlantaswingclassic.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:388:2026-10-01",
@@ -9834,7 +9914,67 @@
       "lon": 11.0679977,
       "url": "https://norwegianopen.no/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:t-riverswingnights-dresden-germany:2026-10-01",
+      "event_id": null,
+      "name": "RiverSwingNights",
+      "start_date": "2026-10-01",
+      "end_date": "2026-10-05",
+      "weekend_start": "2026-10-01",
+      "weekend_end": "2026-10-04",
+      "weekend_key": "2026-10-01",
+      "status": "confirmed",
+      "kind": "trial",
+      "city": "Dresden",
+      "country": "Germany",
+      "continent": "Europe",
+      "lat": 51.0504088,
+      "lon": 13.7372621,
+      "url": "http://www.riverswingnights.com/",
+      "year": 2026,
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:t-westie-harbor-gothenburg-sweden:2026-10-01",
+      "event_id": null,
+      "name": "Westie Harbor",
+      "start_date": "2026-10-01",
+      "end_date": "2026-10-05",
+      "weekend_start": "2026-10-01",
+      "weekend_end": "2026-10-04",
+      "weekend_key": "2026-10-01",
+      "status": "confirmed",
+      "kind": "trial",
+      "city": "Gothenburg",
+      "country": "Sweden",
+      "continent": "Europe",
+      "lat": 57.70887,
+      "lon": 11.97456,
+      "url": "http://www.westieharbor.com/",
+      "year": 2026,
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:t-autumn-beat-riga-latvia:2026-10-02",
+      "event_id": null,
+      "name": "Autumn Beat",
+      "start_date": "2026-10-02",
+      "end_date": "2026-10-05",
+      "weekend_start": "2026-10-01",
+      "weekend_end": "2026-10-04",
+      "weekend_key": "2026-10-01",
+      "status": "confirmed",
+      "kind": "trial",
+      "city": "Riga",
+      "country": "Latvia",
+      "continent": "Europe",
+      "lat": 56.9676941,
+      "lon": 24.1056221,
+      "url": "https://autumnbeat.lv/",
+      "year": 2026,
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:8:2026-10-08",
@@ -9852,9 +9992,9 @@
       "continent": "America",
       "lat": 37.7749295,
       "lon": -122.4194155,
-      "url": "https://boogiebythebay.com",
+      "url": "https://boogiebythebay.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:178:2026-10-09",
@@ -9872,9 +10012,9 @@
       "continent": "America",
       "lat": 45.5018869,
       "lon": -73.56739189999999,
-      "url": "http://montrealwestiefest.com",
+      "url": "http://montrealwestiefest.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:367:2026-10-10",
@@ -9917,7 +10057,7 @@
       "lon": 9.1824027,
       "url": "https://www.westcoastswingmilan.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:179:2026-10-15",
@@ -9937,7 +10077,7 @@
       "lon": 174.7644881,
       "url": "https://www.streetswing.co.nz/the-new-zealand-open",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:43:2026-10-15",
@@ -9957,27 +10097,7 @@
       "lon": -117.8265049,
       "url": "https://paradisecountrydancefestival.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
-    },
-    {
-      "id": "confirmed:286:2026-10-15",
-      "event_id": 286,
-      "name": "WCS Festival",
-      "start_date": "2026-10-15",
-      "end_date": "2026-10-17",
-      "weekend_start": "2026-10-15",
-      "weekend_end": "2026-10-18",
-      "weekend_key": "2026-10-15",
-      "status": "confirmed",
-      "kind": "registry",
-      "city": "Düsseldorf",
-      "country": "Germany",
-      "continent": "Europe",
-      "lat": 51.2230411,
-      "lon": 6.7824545,
-      "url": "http://www.wcsfestival.com",
-      "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:267:2026-10-16",
@@ -9995,9 +10115,29 @@
       "continent": "America",
       "lat": 39.9525839,
       "lon": -75.1652215,
-      "url": "http://www.swustlicious.com",
+      "url": "http://www.swustlicious.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:286:2026-10-16",
+      "event_id": 286,
+      "name": "WCS Festival",
+      "start_date": "2026-10-16",
+      "end_date": "2026-10-18",
+      "weekend_start": "2026-10-15",
+      "weekend_end": "2026-10-18",
+      "weekend_key": "2026-10-15",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Duesseldorf",
+      "country": "Germany",
+      "continent": "Europe",
+      "lat": 51.2230411,
+      "lon": 6.7824545,
+      "url": "http://www.wcsfestival.com/",
+      "year": 2026,
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:350:2026-10-22",
@@ -10017,7 +10157,7 @@
       "lon": 10.89779,
       "url": "https://www.augsburgwestiestation.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:65:2026-10-22",
@@ -10035,14 +10175,14 @@
       "continent": "America",
       "lat": 33.6638439,
       "lon": -117.9047429,
-      "url": "http://Hstswing.com",
+      "url": "http://hstswing.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:380:2026-10-22",
       "event_id": 380,
-      "name": "SASS- Spooky Albany Swing Spectacular",
+      "name": "SASS Spooky Albany Swing Spectacular",
       "start_date": "2026-10-22",
       "end_date": "2026-10-25",
       "weekend_start": "2026-10-22",
@@ -10055,9 +10195,9 @@
       "continent": "America",
       "lat": 42.6518095,
       "lon": -73.75447070000001,
-      "url": "http://www.spookyalbanyswing.com",
+      "url": "http://www.spookyalbanyswing.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:125:2026-10-22",
@@ -10070,21 +10210,21 @@
       "weekend_key": "2026-10-22",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Chicago",
+      "city": "CHICAGO",
       "country": "United States",
       "continent": "America",
       "lat": 41.88325,
       "lon": -87.6323879,
-      "url": "https://swingcitychicago.com",
+      "url": "https://swingcitychicago.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
-      "id": "confirmed:346:2026-10-22",
+      "id": "confirmed:346:2026-10-23",
       "event_id": 346,
       "name": "Swingside Invitational",
-      "start_date": "2026-10-22",
-      "end_date": "2026-10-24",
+      "start_date": "2026-10-23",
+      "end_date": "2026-10-25",
       "weekend_start": "2026-10-22",
       "weekend_end": "2026-10-25",
       "weekend_key": "2026-10-22",
@@ -10095,9 +10235,9 @@
       "continent": "Europe",
       "lat": 50.6402286,
       "lon": 5.5689372,
-      "url": "http://www.swingside-invitational.com",
+      "url": "https://www.swingside-invitational.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:229:2026-10-28",
@@ -10115,9 +10255,9 @@
       "continent": "Europe",
       "lat": 59.3251172,
       "lon": 18.0710935,
-      "url": "http://www.snowcs.se",
+      "url": "http://www.snowcs.se/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:340:2026-10-29",
@@ -10137,7 +10277,7 @@
       "lon": 103.819836,
       "url": "https://spookywestieweekend.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:236:2026-10-29",
@@ -10155,14 +10295,14 @@
       "continent": "Europe",
       "lat": 52.2296756,
       "lon": 21.0122287,
-      "url": "http://www.warsawhalloweenswing.com",
+      "url": "http://www.warsawhalloweenswing.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:31:2026-11-05",
       "event_id": 31,
-      "name": "Mountain Magic Dance Convention",
+      "name": "Mountain Magic",
       "start_date": "2026-11-05",
       "end_date": "2026-11-08",
       "weekend_start": "2026-11-05",
@@ -10175,14 +10315,14 @@
       "continent": "America",
       "lat": 39.5056072,
       "lon": -119.7788687,
-      "url": "http://mountainmagic.dance",
+      "url": "http://mountainmagic.dance/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:79:2026-11-05",
       "event_id": 79,
-      "name": "Sea to Sky Seattle",
+      "name": "Sea to Sky",
       "start_date": "2026-11-05",
       "end_date": "2026-11-09",
       "weekend_start": "2026-11-05",
@@ -10195,9 +10335,9 @@
       "continent": "America",
       "lat": 47.6061389,
       "lon": -122.3328481,
-      "url": "http://Seatoskywcs.com",
+      "url": "http://seatoskywcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:330:2026-11-05",
@@ -10215,9 +10355,9 @@
       "continent": "Australia",
       "lat": -34.9284989,
       "lon": 138.6007456,
-      "url": "http://www.simplyadelaidewcs.com.au",
+      "url": "http://www.simplyadelaidewcs.com.au/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:137:2026-11-05",
@@ -10230,14 +10370,14 @@
       "weekend_key": "2026-11-05",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Tampa",
+      "city": "Tampa Bay",
       "country": "United States",
       "continent": "America",
       "lat": 27.9516896,
       "lon": -82.45875269999999,
-      "url": "http://www.tbcwcs.com",
+      "url": "http://www.tbcwcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:194:2026-11-06",
@@ -10257,7 +10397,7 @@
       "lon": 37.6150527,
       "url": "http://westiefest.org/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:312:2026-11-06",
@@ -10270,19 +10410,19 @@
       "weekend_key": "2026-11-05",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Toulouse",
+      "city": "TOULOUSE",
       "country": "France",
       "continent": "Europe",
       "lat": 43.6048462,
       "lon": 1.442848,
-      "url": "http://www.westiepinkcity.fr",
+      "url": "http://www.westiepinkcity.fr/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:288:2026-11-12",
       "event_id": 288,
-      "name": "Midnight Madness WCS 2026",
+      "name": "Midnight Madness",
       "start_date": "2026-11-12",
       "end_date": "2026-11-15",
       "weekend_start": "2026-11-12",
@@ -10290,14 +10430,14 @@
       "weekend_key": "2026-11-12",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Dallas",
+      "city": "Dallas Ft. Worth",
       "country": "United States",
       "continent": "America",
       "lat": 32.7831,
       "lon": -96.8067,
-      "url": "http://www.MidnightMadnessWCS.com",
+      "url": "http://www.midnightmadnesswcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:376:2026-11-12",
@@ -10310,14 +10450,14 @@
       "weekend_key": "2026-11-12",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Providence",
+      "city": "Providence RI",
       "country": "United States",
       "continent": "America",
       "lat": 41.8245558,
       "lon": -71.414199,
-      "url": "http://www.northeastswingclassic.com",
+      "url": "http://www.northeastswingclassic.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:270:2026-11-12",
@@ -10330,14 +10470,14 @@
       "weekend_key": "2026-11-12",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Lyon",
+      "city": "LYON",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
-      "url": "http://www.frenchywesty.com",
+      "url": "http://www.frenchywesty.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:269:2026-11-13",
@@ -10355,9 +10495,9 @@
       "continent": "Europe",
       "lat": 47.497912,
       "lon": 19.040235,
-      "url": "http://www.asc-budapest.com",
+      "url": "http://www.asc-budapest.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:365:2026-11-13",
@@ -10375,9 +10515,9 @@
       "continent": "Europe",
       "lat": 51.5072178,
       "lon": -0.1275862,
-      "url": "http://www.Flowstatefest.com",
+      "url": "http://www.flowstatefest.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:181:2026-11-19",
@@ -10390,14 +10530,14 @@
       "weekend_key": "2026-11-19",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Herndon",
+      "city": "Washington",
       "country": "United States",
       "continent": "America",
       "lat": 38.9695545,
       "lon": -77.3860976,
-      "url": "http://www.dcswingexperience.com",
+      "url": "http://www.dcswingexperience.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:323:2026-11-19",
@@ -10415,9 +10555,9 @@
       "continent": "America",
       "lat": 34.7295497,
       "lon": -86.5853155,
-      "url": "http://rocketcityswing.com",
+      "url": "http://rocketcityswing.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:68:2026-11-25",
@@ -10440,6 +10580,26 @@
       "source": "edition_calendar_dates"
     },
     {
+      "id": "confirmed:t-the-open-swing-dance-championships-los-angeles-united-states:2026-11-25",
+      "event_id": null,
+      "name": "The Open Swing Dance  Championships",
+      "start_date": "2026-11-25",
+      "end_date": "2026-11-29",
+      "weekend_start": "2026-11-19",
+      "weekend_end": "2026-11-22",
+      "weekend_key": "2026-11-19",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Los Angeles",
+      "country": "United States",
+      "continent": "America",
+      "lat": 34.0549076,
+      "lon": -118.242643,
+      "url": "http://www.theopenswing.com/",
+      "year": 2026,
+      "source": "events_list_current"
+    },
+    {
       "id": "confirmed:87:2026-11-26",
       "event_id": 87,
       "name": "CASH Bash",
@@ -10457,12 +10617,12 @@
       "lon": -81.6943605,
       "url": "https://cashdanceclub.org/cash-bash/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:212:2026-12-03",
       "event_id": 212,
-      "name": "The After Party aka TAP",
+      "name": "The After Party (TAP)",
       "start_date": "2026-12-03",
       "end_date": "2026-12-07",
       "weekend_start": "2026-12-03",
@@ -10475,9 +10635,9 @@
       "continent": "America",
       "lat": 33.7174708,
       "lon": -117.8311428,
-      "url": "http://www.tapwcs.com",
+      "url": "http://www.tapwcs.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:238:2026-12-03",
@@ -10495,9 +10655,9 @@
       "continent": "Europe",
       "lat": 59.9121746,
       "lon": 10.7312704,
-      "url": "http://www.winterwhite.no",
+      "url": "http://www.winterwhite.no/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:290:2026-12-05",
@@ -10538,9 +10698,9 @@
       "continent": "Europe",
       "lat": 52.52000659999999,
       "lon": 13.404954,
-      "url": "https://berlinswingrevolution.com",
+      "url": "https://berlinswingrevolution.com/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:377:2026-12-10",
@@ -10560,7 +10720,7 @@
       "lon": 19.9449799,
       "url": "https://www.santaswing.pl/",
       "year": 2026,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "hiatus:990001:2026-12-11",
@@ -10573,14 +10733,34 @@
       "weekend_key": "2026-12-10",
       "status": "hiatus",
       "kind": "registry",
-      "city": "Toulouse",
+      "city": "Toulouse-Blagnac",
       "country": "France",
       "continent": "Europe",
-      "lat": 43.6048462,
-      "lon": 1.442848,
+      "lat": null,
+      "lon": null,
       "url": "https://www.globalgrandprixwcs.com/",
       "year": 2026,
-      "source": "operator_override"
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:t-swiss-open-wcs-geneva-switzerland:2026-12-18",
+      "event_id": null,
+      "name": "Swiss Open WCS",
+      "start_date": "2026-12-18",
+      "end_date": "2026-12-20",
+      "weekend_start": "2026-12-17",
+      "weekend_end": "2026-12-20",
+      "weekend_key": "2026-12-17",
+      "status": "confirmed",
+      "kind": "trial",
+      "city": "Geneva",
+      "country": "Switzerland",
+      "continent": "Europe",
+      "lat": 46.2043907,
+      "lon": 6.1431577,
+      "url": "http://www.swissopenwcs.ch/",
+      "year": 2026,
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:75:2026-12-28",
@@ -10598,9 +10778,9 @@
       "continent": "America",
       "lat": 32.7831,
       "lon": -96.8067,
-      "url": "http://www.ucwdcworlds.com",
+      "url": "http://www.ucwdcworlds.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:42:2026-12-30",
@@ -10618,14 +10798,14 @@
       "continent": "America",
       "lat": 28.5383832,
       "lon": -81.3789269,
-      "url": "http://www.floorplayswingvacation.com",
+      "url": "http://www.floorplayswingvacation.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:214:2026-12-30",
       "event_id": 214,
-      "name": "New Years Swing Fling",
+      "name": "New Year's Swing Fling",
       "start_date": "2026-12-30",
       "end_date": "2027-01-03",
       "weekend_start": "2026-12-24",
@@ -10638,9 +10818,9 @@
       "continent": "Europe",
       "lat": 51.5072178,
       "lon": -0.1275862,
-      "url": "http://nysf.uk",
+      "url": "http://nysf.uk/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:141:2026-12-30",
@@ -10658,9 +10838,9 @@
       "continent": "America",
       "lat": 36.1626638,
       "lon": -86.7816016,
-      "url": "http://www.spotlightnewyears.com",
+      "url": "http://www.spotlightnewyears.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:289:2026-12-30",
@@ -10673,15 +10853,14 @@
       "weekend_key": "2026-12-24",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Brno",
-      "country": "Czech Republic",
+      "city": "Wels",
+      "country": "Austria",
       "continent": "Europe",
       "lat": 49.1950602,
       "lon": 16.6068371,
       "url": "https://www.swingvester.com/",
-      "year": 2026,
-      "source": "edition_calendar_dates",
-      "has_results": true
+      "year": 2027,
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:334:2026-12-31",
@@ -10699,9 +10878,9 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://Countdownswingboston.com",
+      "url": "http://countdownswingboston.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:240:2026-12-31",
@@ -10719,9 +10898,9 @@
       "continent": "Europe",
       "lat": 59.3251172,
       "lon": 18.0710935,
-      "url": "http://www.westiegala.com",
+      "url": "http://www.westiegala.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:184:2027-01-05",
@@ -10739,9 +10918,29 @@
       "continent": "Europe",
       "lat": 47.497912,
       "lon": 19.040235,
-      "url": "http://wcs-budafest.com",
+      "url": "http://wcs-budafest.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:t-swingco-portland-united-states:2027-01-07",
+      "event_id": null,
+      "name": "SwingCo",
+      "start_date": "2027-01-07",
+      "end_date": "2027-01-11",
+      "weekend_start": "2027-01-07",
+      "weekend_end": "2027-01-10",
+      "weekend_key": "2027-01-07",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Portland",
+      "country": "United States",
+      "continent": "America",
+      "lat": 45.515232,
+      "lon": -122.6783853,
+      "url": "https://swingco.dance/",
+      "year": 2027,
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:200:2027-01-14",
@@ -10759,9 +10958,29 @@
       "continent": "America",
       "lat": 30.267153,
       "lon": -97.7430608,
-      "url": "https://austinswingdance.com",
+      "url": "https://austinswingdance.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:t-cologne-calling-wcs-koln-germany:2027-01-14",
+      "event_id": null,
+      "name": "Cologne Calling WCS",
+      "start_date": "2027-01-14",
+      "end_date": "2027-01-17",
+      "weekend_start": "2027-01-14",
+      "weekend_end": "2027-01-17",
+      "weekend_key": "2027-01-14",
+      "status": "confirmed",
+      "kind": "trial",
+      "city": "Köln",
+      "country": "Germany",
+      "continent": "Europe",
+      "lat": null,
+      "lon": null,
+      "url": "https://colognecallingwcs.com/",
+      "year": 2027,
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:309:2027-01-15",
@@ -10781,7 +11000,7 @@
       "lon": 4.359999699999999,
       "url": "https://www.avignoncityswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:62:2027-01-15",
@@ -10799,9 +11018,9 @@
       "continent": "America",
       "lat": 36.5972925,
       "lon": -121.8977688,
-      "url": "http://www.montereyswing.com",
+      "url": "http://www.montereyswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:381:2027-01-16",
@@ -10843,12 +11062,12 @@
       "lon": -85.7663724,
       "url": "https://derbycityswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:301:2027-01-21",
       "event_id": 301,
-      "name": "SWING RESOLUTION",
+      "name": "Swing Resolution",
       "start_date": "2027-01-21",
       "end_date": "2027-01-25",
       "weekend_start": "2027-01-21",
@@ -10861,9 +11080,9 @@
       "continent": "Europe",
       "lat": 55.953252,
       "lon": -3.188267,
-      "url": "http://www.swingresolution.com",
+      "url": "http://www.swingresolution.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:183:2027-01-22",
@@ -10876,19 +11095,39 @@
       "weekend_key": "2027-01-21",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Wilmington",
+      "city": "WILMINGTON DEL",
       "country": "United States",
       "continent": "America",
       "lat": 39.744655,
       "lon": -75.5483909,
       "url": "https://freedomswingdance.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:t-swing-in-paris-paris-france:2027-01-22",
+      "event_id": null,
+      "name": "Swing In Paris",
+      "start_date": "2027-01-22",
+      "end_date": "2027-01-25",
+      "weekend_start": "2027-01-21",
+      "weekend_end": "2027-01-24",
+      "weekend_key": "2027-01-21",
+      "status": "confirmed",
+      "kind": "trial",
+      "city": "PARIS",
+      "country": "France",
+      "continent": "Europe",
+      "lat": 48.8575475,
+      "lon": 2.3513765,
+      "url": "http://swing-in-paris.com/",
+      "year": 2027,
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:273:2027-02-04",
       "event_id": 273,
-      "name": "Charlotte WestieFest",
+      "name": "Charlotte Westie Fest",
       "start_date": "2027-02-04",
       "end_date": "2027-02-07",
       "weekend_start": "2027-02-04",
@@ -10903,7 +11142,7 @@
       "lon": -80.84089329999999,
       "url": "https://charlottewestiefest.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:215:2027-02-04",
@@ -10921,9 +11160,9 @@
       "continent": "Europe",
       "lat": 59.9310584,
       "lon": 30.3609097,
-      "url": "http://swingandsnow.ru",
+      "url": "http://swingandsnow.ru/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:258:2027-02-04",
@@ -10943,7 +11182,7 @@
       "lon": 8.541694,
       "url": "https://swingtzerland.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:387:2027-02-04",
@@ -10957,13 +11196,13 @@
       "status": "confirmed",
       "kind": "registry",
       "city": "Waterloo",
-      "country": "Canada",
+      "country": "United States",
       "continent": "America",
       "lat": 43.4819752,
       "lon": -80.5261203,
-      "url": "http://www.waterlooopenwcs.com",
+      "url": "http://www.waterlooopenwcs.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:363:2027-02-05",
@@ -10981,9 +11220,9 @@
       "continent": "Europe",
       "lat": 54.0024774,
       "lon": -6.388300099999999,
-      "url": "http://www.Trinityswing.com",
+      "url": "http://www.trinityswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:302:2027-02-06",
@@ -11023,9 +11262,9 @@
       "continent": "Europe",
       "lat": 48.2672137,
       "lon": 7.725619099999999,
-      "url": "https://www.euro-dance-festival.com",
+      "url": "https://www.euro-dance-festival.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:12:2027-02-11",
@@ -11043,9 +11282,9 @@
       "continent": "America",
       "lat": 38.5781342,
       "lon": -121.4944209,
-      "url": "http://www.capitalswingconvention.com",
+      "url": "http://www.capitalswingconvention.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:344:2027-02-18",
@@ -11063,9 +11302,9 @@
       "continent": "Europe",
       "lat": 42.416489,
       "lon": -8.8252502,
-      "url": "https://www.arousawestiefest.com",
+      "url": "https://www.arousawestiefest.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:343:2027-02-18",
@@ -11085,7 +11324,7 @@
       "lon": -98.4945922,
       "url": "https://swingcrush.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:386:2027-02-19",
@@ -11105,7 +11344,7 @@
       "lon": 14.4378005,
       "url": "https://praguealchemyswing.cz/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:310:2027-02-19",
@@ -11123,9 +11362,9 @@
       "continent": "Europe",
       "lat": 59.3251172,
       "lon": 18.0710935,
-      "url": "http://www.valentineswing.dance",
+      "url": "http://www.valentineswing.dance/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:272:2027-02-25",
@@ -11143,9 +11382,9 @@
       "continent": "Europe",
       "lat": 48.8575475,
       "lon": 2.3513765,
-      "url": "http://Https://parisswingclassic.com",
+      "url": "http://https//parisswingclassic.com",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:244:2027-02-25",
@@ -11163,9 +11402,9 @@
       "continent": "America",
       "lat": 45.515232,
       "lon": -122.6783853,
-      "url": "https://rosecityswing.com",
+      "url": "https://rosecityswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:394:2027-02-25",
@@ -11183,9 +11422,9 @@
       "continent": "Australia",
       "lat": -42.8826055,
       "lon": 147.3257196,
-      "url": "http://www.southernlightsswing.com.au",
+      "url": "http://www.southernlightsswing.com.au/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:297:2027-02-25",
@@ -11203,9 +11442,9 @@
       "continent": "Europe",
       "lat": 62.4917035,
       "lon": 27.7880116,
-      "url": "https://www.wintercoastswing.com",
+      "url": "https://www.wintercoastswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:378:2027-02-26",
@@ -11218,14 +11457,14 @@
       "weekend_key": "2027-02-25",
       "status": "confirmed",
       "kind": "registry",
-      "city": "New York",
+      "city": "New York City",
       "country": "United States",
       "continent": "America",
       "lat": 40.7127753,
       "lon": -74.0059728,
-      "url": "https://www.flowfest.nyc",
+      "url": "https://www.flowfest.nyc/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:92:2027-03-04",
@@ -11243,9 +11482,9 @@
       "continent": "America",
       "lat": 38.9072873,
       "lon": -77.0369274,
-      "url": "http://www.atlanticdancejam.com",
+      "url": "http://www.atlanticdancejam.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:232:2027-03-05",
@@ -11257,7 +11496,7 @@
       "weekend_end": "2027-03-07",
       "weekend_key": "2027-03-04",
       "status": "confirmed",
-      "kind": "registry",
+      "kind": "trial",
       "city": "Trondheim",
       "country": "Norway",
       "continent": "Europe",
@@ -11265,7 +11504,7 @@
       "lon": 10.3950528,
       "url": "https://www.norwaywestiefest.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:333:2027-03-05",
@@ -11285,7 +11524,7 @@
       "lon": 174.7787463,
       "url": "https://swingvasion.nz/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:197:2027-03-11",
@@ -11303,14 +11542,14 @@
       "continent": "America",
       "lat": 39.7392358,
       "lon": -104.990251,
-      "url": "http://www.5280westival.com",
+      "url": "http://www.5280westival.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:275:2027-03-11",
       "event_id": 275,
-      "name": "Dutch Open Wcs",
+      "name": "Dutch Open West Coast Swing",
       "start_date": "2027-03-11",
       "end_date": "2027-03-14",
       "weekend_start": "2027-03-11",
@@ -11323,9 +11562,29 @@
       "continent": "Europe",
       "lat": 51.5256257,
       "lon": 5.9736992,
-      "url": "http://www.dutchopenwcs.com",
+      "url": "http://www.dutchopenwcs.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:t-h-town-throw-down-2027-houston-united-states:2027-03-11",
+      "event_id": null,
+      "name": "H-Town Throw Down 2027",
+      "start_date": "2027-03-11",
+      "end_date": "2027-03-14",
+      "weekend_start": "2027-03-11",
+      "weekend_end": "2027-03-14",
+      "weekend_key": "2027-03-11",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Houston",
+      "country": "United States",
+      "continent": "America",
+      "lat": 29.7600771,
+      "lon": -95.3701108,
+      "url": "http://www.htownthrowdownwcs.com/",
+      "year": 2027,
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:314:2027-03-11",
@@ -11343,9 +11602,9 @@
       "continent": "Europe",
       "lat": 47.497912,
       "lon": 19.040235,
-      "url": "https://westiespringthing.com",
+      "url": "https://westiespringthing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:318:2027-03-12",
@@ -11386,9 +11645,9 @@
       "continent": "America",
       "lat": 34.703947,
       "lon": -118.1481016,
-      "url": "http://www.highdesertdanceclassic.com",
+      "url": "http://www.highdesertdanceclassic.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:292:2027-03-18",
@@ -11406,9 +11665,9 @@
       "continent": "Europe",
       "lat": 50.06465009999999,
       "lon": 19.9449799,
-      "url": "https://kingswing.pl",
+      "url": "https://kingswing.pl/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:142:2027-03-18",
@@ -11428,7 +11687,7 @@
       "lon": -87.6323879,
       "url": "https://thechicagoclassic.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:186:2027-03-18",
@@ -11441,14 +11700,14 @@
       "weekend_key": "2027-03-18",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Lyon",
+      "city": "LYON",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
-      "url": "http://www.west-in-lyon.fr",
+      "url": "http://www.west-in-lyon.fr/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:9:2027-03-19",
@@ -11466,9 +11725,9 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://teapartyswings.com",
+      "url": "http://teapartyswings.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:18:2027-03-25",
@@ -11488,12 +11747,12 @@
       "lon": -122.3328481,
       "url": "https://easterswing.org/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:132:2027-03-25",
       "event_id": 132,
-      "name": "TULSA SPRING SWING",
+      "name": "Tulsa Spring Swing",
       "start_date": "2027-03-25",
       "end_date": "2027-03-28",
       "weekend_start": "2027-03-25",
@@ -11506,9 +11765,9 @@
       "continent": "America",
       "lat": 36.1551375,
       "lon": -95.989501,
-      "url": "http://www.TulsaSpringSwing.com",
+      "url": "http://www.tulsaspringswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:154:2027-03-25",
@@ -11526,9 +11785,9 @@
       "continent": "Europe",
       "lat": 51.5072178,
       "lon": -0.1275862,
-      "url": "http://www.ukwcschamps.com",
+      "url": "http://www.ukwcschamps.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:153:2027-03-26",
@@ -11577,9 +11836,29 @@
       "has_results": true
     },
     {
+      "id": "confirmed:t-franconian-swing-project-nurnberg-germany:2027-04-08",
+      "event_id": null,
+      "name": "Franconian Swing Project",
+      "start_date": "2027-04-08",
+      "end_date": "2027-04-11",
+      "weekend_start": "2027-04-08",
+      "weekend_end": "2027-04-11",
+      "weekend_key": "2027-04-08",
+      "status": "confirmed",
+      "kind": "trial",
+      "city": "Nürnberg",
+      "country": "Germany",
+      "continent": "Europe",
+      "lat": 49.45428810000001,
+      "lon": 11.0745641,
+      "url": "https://franconian-swing-project.de/",
+      "year": 2027,
+      "source": "events_list_current"
+    },
+    {
       "id": "confirmed:210:2027-04-08",
       "event_id": 210,
-      "name": "KOREAN OPEN WCS CHAMPIONSHIPS",
+      "name": "Korean Open WCS Championships",
       "start_date": "2027-04-08",
       "end_date": "2027-04-11",
       "weekend_start": "2027-04-08",
@@ -11592,9 +11871,9 @@
       "continent": "Asia",
       "lat": 37.4751578,
       "lon": 126.6312666,
-      "url": "https://www.kopenwcs.com",
+      "url": "https://www.kopenwcs.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:304:2027-04-09",
@@ -11637,12 +11916,12 @@
       "lon": 14.5057515,
       "url": "https://slovenianopen.dance/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:218:2027-04-15",
       "event_id": 218,
-      "name": "Asia WCS Open 2027",
+      "name": "Asia West Coast Swing Open",
       "start_date": "2027-04-15",
       "end_date": "2027-04-18",
       "weekend_start": "2027-04-15",
@@ -11657,7 +11936,7 @@
       "lon": 103.819836,
       "url": "https://asiawcsopen.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:293:2027-04-16",
@@ -11677,7 +11956,7 @@
       "lon": -1.553621,
       "url": "https://www.westynantes.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:203:2027-04-22",
@@ -11695,9 +11974,9 @@
       "continent": "Europe",
       "lat": 53.4807593,
       "lon": -2.2426305,
-      "url": "http://www.DetonationDance.com",
+      "url": "http://www.detonationdance.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:345:2027-04-22",
@@ -11717,7 +11996,7 @@
       "lon": 55.9578555,
       "url": "https://t.me/honeyfest",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:393:2027-04-22",
@@ -11735,14 +12014,14 @@
       "continent": "America",
       "lat": 45.4200572,
       "lon": -75.7003397,
-      "url": "http://www.swinginbloom.ca",
+      "url": "http://www.swinginbloom.ca/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:370:2027-04-22",
       "event_id": 370,
-      "name": "SwingIn Festival",
+      "name": "SwingIN Festival",
       "start_date": "2027-04-22",
       "end_date": "2027-04-25",
       "weekend_start": "2027-04-22",
@@ -11755,14 +12034,14 @@
       "continent": "Europe",
       "lat": 50.73743,
       "lon": 7.0982068,
-      "url": "http://www.swinginfestival.de",
+      "url": "http://www.swinginfestival.de/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:259:2027-04-22",
       "event_id": 259,
-      "name": "Swingover 2027",
+      "name": "Swingover",
       "start_date": "2027-04-22",
       "end_date": "2027-04-25",
       "weekend_start": "2027-04-22",
@@ -11775,9 +12054,9 @@
       "continent": "America",
       "lat": 28.5383832,
       "lon": -81.3789269,
-      "url": "http://swingoverevent.com",
+      "url": "http://swingoverevent.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:347:2027-04-29",
@@ -11797,7 +12076,7 @@
       "lon": -3.7032905,
       "url": "https://beemadwcs.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:116:2027-04-29",
@@ -11815,9 +12094,9 @@
       "continent": "America",
       "lat": 51.04473309999999,
       "lon": -114.0718831,
-      "url": "http://www.calgarydancestampede.com",
+      "url": "http://www.calgarydancestampede.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:187:2027-04-29",
@@ -11837,7 +12116,7 @@
       "lon": -118.3074827,
       "url": "https://cityofangelswcs.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:144:2027-04-29",
@@ -11855,9 +12134,9 @@
       "continent": "America",
       "lat": 41.7658043,
       "lon": -72.6733723,
-      "url": "http://www.sis.djkenm.com",
+      "url": "http://www.sis.djkenm.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:253:2027-04-30",
@@ -11916,14 +12195,14 @@
       "weekend_key": "2027-05-06",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Silver Spring",
+      "city": "Washington DC",
       "country": "United States",
       "continent": "America",
       "lat": 38.9906654,
       "lon": -77.026088,
       "url": "https://dancejamproductions.com/westieweekend/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:336:2027-05-07",
@@ -11987,9 +12266,9 @@
       "continent": "America",
       "lat": 42.1967113,
       "lon": -122.7139216,
-      "url": "http://wwww.soswingdance.com",
+      "url": "http://wwww.soswingdance.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:174:2027-05-13",
@@ -12002,37 +12281,14 @@
       "weekend_key": "2027-05-13",
       "status": "confirmed",
       "kind": "registry",
-      "city": "St. Petersburg",
-      "country": "Russia",
-      "continent": "Europe",
-      "lat": 59.9310584,
-      "lon": 30.3609097,
+      "city": "Gold Coast",
+      "country": "Australia",
+      "continent": "Australia",
+      "lat": -27.9769248,
+      "lon": 153.380936,
       "url": "https://rawconnection.com.au/swingsation/",
       "year": 2027,
-      "source": "edition_calendar_dates"
-    },
-    {
-      "id": "expected:221:2027-05-14",
-      "event_id": 221,
-      "name": "Gateway Swing Classic",
-      "start_date": "2027-05-14",
-      "end_date": "2027-05-17",
-      "weekend_start": "2027-05-13",
-      "weekend_end": "2027-05-16",
-      "weekend_key": "2027-05-13",
-      "status": "expected",
-      "kind": "registry",
-      "city": "St. Louis",
-      "country": "United States",
-      "continent": "America",
-      "lat": 38.62742799999999,
-      "lon": -90.1982439,
-      "url": "http://gatewayswing.com",
-      "year": 2027,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-05-14",
-      "has_results": true
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:379:2027-05-14",
@@ -12101,6 +12357,26 @@
       "has_results": true
     },
     {
+      "id": "confirmed:221:2027-05-20",
+      "event_id": 221,
+      "name": "Gateway Swing Classic",
+      "start_date": "2027-05-20",
+      "end_date": "2027-05-23",
+      "weekend_start": "2027-05-20",
+      "weekend_end": "2027-05-23",
+      "weekend_key": "2027-05-20",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "St. Louis",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.62742799999999,
+      "lon": -90.1982439,
+      "url": "http://gatewayswing.com/",
+      "year": 2027,
+      "source": "events_list_current"
+    },
+    {
       "id": "confirmed:364:2027-05-21",
       "event_id": 364,
       "name": "Nanaimo Dance Fusion",
@@ -12116,9 +12392,9 @@
       "continent": "America",
       "lat": 49.1658836,
       "lon": -123.9400647,
-      "url": "http://www.nanaimodancefusion.ca",
+      "url": "http://www.nanaimodancefusion.ca/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:206:2027-05-22",
@@ -12159,9 +12435,9 @@
       "continent": "America",
       "lat": 33.7501275,
       "lon": -84.3885209,
-      "url": "http://www.usagrandnationals.com",
+      "url": "http://www.usagrandnationals.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:368:2027-05-30",
@@ -12204,7 +12480,7 @@
       "lon": -1.61778,
       "url": "https://www.fcswing.co.uk/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:76:2027-06-03",
@@ -12222,9 +12498,9 @@
       "continent": "America",
       "lat": 42.32971819999999,
       "lon": -83.0424533,
-      "url": "http://MichiganClassicSwing.com",
+      "url": "http://michiganclassicswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:25:2027-06-04",
@@ -12283,19 +12559,19 @@
       "weekend_key": "2027-06-10",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Gdańsk",
+      "city": "Gdansk",
       "country": "Poland",
       "continent": "Europe",
       "lat": 54.35202520000001,
       "lon": 18.6466384,
-      "url": "http://www.balticswing.com",
+      "url": "http://www.balticswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:220:2027-06-10",
       "event_id": 220,
-      "name": "D-TOWNSWING 2027",
+      "name": "D-Town Swing",
       "start_date": "2027-06-10",
       "end_date": "2027-06-13",
       "weekend_start": "2027-06-10",
@@ -12308,9 +12584,9 @@
       "continent": "Europe",
       "lat": 51.2230411,
       "lon": 6.7824545,
-      "url": "http://www.d-townswing.com",
+      "url": "http://www.d-townswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:162:2027-06-17",
@@ -12328,9 +12604,9 @@
       "continent": "America",
       "lat": 30.4514677,
       "lon": -91.1871466,
-      "url": "http://www.swingapaloozaevent.com",
+      "url": "http://www.swingapaloozaevent.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:405:2027-06-18",
@@ -12371,9 +12647,9 @@
       "continent": "Europe",
       "lat": 48.8891149,
       "lon": 9.1942834,
-      "url": "https://baroqueswing.com",
+      "url": "https://baroqueswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "confirmed:96:2027-06-24",
@@ -12391,9 +12667,29 @@
       "continent": "America",
       "lat": 40.4966567,
       "lon": -74.4442802,
-      "url": "http://www.libertyswing.com",
+      "url": "http://www.libertyswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
+    },
+    {
+      "id": "confirmed:t-neverlandswing-dutch-swing-championships-2027-amsterdam-nether:2027-06-24",
+      "event_id": null,
+      "name": "NeverlandSwing Dutch Swing Championships 2027",
+      "start_date": "2027-06-24",
+      "end_date": "2027-06-28",
+      "weekend_start": "2027-06-24",
+      "weekend_end": "2027-06-27",
+      "weekend_key": "2027-06-24",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Amsterdam",
+      "country": "Netherlands",
+      "continent": "Europe",
+      "lat": 52.3675734,
+      "lon": 4.9041389,
+      "url": "http://www.neverlandswing.com/",
+      "year": 2027,
+      "source": "events_list_current"
     },
     {
       "id": "expected:109:2027-06-25",
@@ -12434,9 +12730,9 @@
       "continent": "Europe",
       "lat": 45.899247,
       "lon": 6.129384,
-      "url": "http://frenchconnectionwcs.com",
+      "url": "http://frenchconnectionwcs.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:261:2027-06-25",
@@ -12525,6 +12821,26 @@
       "source": "edition_calendar_dates"
     },
     {
+      "id": "confirmed:t-swing-valley-bad-hofgastein-austria:2027-07-01",
+      "event_id": null,
+      "name": "Swing Valley",
+      "start_date": "2027-07-01",
+      "end_date": "2027-07-04",
+      "weekend_start": "2027-07-01",
+      "weekend_end": "2027-07-04",
+      "weekend_key": "2027-07-01",
+      "status": "confirmed",
+      "kind": "trial",
+      "city": "Bad Hofgastein",
+      "country": "Austria",
+      "continent": "Europe",
+      "lat": 47.1725556,
+      "lon": 13.0987448,
+      "url": "http://swing-valley.com/",
+      "year": 2027,
+      "source": "events_list_current"
+    },
+    {
       "id": "expected:1:2027-07-02",
       "event_id": 1,
       "name": "4TH of July Convention",
@@ -12586,9 +12902,9 @@
       "continent": "America",
       "lat": 35.2270768,
       "lon": -80.84089329999999,
-      "url": "https://carolinasummerswing.com",
+      "url": "https://carolinasummerswing.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:156:2027-07-09",
@@ -12698,9 +13014,9 @@
       "continent": "America",
       "lat": 38.9822282,
       "lon": -94.6707917,
-      "url": "http://www.midwestwestiefest.com",
+      "url": "http://www.midwestwestiefest.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:385:2027-07-16",
@@ -12911,7 +13227,7 @@
     {
       "id": "expected:282:2027-08-05",
       "event_id": 282,
-      "name": "German Open WCS",
+      "name": "German Open",
       "start_date": "2027-08-05",
       "end_date": "2027-08-09",
       "weekend_start": "2027-08-05",
@@ -12924,7 +13240,7 @@
       "continent": "Europe",
       "lat": 47.9990077,
       "lon": 7.842104299999999,
-      "url": "http://www.go-wcs.com",
+      "url": "http://www.go-wcs.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -12946,7 +13262,7 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://www.nedancefestival.com",
+      "url": "http://www.nedancefestival.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -12963,12 +13279,12 @@
       "weekend_key": "2027-08-05",
       "status": "expected",
       "kind": "registry",
-      "city": "Herndon",
+      "city": "Washington",
       "country": "United States",
       "continent": "America",
       "lat": 38.9695545,
       "lon": -77.3860976,
-      "url": "http://www.swingfling.com",
+      "url": "http://www.swingfling.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -12990,7 +13306,7 @@
       "continent": "America",
       "lat": 37.7749295,
       "lon": -122.4194155,
-      "url": "http://www.DanceGeekProductions.Art",
+      "url": "http://www.dancegeekproductions.art/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13057,7 +13373,7 @@
       "continent": "Europe",
       "lat": 59.3251172,
       "lon": 18.0710935,
-      "url": "http://www.uptownswing.se",
+      "url": "http://www.uptownswing.se/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13074,8 +13390,8 @@
       "weekend_key": "2027-08-19",
       "status": "expected",
       "kind": "registry",
-      "city": "Perth",
-      "country": "Australia",
+      "city": "Christchurch",
+      "country": "New Zealand",
       "continent": "Australia",
       "lat": -31.9513993,
       "lon": 115.8616783,
@@ -13101,7 +13417,7 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://Summerhummerboston.com",
+      "url": "http://summerhummerboston.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13123,7 +13439,7 @@
       "continent": "America",
       "lat": 44.0581728,
       "lon": -121.3153096,
-      "url": "http://thebendconnection.com",
+      "url": "http://thebendconnection.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13145,7 +13461,7 @@
       "continent": "America",
       "lat": 41.88325,
       "lon": -87.6323879,
-      "url": "http://www.chicagolanddancefestival.com",
+      "url": "http://www.chicagolanddancefestival.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13190,7 +13506,7 @@
       "continent": "America",
       "lat": 33.4482948,
       "lon": -112.0725488,
-      "url": "http://www.desertcityswing.com",
+      "url": "http://www.desertcityswing.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13207,12 +13523,12 @@
       "weekend_key": "2027-08-26",
       "status": "expected",
       "kind": "registry",
-      "city": "Lyon",
+      "city": "LYON",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
-      "url": "http://www.frenchywesty.com",
+      "url": "http://www.frenchywesty.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13256,7 +13572,7 @@
       "continent": "Asia",
       "lat": 33.5042779,
       "lon": 126.519838,
-      "url": "http://koreawestival.com",
+      "url": "http://koreawestival.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13300,7 +13616,7 @@
       "continent": "America",
       "lat": 30.3297566,
       "lon": -81.6591529,
-      "url": "http://www.jaxwestiefest.com",
+      "url": "http://www.jaxwestiefest.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13322,7 +13638,7 @@
       "continent": "Europe",
       "lat": 48.1351253,
       "lon": 11.5819806,
-      "url": "https://bavarianopen.com",
+      "url": "https://bavarianopen.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13331,7 +13647,7 @@
     {
       "id": "expected:47:2027-09-10",
       "event_id": 47,
-      "name": "SwingTime Denver",
+      "name": "Swingtime in the Rockies",
       "start_date": "2027-09-10",
       "end_date": "2027-09-13",
       "weekend_start": "2027-09-09",
@@ -13344,7 +13660,7 @@
       "continent": "America",
       "lat": 39.7392358,
       "lon": -104.990251,
-      "url": "http://www.swingtimewcs.com",
+      "url": "http://www.swingtimewcs.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13410,7 +13726,7 @@
       "continent": "America",
       "lat": 47.6061389,
       "lon": -122.3328481,
-      "url": "https://www.retaliationswing.com",
+      "url": "https://www.retaliationswing.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13419,7 +13735,7 @@
     {
       "id": "expected:357:2027-09-17",
       "event_id": 357,
-      "name": "WCS Party in Vienna",
+      "name": "WCS Party",
       "start_date": "2027-09-17",
       "end_date": "2027-09-21",
       "weekend_start": "2027-09-16",
@@ -13476,7 +13792,7 @@
       "continent": "Europe",
       "lat": 60.16985569999999,
       "lon": 24.938379,
-      "url": "http://www.finnfest.fi",
+      "url": "http://www.finnfest.fi/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13485,7 +13801,7 @@
     {
       "id": "expected:342:2027-09-18",
       "event_id": 342,
-      "name": "Global Grand Prix -- West Coast Swing Championships",
+      "name": "Global Grand Prix - West Coast Swing Reunion",
       "start_date": "2027-09-18",
       "end_date": "2027-09-21",
       "weekend_start": "2027-09-16",
@@ -13493,11 +13809,11 @@
       "weekend_key": "2027-09-16",
       "status": "expected",
       "kind": "registry",
-      "city": "Toulouse",
+      "city": "Paris",
       "country": "France",
       "continent": "Europe",
-      "lat": 43.6048462,
-      "lon": 1.442848,
+      "lat": 48.8575475,
+      "lon": 2.3513765,
       "url": "https://www.globalgrandprixwcs.com/",
       "year": 2027,
       "source": "expected_yoy",
@@ -13520,7 +13836,7 @@
       "continent": "America",
       "lat": 20.6871826,
       "lon": -156.4391668,
-      "url": "http://www.alohaopenwcs.com",
+      "url": "http://www.alohaopenwcs.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13564,7 +13880,7 @@
       "continent": "America",
       "lat": 38.62742799999999,
       "lon": -90.1982439,
-      "url": "http://Www.mmisl.com",
+      "url": "http://www.mmisl.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13586,7 +13902,7 @@
       "continent": "Europe",
       "lat": 51.5072178,
       "lon": -0.1275862,
-      "url": "http://www.MidlandSwingOpen.com",
+      "url": "http://www.midlandswingopen.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13595,7 +13911,7 @@
     {
       "id": "expected:361:2027-09-24",
       "event_id": 361,
-      "name": "Mooseland Swing 2026",
+      "name": "Mooseland Swing",
       "start_date": "2027-09-24",
       "end_date": "2027-09-28",
       "weekend_start": "2027-09-23",
@@ -13625,7 +13941,7 @@
       "weekend_key": "2027-09-23",
       "status": "expected",
       "kind": "registry",
-      "city": "Wilmington",
+      "city": "WILMINGTON",
       "country": "United States",
       "continent": "America",
       "lat": 39.744655,
@@ -13676,7 +13992,7 @@
       "lon": -84.3885209,
       "url": "https://www.atlantaswingclassic.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:8:2027-10-08",
@@ -13694,7 +14010,7 @@
       "continent": "America",
       "lat": 37.7749295,
       "lon": -122.4194155,
-      "url": "https://boogiebythebay.com",
+      "url": "https://boogiebythebay.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13716,7 +14032,7 @@
       "continent": "America",
       "lat": 45.5018869,
       "lon": -73.56739189999999,
-      "url": "http://montrealwestiefest.com",
+      "url": "http://montrealwestiefest.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13827,9 +14143,9 @@
       "continent": "Europe",
       "lat": 51.2230411,
       "lon": 6.7824545,
-      "url": "http://www.wcsfestival.com",
+      "url": "http://www.wcsfestival.com/",
       "year": 2027,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:267:2027-10-16",
@@ -13847,7 +14163,7 @@
       "continent": "America",
       "lat": 39.9525839,
       "lon": -75.1652215,
-      "url": "http://www.swustlicious.com",
+      "url": "http://www.swustlicious.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13891,7 +14207,7 @@
       "continent": "America",
       "lat": 33.6638439,
       "lon": -117.9047429,
-      "url": "http://Hstswing.com",
+      "url": "http://hstswing.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13900,7 +14216,7 @@
     {
       "id": "expected:380:2027-10-22",
       "event_id": 380,
-      "name": "SASS- Spooky Albany Swing Spectacular",
+      "name": "SASS Spooky Albany Swing Spectacular",
       "start_date": "2027-10-22",
       "end_date": "2027-10-25",
       "weekend_start": "2027-10-21",
@@ -13913,7 +14229,7 @@
       "continent": "America",
       "lat": 42.6518095,
       "lon": -73.75447070000001,
-      "url": "http://www.spookyalbanyswing.com",
+      "url": "http://www.spookyalbanyswing.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -13930,23 +14246,23 @@
       "weekend_key": "2027-10-21",
       "status": "expected",
       "kind": "registry",
-      "city": "Chicago",
+      "city": "CHICAGO",
       "country": "United States",
       "continent": "America",
       "lat": 41.88325,
       "lon": -87.6323879,
-      "url": "https://swingcitychicago.com",
+      "url": "https://swingcitychicago.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-10-22"
     },
     {
-      "id": "expected:346:2027-10-22",
+      "id": "expected:346:2027-10-23",
       "event_id": 346,
       "name": "Swingside Invitational",
-      "start_date": "2027-10-22",
-      "end_date": "2027-10-24",
+      "start_date": "2027-10-23",
+      "end_date": "2027-10-25",
       "weekend_start": "2027-10-21",
       "weekend_end": "2027-10-24",
       "weekend_key": "2027-10-21",
@@ -13957,11 +14273,11 @@
       "continent": "Europe",
       "lat": 50.6402286,
       "lon": 5.5689372,
-      "url": "http://www.swingside-invitational.com",
+      "url": "https://www.swingside-invitational.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-10-22"
+      "projected_from_start": "2026-10-23"
     },
     {
       "id": "expected:229:2027-10-28",
@@ -13979,7 +14295,7 @@
       "continent": "Europe",
       "lat": 59.3251172,
       "lon": 18.0710935,
-      "url": "http://www.snowcs.se",
+      "url": "http://www.snowcs.se/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14023,7 +14339,7 @@
       "continent": "Europe",
       "lat": 52.2296756,
       "lon": 21.0122287,
-      "url": "http://www.warsawhalloweenswing.com",
+      "url": "http://www.warsawhalloweenswing.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14032,7 +14348,7 @@
     {
       "id": "expected:31:2027-11-05",
       "event_id": 31,
-      "name": "Mountain Magic Dance Convention",
+      "name": "Mountain Magic",
       "start_date": "2027-11-05",
       "end_date": "2027-11-08",
       "weekend_start": "2027-11-04",
@@ -14045,7 +14361,7 @@
       "continent": "America",
       "lat": 39.5056072,
       "lon": -119.7788687,
-      "url": "http://mountainmagic.dance",
+      "url": "http://mountainmagic.dance/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14054,7 +14370,7 @@
     {
       "id": "expected:79:2027-11-05",
       "event_id": 79,
-      "name": "Sea to Sky Seattle",
+      "name": "Sea to Sky",
       "start_date": "2027-11-05",
       "end_date": "2027-11-09",
       "weekend_start": "2027-11-04",
@@ -14067,7 +14383,7 @@
       "continent": "America",
       "lat": 47.6061389,
       "lon": -122.3328481,
-      "url": "http://Seatoskywcs.com",
+      "url": "http://seatoskywcs.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14089,7 +14405,7 @@
       "continent": "Australia",
       "lat": -34.9284989,
       "lon": 138.6007456,
-      "url": "http://www.simplyadelaidewcs.com.au",
+      "url": "http://www.simplyadelaidewcs.com.au/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14106,12 +14422,12 @@
       "weekend_key": "2027-11-04",
       "status": "expected",
       "kind": "registry",
-      "city": "Tampa",
+      "city": "Tampa Bay",
       "country": "United States",
       "continent": "America",
       "lat": 27.9516896,
       "lon": -82.45875269999999,
-      "url": "http://www.tbcwcs.com",
+      "url": "http://www.tbcwcs.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14150,12 +14466,12 @@
       "weekend_key": "2027-11-04",
       "status": "expected",
       "kind": "registry",
-      "city": "Toulouse",
+      "city": "TOULOUSE",
       "country": "France",
       "continent": "Europe",
       "lat": 43.6048462,
       "lon": 1.442848,
-      "url": "http://www.westiepinkcity.fr",
+      "url": "http://www.westiepinkcity.fr/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14164,7 +14480,7 @@
     {
       "id": "expected:288:2027-11-12",
       "event_id": 288,
-      "name": "Midnight Madness WCS 2026",
+      "name": "Midnight Madness",
       "start_date": "2027-11-12",
       "end_date": "2027-11-15",
       "weekend_start": "2027-11-11",
@@ -14172,12 +14488,12 @@
       "weekend_key": "2027-11-11",
       "status": "expected",
       "kind": "registry",
-      "city": "Dallas",
+      "city": "Dallas Ft. Worth",
       "country": "United States",
       "continent": "America",
       "lat": 32.7831,
       "lon": -96.8067,
-      "url": "http://www.MidnightMadnessWCS.com",
+      "url": "http://www.midnightmadnesswcs.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14194,12 +14510,12 @@
       "weekend_key": "2027-11-11",
       "status": "expected",
       "kind": "registry",
-      "city": "Providence",
+      "city": "Providence RI",
       "country": "United States",
       "continent": "America",
       "lat": 41.8245558,
       "lon": -71.414199,
-      "url": "http://www.northeastswingclassic.com",
+      "url": "http://www.northeastswingclassic.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14216,12 +14532,12 @@
       "weekend_key": "2027-11-11",
       "status": "expected",
       "kind": "registry",
-      "city": "Lyon",
+      "city": "LYON",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
-      "url": "http://www.frenchywesty.com",
+      "url": "http://www.frenchywesty.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14243,7 +14559,7 @@
       "continent": "Europe",
       "lat": 47.497912,
       "lon": 19.040235,
-      "url": "http://www.asc-budapest.com",
+      "url": "http://www.asc-budapest.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14265,7 +14581,7 @@
       "continent": "Europe",
       "lat": 51.5072178,
       "lon": -0.1275862,
-      "url": "http://www.Flowstatefest.com",
+      "url": "http://www.flowstatefest.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14282,12 +14598,12 @@
       "weekend_key": "2027-11-18",
       "status": "expected",
       "kind": "registry",
-      "city": "Herndon",
+      "city": "Washington",
       "country": "United States",
       "continent": "America",
       "lat": 38.9695545,
       "lon": -77.3860976,
-      "url": "http://www.dcswingexperience.com",
+      "url": "http://www.dcswingexperience.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14309,7 +14625,7 @@
       "continent": "America",
       "lat": 34.7295497,
       "lon": -86.5853155,
-      "url": "http://rocketcityswing.com",
+      "url": "http://rocketcityswing.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14362,7 +14678,7 @@
     {
       "id": "expected:212:2027-12-03",
       "event_id": 212,
-      "name": "The After Party aka TAP",
+      "name": "The After Party (TAP)",
       "start_date": "2027-12-03",
       "end_date": "2027-12-07",
       "weekend_start": "2027-12-02",
@@ -14375,7 +14691,7 @@
       "continent": "America",
       "lat": 33.7174708,
       "lon": -117.8311428,
-      "url": "http://www.tapwcs.com",
+      "url": "http://www.tapwcs.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14397,7 +14713,7 @@
       "continent": "Europe",
       "lat": 59.9121746,
       "lon": 10.7312704,
-      "url": "http://www.winterwhite.no",
+      "url": "http://www.winterwhite.no/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14442,7 +14758,7 @@
       "continent": "Europe",
       "lat": 52.52000659999999,
       "lon": 13.404954,
-      "url": "https://berlinswingrevolution.com",
+      "url": "https://berlinswingrevolution.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -14491,28 +14807,6 @@
       "source": "operator_override"
     },
     {
-      "id": "expected:289:2027-12-30",
-      "event_id": 289,
-      "name": "SwingVester",
-      "start_date": "2027-12-30",
-      "end_date": "2028-01-04",
-      "weekend_start": "2027-12-30",
-      "weekend_end": "2028-01-02",
-      "weekend_key": "2027-12-30",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Brno",
-      "country": "Czech Republic",
-      "continent": "Europe",
-      "lat": 49.1950602,
-      "lon": 16.6068371,
-      "url": "https://www.swingvester.com/",
-      "year": 2027,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-12-30"
-    },
-    {
       "id": "expected:196:2027-12-31",
       "event_id": 196,
       "name": "SwingCouver",
@@ -14551,7 +14845,7 @@
       "continent": "Europe",
       "lat": 47.497912,
       "lon": 19.040235,
-      "url": "http://wcs-budafest.com",
+      "url": "http://wcs-budafest.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -14573,7 +14867,7 @@
       "continent": "America",
       "lat": 30.267153,
       "lon": -97.7430608,
-      "url": "https://austinswingdance.com",
+      "url": "https://austinswingdance.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -14617,7 +14911,7 @@
       "continent": "America",
       "lat": 36.5972925,
       "lon": -121.8977688,
-      "url": "http://www.montereyswing.com",
+      "url": "http://www.montereyswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -14670,7 +14964,7 @@
     {
       "id": "expected:301:2028-01-21",
       "event_id": 301,
-      "name": "SWING RESOLUTION",
+      "name": "Swing Resolution",
       "start_date": "2028-01-21",
       "end_date": "2028-01-25",
       "weekend_start": "2028-01-20",
@@ -14683,7 +14977,7 @@
       "continent": "Europe",
       "lat": 55.953252,
       "lon": -3.188267,
-      "url": "http://www.swingresolution.com",
+      "url": "http://www.swingresolution.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -14700,7 +14994,7 @@
       "weekend_key": "2028-01-20",
       "status": "expected",
       "kind": "registry",
-      "city": "Wilmington",
+      "city": "WILMINGTON DEL",
       "country": "United States",
       "continent": "America",
       "lat": 39.744655,
@@ -14714,7 +15008,7 @@
     {
       "id": "expected:273:2028-02-04",
       "event_id": 273,
-      "name": "Charlotte WestieFest",
+      "name": "Charlotte Westie Fest",
       "start_date": "2028-02-04",
       "end_date": "2028-02-07",
       "weekend_start": "2028-02-03",
@@ -14749,7 +15043,7 @@
       "continent": "Europe",
       "lat": 59.9310584,
       "lon": 30.3609097,
-      "url": "http://swingandsnow.ru",
+      "url": "http://swingandsnow.ru/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -14789,11 +15083,11 @@
       "status": "expected",
       "kind": "registry",
       "city": "Waterloo",
-      "country": "Canada",
+      "country": "United States",
       "continent": "America",
       "lat": 43.4819752,
       "lon": -80.5261203,
-      "url": "http://www.waterlooopenwcs.com",
+      "url": "http://www.waterlooopenwcs.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -14815,7 +15109,7 @@
       "continent": "Europe",
       "lat": 54.0024774,
       "lon": -6.388300099999999,
-      "url": "http://www.Trinityswing.com",
+      "url": "http://www.trinityswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -14859,7 +15153,7 @@
       "continent": "America",
       "lat": 38.5781342,
       "lon": -121.4944209,
-      "url": "http://www.capitalswingconvention.com",
+      "url": "http://www.capitalswingconvention.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -14881,7 +15175,7 @@
       "continent": "Europe",
       "lat": 42.416489,
       "lon": -8.8252502,
-      "url": "https://www.arousawestiefest.com",
+      "url": "https://www.arousawestiefest.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -14947,7 +15241,7 @@
       "continent": "Europe",
       "lat": 59.3251172,
       "lon": 18.0710935,
-      "url": "http://www.valentineswing.dance",
+      "url": "http://www.valentineswing.dance/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -14969,7 +15263,7 @@
       "continent": "Europe",
       "lat": 48.8575475,
       "lon": 2.3513765,
-      "url": "http://Https://parisswingclassic.com",
+      "url": "http://https//parisswingclassic.com",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -14991,7 +15285,7 @@
       "continent": "America",
       "lat": 45.515232,
       "lon": -122.6783853,
-      "url": "https://rosecityswing.com",
+      "url": "https://rosecityswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15013,7 +15307,7 @@
       "continent": "Australia",
       "lat": -42.8826055,
       "lon": 147.3257196,
-      "url": "http://www.southernlightsswing.com.au",
+      "url": "http://www.southernlightsswing.com.au/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15035,7 +15329,7 @@
       "continent": "Europe",
       "lat": 62.4917035,
       "lon": 27.7880116,
-      "url": "https://www.wintercoastswing.com",
+      "url": "https://www.wintercoastswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15052,12 +15346,12 @@
       "weekend_key": "2028-02-24",
       "status": "expected",
       "kind": "registry",
-      "city": "New York",
+      "city": "New York City",
       "country": "United States",
       "continent": "America",
       "lat": 40.7127753,
       "lon": -74.0059728,
-      "url": "https://www.flowfest.nyc",
+      "url": "https://www.flowfest.nyc/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15079,9 +15373,9 @@
       "continent": "Europe",
       "lat": 48.2672137,
       "lon": 7.725619099999999,
-      "url": "https://www.euro-dance-festival.com",
+      "url": "https://www.euro-dance-festival.com/",
       "year": 2028,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:92:2028-03-04",
@@ -15099,7 +15393,7 @@
       "continent": "America",
       "lat": 38.9072873,
       "lon": -77.0369274,
-      "url": "http://www.atlanticdancejam.com",
+      "url": "http://www.atlanticdancejam.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15165,7 +15459,7 @@
       "continent": "America",
       "lat": 39.7392358,
       "lon": -104.990251,
-      "url": "http://www.5280westival.com",
+      "url": "http://www.5280westival.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15174,7 +15468,7 @@
     {
       "id": "expected:275:2028-03-11",
       "event_id": 275,
-      "name": "Dutch Open Wcs",
+      "name": "Dutch Open West Coast Swing",
       "start_date": "2028-03-11",
       "end_date": "2028-03-14",
       "weekend_start": "2028-03-09",
@@ -15187,7 +15481,7 @@
       "continent": "Europe",
       "lat": 51.5256257,
       "lon": 5.9736992,
-      "url": "http://www.dutchopenwcs.com",
+      "url": "http://www.dutchopenwcs.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15209,7 +15503,7 @@
       "continent": "Europe",
       "lat": 47.497912,
       "lon": 19.040235,
-      "url": "https://westiespringthing.com",
+      "url": "https://westiespringthing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15254,7 +15548,7 @@
       "continent": "America",
       "lat": 34.703947,
       "lon": -118.1481016,
-      "url": "http://www.highdesertdanceclassic.com",
+      "url": "http://www.highdesertdanceclassic.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15276,7 +15570,7 @@
       "continent": "Europe",
       "lat": 50.06465009999999,
       "lon": 19.9449799,
-      "url": "https://kingswing.pl",
+      "url": "https://kingswing.pl/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15315,12 +15609,12 @@
       "weekend_key": "2028-03-16",
       "status": "expected",
       "kind": "registry",
-      "city": "Lyon",
+      "city": "LYON",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
-      "url": "http://www.west-in-lyon.fr",
+      "url": "http://www.west-in-lyon.fr/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15342,7 +15636,7 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://teapartyswings.com",
+      "url": "http://teapartyswings.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15373,7 +15667,7 @@
     {
       "id": "expected:132:2028-03-25",
       "event_id": 132,
-      "name": "TULSA SPRING SWING",
+      "name": "Tulsa Spring Swing",
       "start_date": "2028-03-25",
       "end_date": "2028-03-28",
       "weekend_start": "2028-03-23",
@@ -15386,7 +15680,7 @@
       "continent": "America",
       "lat": 36.1551375,
       "lon": -95.989501,
-      "url": "http://www.TulsaSpringSwing.com",
+      "url": "http://www.tulsaspringswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15408,7 +15702,7 @@
       "continent": "Europe",
       "lat": 51.5072178,
       "lon": -0.1275862,
-      "url": "http://www.ukwcschamps.com",
+      "url": "http://www.ukwcschamps.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15463,7 +15757,7 @@
     {
       "id": "expected:210:2028-04-08",
       "event_id": 210,
-      "name": "KOREAN OPEN WCS CHAMPIONSHIPS",
+      "name": "Korean Open WCS Championships",
       "start_date": "2028-04-08",
       "end_date": "2028-04-11",
       "weekend_start": "2028-04-06",
@@ -15476,7 +15770,7 @@
       "continent": "Asia",
       "lat": 37.4751578,
       "lon": 126.6312666,
-      "url": "https://www.kopenwcs.com",
+      "url": "https://www.kopenwcs.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15530,7 +15824,7 @@
     {
       "id": "expected:218:2028-04-15",
       "event_id": 218,
-      "name": "Asia WCS Open 2027",
+      "name": "Asia West Coast Swing Open",
       "start_date": "2028-04-15",
       "end_date": "2028-04-18",
       "weekend_start": "2028-04-13",
@@ -15587,7 +15881,7 @@
       "continent": "Europe",
       "lat": 53.4807593,
       "lon": -2.2426305,
-      "url": "http://www.DetonationDance.com",
+      "url": "http://www.detonationdance.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15631,7 +15925,7 @@
       "continent": "America",
       "lat": 45.4200572,
       "lon": -75.7003397,
-      "url": "http://www.swinginbloom.ca",
+      "url": "http://www.swinginbloom.ca/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15640,7 +15934,7 @@
     {
       "id": "expected:370:2028-04-22",
       "event_id": 370,
-      "name": "SwingIn Festival",
+      "name": "SwingIN Festival",
       "start_date": "2028-04-22",
       "end_date": "2028-04-25",
       "weekend_start": "2028-04-20",
@@ -15653,7 +15947,7 @@
       "continent": "Europe",
       "lat": 50.73743,
       "lon": 7.0982068,
-      "url": "http://www.swinginfestival.de",
+      "url": "http://www.swinginfestival.de/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15662,7 +15956,7 @@
     {
       "id": "expected:259:2028-04-22",
       "event_id": 259,
-      "name": "Swingover 2027",
+      "name": "Swingover",
       "start_date": "2028-04-22",
       "end_date": "2028-04-25",
       "weekend_start": "2028-04-20",
@@ -15675,7 +15969,7 @@
       "continent": "America",
       "lat": 28.5383832,
       "lon": -81.3789269,
-      "url": "http://swingoverevent.com",
+      "url": "http://swingoverevent.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15719,7 +16013,7 @@
       "continent": "America",
       "lat": 51.04473309999999,
       "lon": -114.0718831,
-      "url": "http://www.calgarydancestampede.com",
+      "url": "http://www.calgarydancestampede.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15763,7 +16057,7 @@
       "continent": "America",
       "lat": 41.7658043,
       "lon": -72.6733723,
-      "url": "http://www.sis.djkenm.com",
+      "url": "http://www.sis.djkenm.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15826,7 +16120,7 @@
       "weekend_key": "2028-05-04",
       "status": "expected",
       "kind": "registry",
-      "city": "Silver Spring",
+      "city": "Washington DC",
       "country": "United States",
       "continent": "America",
       "lat": 38.9906654,
@@ -15899,7 +16193,7 @@
       "continent": "America",
       "lat": 42.1967113,
       "lon": -122.7139216,
-      "url": "http://wwww.soswingdance.com",
+      "url": "http://wwww.soswingdance.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -15916,39 +16210,16 @@
       "weekend_key": "2028-05-11",
       "status": "expected",
       "kind": "registry",
-      "city": "St. Petersburg",
-      "country": "Russia",
-      "continent": "Europe",
-      "lat": 59.9310584,
-      "lon": 30.3609097,
+      "city": "Gold Coast",
+      "country": "Australia",
+      "continent": "Australia",
+      "lat": -27.9769248,
+      "lon": 153.380936,
       "url": "https://rawconnection.com.au/swingsation/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
       "projected_from_start": "2027-05-13"
-    },
-    {
-      "id": "expected:221:2028-05-14",
-      "event_id": 221,
-      "name": "Gateway Swing Classic",
-      "start_date": "2028-05-14",
-      "end_date": "2028-05-17",
-      "weekend_start": "2028-05-11",
-      "weekend_end": "2028-05-14",
-      "weekend_key": "2028-05-11",
-      "status": "expected",
-      "kind": "registry",
-      "city": "St. Louis",
-      "country": "United States",
-      "continent": "America",
-      "lat": 38.62742799999999,
-      "lon": -90.1982439,
-      "url": "http://gatewayswing.com",
-      "year": 2028,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-05-14",
-      "has_results": true
     },
     {
       "id": "expected:379:2028-05-14",
@@ -16019,6 +16290,28 @@
       "has_results": true
     },
     {
+      "id": "expected:221:2028-05-20",
+      "event_id": 221,
+      "name": "Gateway Swing Classic",
+      "start_date": "2028-05-20",
+      "end_date": "2028-05-23",
+      "weekend_start": "2028-05-18",
+      "weekend_end": "2028-05-21",
+      "weekend_key": "2028-05-18",
+      "status": "expected",
+      "kind": "registry",
+      "city": "St. Louis",
+      "country": "United States",
+      "continent": "America",
+      "lat": 38.62742799999999,
+      "lon": -90.1982439,
+      "url": "http://gatewayswing.com/",
+      "year": 2028,
+      "source": "expected_yoy",
+      "projected_from_year": 2027,
+      "projected_from_start": "2027-05-20"
+    },
+    {
       "id": "expected:364:2028-05-21",
       "event_id": 364,
       "name": "Nanaimo Dance Fusion",
@@ -16034,7 +16327,7 @@
       "continent": "America",
       "lat": 49.1658836,
       "lon": -123.9400647,
-      "url": "http://www.nanaimodancefusion.ca",
+      "url": "http://www.nanaimodancefusion.ca/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -16079,7 +16372,7 @@
       "continent": "America",
       "lat": 33.7501275,
       "lon": -84.3885209,
-      "url": "http://www.usagrandnationals.com",
+      "url": "http://www.usagrandnationals.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -16146,7 +16439,7 @@
       "continent": "America",
       "lat": 42.32971819999999,
       "lon": -83.0424533,
-      "url": "http://MichiganClassicSwing.com",
+      "url": "http://michiganclassicswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -16209,12 +16502,12 @@
       "weekend_key": "2028-06-08",
       "status": "expected",
       "kind": "registry",
-      "city": "Gdańsk",
+      "city": "Gdansk",
       "country": "Poland",
       "continent": "Europe",
       "lat": 54.35202520000001,
       "lon": 18.6466384,
-      "url": "http://www.balticswing.com",
+      "url": "http://www.balticswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -16223,7 +16516,7 @@
     {
       "id": "expected:220:2028-06-10",
       "event_id": 220,
-      "name": "D-TOWNSWING 2027",
+      "name": "D-Town Swing",
       "start_date": "2028-06-10",
       "end_date": "2028-06-13",
       "weekend_start": "2028-06-08",
@@ -16236,7 +16529,7 @@
       "continent": "Europe",
       "lat": 51.2230411,
       "lon": 6.7824545,
-      "url": "http://www.d-townswing.com",
+      "url": "http://www.d-townswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -16258,7 +16551,7 @@
       "continent": "America",
       "lat": 30.4514677,
       "lon": -91.1871466,
-      "url": "http://www.swingapaloozaevent.com",
+      "url": "http://www.swingapaloozaevent.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -16303,7 +16596,7 @@
       "continent": "Europe",
       "lat": 48.8891149,
       "lon": 9.1942834,
-      "url": "https://baroqueswing.com",
+      "url": "https://baroqueswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -16325,7 +16618,7 @@
       "continent": "America",
       "lat": 40.4966567,
       "lon": -74.4442802,
-      "url": "http://www.libertyswing.com",
+      "url": "http://www.libertyswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -16370,7 +16663,7 @@
       "continent": "Europe",
       "lat": 45.899247,
       "lon": 6.129384,
-      "url": "http://frenchconnectionwcs.com",
+      "url": "http://frenchconnectionwcs.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -16528,7 +16821,7 @@
       "continent": "America",
       "lat": 35.2270768,
       "lon": -80.84089329999999,
-      "url": "https://carolinasummerswing.com",
+      "url": "https://carolinasummerswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -16642,7 +16935,7 @@
       "continent": "America",
       "lat": 38.9822282,
       "lon": -94.6707917,
-      "url": "http://www.midwestwestiefest.com",
+      "url": "http://www.midwestwestiefest.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -16857,7 +17150,7 @@
     {
       "id": "expected:282:2028-08-05",
       "event_id": 282,
-      "name": "German Open WCS",
+      "name": "German Open",
       "start_date": "2028-08-05",
       "end_date": "2028-08-09",
       "weekend_start": "2028-08-03",
@@ -16870,7 +17163,7 @@
       "continent": "Europe",
       "lat": 47.9990077,
       "lon": 7.842104299999999,
-      "url": "http://www.go-wcs.com",
+      "url": "http://www.go-wcs.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -16892,7 +17185,7 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://www.nedancefestival.com",
+      "url": "http://www.nedancefestival.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -16909,12 +17202,12 @@
       "weekend_key": "2028-08-03",
       "status": "expected",
       "kind": "registry",
-      "city": "Herndon",
+      "city": "Washington",
       "country": "United States",
       "continent": "America",
       "lat": 38.9695545,
       "lon": -77.3860976,
-      "url": "http://www.swingfling.com",
+      "url": "http://www.swingfling.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -16936,7 +17229,7 @@
       "continent": "America",
       "lat": 37.7749295,
       "lon": -122.4194155,
-      "url": "http://www.DanceGeekProductions.Art",
+      "url": "http://www.dancegeekproductions.art/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17003,7 +17296,7 @@
       "continent": "Europe",
       "lat": 59.3251172,
       "lon": 18.0710935,
-      "url": "http://www.uptownswing.se",
+      "url": "http://www.uptownswing.se/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17020,8 +17313,8 @@
       "weekend_key": "2028-08-17",
       "status": "expected",
       "kind": "registry",
-      "city": "Perth",
-      "country": "Australia",
+      "city": "Christchurch",
+      "country": "New Zealand",
       "continent": "Australia",
       "lat": -31.9513993,
       "lon": 115.8616783,
@@ -17047,7 +17340,7 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://Summerhummerboston.com",
+      "url": "http://summerhummerboston.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17069,7 +17362,7 @@
       "continent": "America",
       "lat": 44.0581728,
       "lon": -121.3153096,
-      "url": "http://thebendconnection.com",
+      "url": "http://thebendconnection.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17091,7 +17384,7 @@
       "continent": "America",
       "lat": 41.88325,
       "lon": -87.6323879,
-      "url": "http://www.chicagolanddancefestival.com",
+      "url": "http://www.chicagolanddancefestival.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17136,7 +17429,7 @@
       "continent": "America",
       "lat": 33.4482948,
       "lon": -112.0725488,
-      "url": "http://www.desertcityswing.com",
+      "url": "http://www.desertcityswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17153,12 +17446,12 @@
       "weekend_key": "2028-08-24",
       "status": "expected",
       "kind": "registry",
-      "city": "Lyon",
+      "city": "LYON",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
-      "url": "http://www.frenchywesty.com",
+      "url": "http://www.frenchywesty.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17202,7 +17495,7 @@
       "continent": "Asia",
       "lat": 33.5042779,
       "lon": 126.519838,
-      "url": "http://koreawestival.com",
+      "url": "http://koreawestival.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17246,7 +17539,7 @@
       "continent": "America",
       "lat": 30.3297566,
       "lon": -81.6591529,
-      "url": "http://www.jaxwestiefest.com",
+      "url": "http://www.jaxwestiefest.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17268,7 +17561,7 @@
       "continent": "Europe",
       "lat": 48.1351253,
       "lon": 11.5819806,
-      "url": "https://bavarianopen.com",
+      "url": "https://bavarianopen.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17277,7 +17570,7 @@
     {
       "id": "expected:47:2028-09-10",
       "event_id": 47,
-      "name": "SwingTime Denver",
+      "name": "Swingtime in the Rockies",
       "start_date": "2028-09-10",
       "end_date": "2028-09-13",
       "weekend_start": "2028-09-07",
@@ -17290,7 +17583,7 @@
       "continent": "America",
       "lat": 39.7392358,
       "lon": -104.990251,
-      "url": "http://www.swingtimewcs.com",
+      "url": "http://www.swingtimewcs.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17356,7 +17649,7 @@
       "continent": "America",
       "lat": 47.6061389,
       "lon": -122.3328481,
-      "url": "https://www.retaliationswing.com",
+      "url": "https://www.retaliationswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17365,7 +17658,7 @@
     {
       "id": "expected:357:2028-09-17",
       "event_id": 357,
-      "name": "WCS Party in Vienna",
+      "name": "WCS Party",
       "start_date": "2028-09-17",
       "end_date": "2028-09-21",
       "weekend_start": "2028-09-14",
@@ -17422,7 +17715,7 @@
       "continent": "Europe",
       "lat": 60.16985569999999,
       "lon": 24.938379,
-      "url": "http://www.finnfest.fi",
+      "url": "http://www.finnfest.fi/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17431,7 +17724,7 @@
     {
       "id": "expected:342:2028-09-18",
       "event_id": 342,
-      "name": "Global Grand Prix -- West Coast Swing Championships",
+      "name": "Global Grand Prix - West Coast Swing Reunion",
       "start_date": "2028-09-18",
       "end_date": "2028-09-21",
       "weekend_start": "2028-09-14",
@@ -17439,11 +17732,11 @@
       "weekend_key": "2028-09-14",
       "status": "expected",
       "kind": "registry",
-      "city": "Toulouse",
+      "city": "Paris",
       "country": "France",
       "continent": "Europe",
-      "lat": 43.6048462,
-      "lon": 1.442848,
+      "lat": 48.8575475,
+      "lon": 2.3513765,
       "url": "https://www.globalgrandprixwcs.com/",
       "year": 2028,
       "source": "expected_yoy",
@@ -17466,7 +17759,7 @@
       "continent": "America",
       "lat": 20.6871826,
       "lon": -156.4391668,
-      "url": "http://www.alohaopenwcs.com",
+      "url": "http://www.alohaopenwcs.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17510,7 +17803,7 @@
       "continent": "America",
       "lat": 38.62742799999999,
       "lon": -90.1982439,
-      "url": "http://Www.mmisl.com",
+      "url": "http://www.mmisl.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17532,7 +17825,7 @@
       "continent": "Europe",
       "lat": 51.5072178,
       "lon": -0.1275862,
-      "url": "http://www.MidlandSwingOpen.com",
+      "url": "http://www.midlandswingopen.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17541,7 +17834,7 @@
     {
       "id": "expected:361:2028-09-24",
       "event_id": 361,
-      "name": "Mooseland Swing 2026",
+      "name": "Mooseland Swing",
       "start_date": "2028-09-24",
       "end_date": "2028-09-28",
       "weekend_start": "2028-09-21",
@@ -17571,7 +17864,7 @@
       "weekend_key": "2028-09-21",
       "status": "expected",
       "kind": "registry",
-      "city": "Wilmington",
+      "city": "WILMINGTON",
       "country": "United States",
       "continent": "America",
       "lat": 39.744655,
@@ -17600,7 +17893,7 @@
       "lon": -84.3885209,
       "url": "https://www.atlantaswingclassic.com/",
       "year": 2028,
-      "source": "edition_calendar_dates"
+      "source": "events_list_current"
     },
     {
       "id": "expected:388:2028-10-01",
@@ -17640,7 +17933,7 @@
       "continent": "America",
       "lat": 37.7749295,
       "lon": -122.4194155,
-      "url": "https://boogiebythebay.com",
+      "url": "https://boogiebythebay.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17662,7 +17955,7 @@
       "continent": "America",
       "lat": 45.5018869,
       "lon": -73.56739189999999,
-      "url": "http://montrealwestiefest.com",
+      "url": "http://montrealwestiefest.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17773,7 +18066,7 @@
       "continent": "Europe",
       "lat": 51.2230411,
       "lon": 6.7824545,
-      "url": "http://www.wcsfestival.com",
+      "url": "http://www.wcsfestival.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -17795,7 +18088,7 @@
       "continent": "America",
       "lat": 39.9525839,
       "lon": -75.1652215,
-      "url": "http://www.swustlicious.com",
+      "url": "http://www.swustlicious.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17839,7 +18132,7 @@
       "continent": "America",
       "lat": 33.6638439,
       "lon": -117.9047429,
-      "url": "http://Hstswing.com",
+      "url": "http://hstswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17848,7 +18141,7 @@
     {
       "id": "expected:380:2028-10-22",
       "event_id": 380,
-      "name": "SASS- Spooky Albany Swing Spectacular",
+      "name": "SASS Spooky Albany Swing Spectacular",
       "start_date": "2028-10-22",
       "end_date": "2028-10-25",
       "weekend_start": "2028-10-19",
@@ -17861,7 +18154,7 @@
       "continent": "America",
       "lat": 42.6518095,
       "lon": -73.75447070000001,
-      "url": "http://www.spookyalbanyswing.com",
+      "url": "http://www.spookyalbanyswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17878,23 +18171,23 @@
       "weekend_key": "2028-10-19",
       "status": "expected",
       "kind": "registry",
-      "city": "Chicago",
+      "city": "CHICAGO",
       "country": "United States",
       "continent": "America",
       "lat": 41.88325,
       "lon": -87.6323879,
-      "url": "https://swingcitychicago.com",
+      "url": "https://swingcitychicago.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-10-22"
     },
     {
-      "id": "expected:346:2028-10-22",
+      "id": "expected:346:2028-10-23",
       "event_id": 346,
       "name": "Swingside Invitational",
-      "start_date": "2028-10-22",
-      "end_date": "2028-10-24",
+      "start_date": "2028-10-23",
+      "end_date": "2028-10-25",
       "weekend_start": "2028-10-19",
       "weekend_end": "2028-10-22",
       "weekend_key": "2028-10-19",
@@ -17905,11 +18198,11 @@
       "continent": "Europe",
       "lat": 50.6402286,
       "lon": 5.5689372,
-      "url": "http://www.swingside-invitational.com",
+      "url": "https://www.swingside-invitational.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-10-22"
+      "projected_from_start": "2026-10-23"
     },
     {
       "id": "expected:229:2028-10-28",
@@ -17927,7 +18220,7 @@
       "continent": "Europe",
       "lat": 59.3251172,
       "lon": 18.0710935,
-      "url": "http://www.snowcs.se",
+      "url": "http://www.snowcs.se/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17971,7 +18264,7 @@
       "continent": "Europe",
       "lat": 52.2296756,
       "lon": 21.0122287,
-      "url": "http://www.warsawhalloweenswing.com",
+      "url": "http://www.warsawhalloweenswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -17980,7 +18273,7 @@
     {
       "id": "expected:31:2028-11-05",
       "event_id": 31,
-      "name": "Mountain Magic Dance Convention",
+      "name": "Mountain Magic",
       "start_date": "2028-11-05",
       "end_date": "2028-11-08",
       "weekend_start": "2028-11-02",
@@ -17993,7 +18286,7 @@
       "continent": "America",
       "lat": 39.5056072,
       "lon": -119.7788687,
-      "url": "http://mountainmagic.dance",
+      "url": "http://mountainmagic.dance/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18002,7 +18295,7 @@
     {
       "id": "expected:79:2028-11-05",
       "event_id": 79,
-      "name": "Sea to Sky Seattle",
+      "name": "Sea to Sky",
       "start_date": "2028-11-05",
       "end_date": "2028-11-09",
       "weekend_start": "2028-11-02",
@@ -18015,7 +18308,7 @@
       "continent": "America",
       "lat": 47.6061389,
       "lon": -122.3328481,
-      "url": "http://Seatoskywcs.com",
+      "url": "http://seatoskywcs.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18037,7 +18330,7 @@
       "continent": "Australia",
       "lat": -34.9284989,
       "lon": 138.6007456,
-      "url": "http://www.simplyadelaidewcs.com.au",
+      "url": "http://www.simplyadelaidewcs.com.au/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18054,12 +18347,12 @@
       "weekend_key": "2028-11-02",
       "status": "expected",
       "kind": "registry",
-      "city": "Tampa",
+      "city": "Tampa Bay",
       "country": "United States",
       "continent": "America",
       "lat": 27.9516896,
       "lon": -82.45875269999999,
-      "url": "http://www.tbcwcs.com",
+      "url": "http://www.tbcwcs.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18098,12 +18391,12 @@
       "weekend_key": "2028-11-02",
       "status": "expected",
       "kind": "registry",
-      "city": "Toulouse",
+      "city": "TOULOUSE",
       "country": "France",
       "continent": "Europe",
       "lat": 43.6048462,
       "lon": 1.442848,
-      "url": "http://www.westiepinkcity.fr",
+      "url": "http://www.westiepinkcity.fr/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18112,7 +18405,7 @@
     {
       "id": "expected:288:2028-11-12",
       "event_id": 288,
-      "name": "Midnight Madness WCS 2026",
+      "name": "Midnight Madness",
       "start_date": "2028-11-12",
       "end_date": "2028-11-15",
       "weekend_start": "2028-11-09",
@@ -18120,12 +18413,12 @@
       "weekend_key": "2028-11-09",
       "status": "expected",
       "kind": "registry",
-      "city": "Dallas",
+      "city": "Dallas Ft. Worth",
       "country": "United States",
       "continent": "America",
       "lat": 32.7831,
       "lon": -96.8067,
-      "url": "http://www.MidnightMadnessWCS.com",
+      "url": "http://www.midnightmadnesswcs.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18142,12 +18435,12 @@
       "weekend_key": "2028-11-09",
       "status": "expected",
       "kind": "registry",
-      "city": "Providence",
+      "city": "Providence RI",
       "country": "United States",
       "continent": "America",
       "lat": 41.8245558,
       "lon": -71.414199,
-      "url": "http://www.northeastswingclassic.com",
+      "url": "http://www.northeastswingclassic.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18164,12 +18457,12 @@
       "weekend_key": "2028-11-09",
       "status": "expected",
       "kind": "registry",
-      "city": "Lyon",
+      "city": "LYON",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
-      "url": "http://www.frenchywesty.com",
+      "url": "http://www.frenchywesty.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18191,7 +18484,7 @@
       "continent": "Europe",
       "lat": 47.497912,
       "lon": 19.040235,
-      "url": "http://www.asc-budapest.com",
+      "url": "http://www.asc-budapest.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18213,7 +18506,7 @@
       "continent": "Europe",
       "lat": 51.5072178,
       "lon": -0.1275862,
-      "url": "http://www.Flowstatefest.com",
+      "url": "http://www.flowstatefest.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18230,12 +18523,12 @@
       "weekend_key": "2028-11-16",
       "status": "expected",
       "kind": "registry",
-      "city": "Herndon",
+      "city": "Washington",
       "country": "United States",
       "continent": "America",
       "lat": 38.9695545,
       "lon": -77.3860976,
-      "url": "http://www.dcswingexperience.com",
+      "url": "http://www.dcswingexperience.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18257,7 +18550,7 @@
       "continent": "America",
       "lat": 34.7295497,
       "lon": -86.5853155,
-      "url": "http://rocketcityswing.com",
+      "url": "http://rocketcityswing.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18310,7 +18603,7 @@
     {
       "id": "expected:212:2028-12-03",
       "event_id": 212,
-      "name": "The After Party aka TAP",
+      "name": "The After Party (TAP)",
       "start_date": "2028-12-03",
       "end_date": "2028-12-07",
       "weekend_start": "2028-11-30",
@@ -18323,7 +18616,7 @@
       "continent": "America",
       "lat": 33.7174708,
       "lon": -117.8311428,
-      "url": "http://www.tapwcs.com",
+      "url": "http://www.tapwcs.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18345,7 +18638,7 @@
       "continent": "Europe",
       "lat": 59.9121746,
       "lon": 10.7312704,
-      "url": "http://www.winterwhite.no",
+      "url": "http://www.winterwhite.no/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18390,7 +18683,7 @@
       "continent": "Europe",
       "lat": 52.52000659999999,
       "lon": 13.404954,
-      "url": "https://berlinswingrevolution.com",
+      "url": "https://berlinswingrevolution.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18434,7 +18727,7 @@
       "continent": "America",
       "lat": 32.7831,
       "lon": -96.8067,
-      "url": "http://www.ucwdcworlds.com",
+      "url": "http://www.ucwdcworlds.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18456,7 +18749,7 @@
       "continent": "America",
       "lat": 28.5383832,
       "lon": -81.3789269,
-      "url": "http://www.floorplayswingvacation.com",
+      "url": "http://www.floorplayswingvacation.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18465,7 +18758,7 @@
     {
       "id": "expected:214:2028-12-30",
       "event_id": 214,
-      "name": "New Years Swing Fling",
+      "name": "New Year's Swing Fling",
       "start_date": "2028-12-30",
       "end_date": "2029-01-03",
       "weekend_start": "2028-12-28",
@@ -18478,7 +18771,7 @@
       "continent": "Europe",
       "lat": 51.5072178,
       "lon": -0.1275862,
-      "url": "http://nysf.uk",
+      "url": "http://nysf.uk/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18500,7 +18793,7 @@
       "continent": "America",
       "lat": 36.1626638,
       "lon": -86.7816016,
-      "url": "http://www.spotlightnewyears.com",
+      "url": "http://www.spotlightnewyears.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18517,8 +18810,8 @@
       "weekend_key": "2028-12-28",
       "status": "expected",
       "kind": "registry",
-      "city": "Brno",
-      "country": "Czech Republic",
+      "city": "Wels",
+      "country": "Austria",
       "continent": "Europe",
       "lat": 49.1950602,
       "lon": 16.6068371,
@@ -18544,7 +18837,7 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://Countdownswingboston.com",
+      "url": "http://countdownswingboston.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
@@ -18589,7 +18882,7 @@
       "continent": "Europe",
       "lat": 59.3251172,
       "lon": 18.0710935,
-      "url": "http://www.westiegala.com",
+      "url": "http://www.westiegala.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,


### PR DESCRIPTION
## Summary
- Rebuild `events_year_calendar.json` after pipeline fallback fix (`scheduled_events.csv` empty -> `events_list/current.json`).
- Restore missing future Trial events for 2026/2027 in the published calendar payload.
- Refresh `event_l2_cards.json` in the same build step.

## Test plan
- [x] `python3 scripts/validate_site_data.py`
- [x] Confirm `events_year_calendar.json` contains 2026/2027 `kind=trial` rows


Made with [Cursor](https://cursor.com)