### PR TITLE
L2 card: Metrics ↔ Tiers + sparkline

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="static/css/site-chrome.css">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
-    <link rel="preload" href="static/data/events_year_calendar.json?v=20260806a" as="fetch" crossorigin>
+    <link rel="preload" href="static/data/events_year_calendar.json?v=20260806b" as="fetch" crossorigin>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMLCY5PE8Z"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -264,6 +264,9 @@
       metricDancers: "Dancers",
       metricPoints: "Points",
       metricNew: "New",
+      cardModeMetrics: "Metrics",
+      cardModeTiers: "Tiers",
+      sparkAria: "Edition trend",
       tierPrefix: "TIER",
       colLeader: "L",
       colFollower: "F",
@@ -316,6 +319,9 @@
       metricDancers: "Танцоры",
       metricPoints: "Очки",
       metricNew: "Новые",
+      cardModeMetrics: "Метрики",
+      cardModeTiers: "Тиры",
+      sparkAria: "Динамика editions",
       tierPrefix: "ТИР",
       colLeader: "L",
       colFollower: "F",
@@ -368,6 +374,9 @@
       metricDancers: "Bailarines",
       metricPoints: "Puntos",
       metricNew: "Nuevos",
+      cardModeMetrics: "Métricas",
+      cardModeTiers: "Tiers",
+      sparkAria: "Tendencia de ediciones",
       tierPrefix: "TIER",
       colLeader: "L",
       colFollower: "F",
@@ -399,7 +408,9 @@
     map: null,
     markers: null,
     markerById: {},
-    eventCards: null
+    eventCards: null,
+    l2CardMode: "tiers",
+    l2SparkMetric: "unique_dancers"
   };
 
   function t(key) {
@@ -1389,6 +1400,8 @@
     state.selectedEventId = null;
     state.hoverEventId = null;
     state.skipDayTip = false;
+    state.l2CardMode = "tiers";
+    state.l2SparkMetric = "unique_dancers";
     document.getElementById("eventDetail").classList.remove("is-open");
     document.getElementById("eventDetail").innerHTML = "";
     var mapCol = document.getElementById("dayMapCol");
@@ -1446,7 +1459,18 @@
       return tiers && tiers[div] && tiers[div].Leader != null && tiers[div].Follower != null;
     });
     if (!rows.length) return "";
-    var html = '<table class="l2-tier-table">' +
+    var tip = tierTipText();
+    var tipHtml = "";
+    if (tip) {
+      tipHtml = '<button type="button" class="l2-tier-tip" aria-label="' +
+        esc(t("tierTipAria")) + '">' +
+        '<span class="l2-tier-tip__mark" aria-hidden="true">i</span>' +
+        '<span class="l2-tier-tip__bubble" role="tooltip">' + esc(tip) + "</span>" +
+        "</button>";
+    }
+    var html = '<div class="l2-tier-panel">' +
+      '<div class="l2-tier-panel__head">' + tipHtml + "</div>" +
+      '<table class="l2-tier-table">' +
       "<thead><tr>" +
       "<th></th>" +
       '<th class="is-lead">' + esc(t("colLeader")) + "</th>" +
@@ -1459,7 +1483,7 @@
         '<td class="is-follow">' + esc(tierLabel(tiers[div].Follower)) + "</td>" +
         "</tr>";
     });
-    html += "</tbody></table>";
+    html += "</tbody></table></div>";
     return html;
   }
 
@@ -1470,12 +1494,69 @@
     return "";
   }
 
+  function sparkMetricKey() {
+    var key = state.l2SparkMetric;
+    if (key === "points" || key === "new_dancers" || key === "unique_dancers") return key;
+    return "unique_dancers";
+  }
+
+  function buildSparklineHtml(history) {
+    var rows = Array.isArray(history) ? history : [];
+    if (!rows.length) {
+      return '<div class="l2-spark" aria-hidden="true"></div>';
+    }
+    var key = sparkMetricKey();
+    var values = rows.map(function (r) {
+      var n = Number(r[key]);
+      return Number.isFinite(n) ? n : 0;
+    });
+    var w = 160;
+    var h = 40;
+    var padX = 4;
+    var padY = 5;
+    var min = Math.min.apply(null, values);
+    var max = Math.max.apply(null, values);
+    var span = max - min || 1;
+    var points = values.map(function (v, i) {
+      var x = padX + (rows.length === 1 ? (w - padX * 2) / 2 : (i / (rows.length - 1)) * (w - padX * 2));
+      var y = h - padY - ((v - min) / span) * (h - padY * 2);
+      return { x: x, y: y, v: v, label: monthYearLabel(rows[i].year, rows[i].month) };
+    });
+    var poly = points.map(function (p) { return p.x.toFixed(1) + "," + p.y.toFixed(1); }).join(" ");
+    var dots = points.map(function (p) {
+      return '<circle class="l2-spark__dot" cx="' + p.x.toFixed(1) + '" cy="' + p.y.toFixed(1) +
+        '" r="2.2"><title>' + esc(p.label + ": " + String(p.v)) + "</title></circle>";
+    }).join("");
+    return '<div class="l2-spark" role="img" aria-label="' + esc(t("sparkAria")) + '">' +
+      '<svg class="l2-spark__svg" viewBox="0 0 ' + w + " " + h +
+      '" width="100%" height="48" preserveAspectRatio="none">' +
+      '<polyline class="l2-spark__line" fill="none" points="' + poly + '"></polyline>' +
+      dots +
+      "</svg></div>";
+  }
+
+  function buildMetricsPanelHtml(last, history) {
+    var active = sparkMetricKey();
+    function metricBtn(key, value, label) {
+      var isOn = active === key ? " is-active" : "";
+      return '<button type="button" class="l2-metric' + isOn + '" data-spark="' + key + '">' +
+        '<span class="l2-metric__value">' + esc(String(value)) + "</span>" +
+        '<span class="l2-metric__label">' + esc(label) + "</span></button>";
+    }
+    return '<div class="l2-event-card__metrics">' +
+      metricBtn("unique_dancers", last.unique_dancers, t("metricDancers")) +
+      metricBtn("points", last.points, t("metricPoints")) +
+      metricBtn("new_dancers", last.new_dancers, t("metricNew")) +
+      "</div>" +
+      buildSparklineHtml(history);
+  }
+
   function showEventCard(e) {
     var detail = document.getElementById("eventDetail");
     var mapCol = document.getElementById("dayMapCol");
     var where = [e.city, e.country].filter(Boolean).join(", ");
     var card = eventCardPayload(e);
-    var tip = tierTipText();
+    var mode = state.l2CardMode === "metrics" ? "metrics" : "tiers";
 
     var left = '<div class="l2-event-card__series">' +
       "<h3>" + esc(e.name) + "</h3>" +
@@ -1507,24 +1588,22 @@
       right += '<div class="l2-event-card__last-head">' +
         '<span class="l2-event-card__last-label">' + esc(t("lastEdition")) + "</span>" +
         '<span class="l2-event-card__last-date">' +
-        esc(monthYearLabel(last.year, last.month)) + "</span>";
-      if (tip) {
-        right += '<button type="button" class="l2-tier-tip" id="l2TierTip" aria-label="' +
-          esc(t("tierTipAria")) + '">' +
-          '<span class="l2-tier-tip__mark" aria-hidden="true">i</span>' +
-          '<span class="l2-tier-tip__bubble" role="tooltip">' + esc(tip) + "</span>" +
-          "</button>";
-      }
+        esc(monthYearLabel(last.year, last.month)) + "</span></div>";
+      right += '<div class="l2-seg" role="tablist" aria-label="' + esc(t("lastEdition")) + '">' +
+        '<button type="button" class="l2-seg__btn' + (mode === "metrics" ? " is-active" : "") +
+        '" role="tab" aria-selected="' + (mode === "metrics" ? "true" : "false") +
+        '" data-card-mode="metrics">' + esc(t("cardModeMetrics")) + "</button>" +
+        '<button type="button" class="l2-seg__btn' + (mode === "tiers" ? " is-active" : "") +
+        '" role="tab" aria-selected="' + (mode === "tiers" ? "true" : "false") +
+        '" data-card-mode="tiers">' + esc(t("cardModeTiers")) + "</button></div>";
+      right += '<div class="l2-event-card__panels">';
+      right += '<div class="l2-event-card__panel' + (mode === "metrics" ? " is-active" : "") +
+        '" data-panel="metrics">' +
+        buildMetricsPanelHtml(last, card.history || []) + "</div>";
+      right += '<div class="l2-event-card__panel' + (mode === "tiers" ? " is-active" : "") +
+        '" data-panel="tiers">' +
+        buildTierTableHtml(last.tiers || {}) + "</div>";
       right += "</div>";
-      right += '<div class="l2-event-card__metrics">' +
-        '<div class="l2-metric"><span class="l2-metric__value">' + esc(String(last.unique_dancers)) +
-        '</span><span class="l2-metric__label">' + esc(t("metricDancers")) + "</span></div>" +
-        '<div class="l2-metric"><span class="l2-metric__value">' + esc(String(last.points)) +
-        '</span><span class="l2-metric__label">' + esc(t("metricPoints")) + "</span></div>" +
-        '<div class="l2-metric"><span class="l2-metric__value">' + esc(String(last.new_dancers)) +
-        '</span><span class="l2-metric__label">' + esc(t("metricNew")) + "</span></div>" +
-        "</div>";
-      right += buildTierTableHtml(last.tiers || {});
     }
     right += "</div>";
 
@@ -1532,6 +1611,20 @@
     detail.classList.add("is-open");
     if (mapCol) mapCol.classList.add("has-event");
     refreshDayMapSize(preferReducedMotion() ? 0 : 230);
+  }
+
+  function refreshOpenEventCard() {
+    if (!state.selectedEventId) return;
+    var events = eventsForYear(state.year);
+    var e = events.find(function (x) {
+      return String(x.id) === String(state.selectedEventId);
+    });
+    if (!e) {
+      e = eventsInYearRaw(state.year).find(function (x) {
+        return String(x.id) === String(state.selectedEventId);
+      });
+    }
+    if (e) showEventCard(e);
   }
 
   function clearEventSelection() {
@@ -1638,6 +1731,34 @@
     closeAllFilterDropdowns();
     state.kind = btn.getAttribute("data-value") || "";
     applyFiltersAndRender();
+  });
+
+  document.getElementById("eventDetail").addEventListener("click", function (e) {
+    var modeBtn = e.target.closest("[data-card-mode]");
+    if (modeBtn) {
+      e.stopPropagation();
+      var nextMode = modeBtn.getAttribute("data-card-mode");
+      if (nextMode !== "metrics" && nextMode !== "tiers") return;
+      if (state.l2CardMode === nextMode) return;
+      state.l2CardMode = nextMode;
+      refreshOpenEventCard();
+      return;
+    }
+    var sparkBtn = e.target.closest("[data-spark]");
+    if (sparkBtn) {
+      e.stopPropagation();
+      var nextSpark = sparkBtn.getAttribute("data-spark");
+      if (
+        nextSpark !== "unique_dancers" &&
+        nextSpark !== "points" &&
+        nextSpark !== "new_dancers"
+      ) {
+        return;
+      }
+      if (state.l2SparkMetric === nextSpark) return;
+      state.l2SparkMetric = nextSpark;
+      refreshOpenEventCard();
+    }
   });
 
   document.querySelectorAll(".cal-dd").forEach(function (dd) {
@@ -1773,13 +1894,13 @@
   var params = new URLSearchParams(window.location.search);
   if (params.get("lang") && I18N[params.get("lang")]) state.lang = params.get("lang");
 
-  fetch("static/data/events_year_calendar.json?v=20260806a")
+  fetch("static/data/events_year_calendar.json?v=20260806b")
     .then(function (r) {
       if (!r.ok) throw new Error("Failed to load calendar data");
       return r.json();
     })
     .then(function (calendar) {
-      return fetch("static/data/event_l2_cards.json?v=20260806a")
+      return fetch("static/data/event_l2_cards.json?v=20260806b")
         .then(function (r) {
           if (!r.ok) return null;
           return r.json();

--- a/scripts/validate_site_data.py
+++ b/scripts/validate_site_data.py
@@ -204,6 +204,8 @@ def validate_event_l2_cards() -> None:
         fail(f"event_l2_cards.json.cards[{sample_key}] must be an object")
     if "series" not in sample:
         fail(f"event_l2_cards.json.cards[{sample_key}] missing series")
+    if "history" in sample and not isinstance(sample["history"], list):
+        fail(f"event_l2_cards.json.cards[{sample_key}].history must be a list")
     print(f"[OK] event_l2_cards.json ({len(cards)} cards)")
 
 

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -1040,9 +1040,85 @@ h1 {
   white-space: nowrap;
 }
 
+.l2-seg {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  padding: 2px;
+  margin-top: 2px;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.05);
+  flex: 0 0 auto;
+}
+
+.l2-seg__btn {
+  border: 0;
+  background: transparent;
+  border-radius: 6px;
+  padding: 4px 6px;
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background-color 160ms var(--ease-out),
+    color 160ms var(--ease-out),
+    transform 140ms var(--ease-out);
+}
+
+.l2-seg__btn:active {
+  transform: scale(0.97);
+}
+
+.l2-seg__btn.is-active {
+  background: #fff;
+  color: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.l2-event-card__panels {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  margin-top: 4px;
+}
+
+.l2-event-card__panel {
+  opacity: 0;
+  transform: scale(0.985);
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  transition:
+    opacity 180ms var(--ease-out),
+    transform 180ms var(--ease-out);
+}
+
+.l2-event-card__panel.is-active {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+  position: relative;
+}
+
+.l2-tier-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-height: 0;
+}
+
+.l2-tier-panel__head {
+  display: flex;
+  justify-content: flex-end;
+  min-height: 16px;
+}
+
 .l2-tier-tip {
   position: relative;
-  margin-left: auto;
+  margin-left: 0;
   flex: 0 0 auto;
   width: 16px;
   height: 16px;
@@ -1101,6 +1177,23 @@ h1 {
   align-items: center;
   gap: 0;
   min-width: 0;
+  border: 0;
+  background: transparent;
+  padding: 2px 0;
+  border-radius: 6px;
+  cursor: pointer;
+  color: inherit;
+  transition:
+    background-color 160ms var(--ease-out),
+    transform 140ms var(--ease-out);
+}
+
+.l2-metric:active {
+  transform: scale(0.97);
+}
+
+.l2-metric.is-active {
+  background: rgba(79, 70, 229, 0.08);
 }
 
 .l2-metric__value {
@@ -1119,10 +1212,33 @@ h1 {
   color: var(--text-tertiary);
 }
 
+.l2-spark {
+  flex: 0 0 auto;
+  height: 48px;
+  margin-top: 6px;
+}
+
+.l2-spark__svg {
+  display: block;
+  width: 100%;
+  height: 48px;
+}
+
+.l2-spark__line {
+  stroke: #4f46e5;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.l2-spark__dot {
+  fill: #4f46e5;
+}
+
 .l2-tier-table {
   width: 100%;
   border-collapse: collapse;
-  margin-top: 4px;
+  margin-top: 0;
   font-size: 9px;
   line-height: 1.15;
   table-layout: fixed;
@@ -1475,6 +1591,9 @@ h1 {
   .day-island__close,
   .l2-row,
   .l2-event-card,
+  .l2-event-card__panel,
+  .l2-seg__btn,
+  .l2-metric,
   .tooltip,
   .cal-dd__btn,
   .cal-dd__menu,

--- a/static/data/event_l2_cards.json
+++ b/static/data/event_l2_cards.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-05",
-  "generated_at": "2026-08-06T09:05:36Z",
+  "generated_at": "2026-08-06T10:48:19Z",
   "tier_tip": {
     "en": "Tier reflects field size for that role under the WSDC points chart. Larger fields award higher placement points. Current ranges (per role, from 5 competitors): Tier 1: 5–10 · Tier 2: 11–19 · Tier 3: 20–39 · Tier 4: 40–79 · Tier 5: 80–129 · Tier 6: 130+.",
     "ru": "Тир отражает размер поля в роли по чарту очков WSDC. Чем больше поле, тем выше очки за места. Текущие диапазоны (на роль, от 5 участников): Тир 1: 5–10 · Тир 2: 11–19 · Тир 3: 20–39 · Тир 4: 40–79 · Тир 5: 80–129 · Тир 6: 130+.",
@@ -44,7 +44,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 7,
+          "unique_dancers": 85,
+          "points": 308,
+          "new_dancers": 7
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 111,
+          "points": 418,
+          "new_dancers": 5
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 93,
+          "points": 372,
+          "new_dancers": 4
+        },
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 109,
+          "points": 445,
+          "new_dancers": 5
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 111,
+          "points": 441,
+          "new_dancers": 7
+        }
+      ]
     },
     "2": {
       "event_id": 2,
@@ -62,7 +99,16 @@
         "points": 40,
         "new_dancers": 2,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1997,
+          "month": 7,
+          "unique_dancers": 4,
+          "points": 40,
+          "new_dancers": 2
+        }
+      ]
     },
     "3": {
       "event_id": 3,
@@ -80,7 +126,30 @@
         "points": 169,
         "new_dancers": 20,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2000,
+          "month": 10,
+          "unique_dancers": 39,
+          "points": 18,
+          "new_dancers": 21
+        },
+        {
+          "year": 2001,
+          "month": 10,
+          "unique_dancers": 11,
+          "points": 76,
+          "new_dancers": 4
+        },
+        {
+          "year": 2003,
+          "month": 10,
+          "unique_dancers": 49,
+          "points": 169,
+          "new_dancers": 20
+        }
+      ]
     },
     "4": {
       "event_id": 4,
@@ -98,7 +167,44 @@
         "points": 208,
         "new_dancers": 11,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1994,
+          "month": 10,
+          "unique_dancers": 4,
+          "points": 26,
+          "new_dancers": 1
+        },
+        {
+          "year": 1995,
+          "month": 10,
+          "unique_dancers": 9,
+          "points": 44,
+          "new_dancers": 4
+        },
+        {
+          "year": 1996,
+          "month": 10,
+          "unique_dancers": 31,
+          "points": 111,
+          "new_dancers": 5
+        },
+        {
+          "year": 1997,
+          "month": 10,
+          "unique_dancers": 11,
+          "points": 51,
+          "new_dancers": 5
+        },
+        {
+          "year": 1998,
+          "month": 10,
+          "unique_dancers": 47,
+          "points": 208,
+          "new_dancers": 11
+        }
+      ]
     },
     "5": {
       "event_id": 5,
@@ -116,7 +222,16 @@
         "points": 3,
         "new_dancers": 8,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1998,
+          "month": 8,
+          "unique_dancers": 38,
+          "points": 3,
+          "new_dancers": 8
+        }
+      ]
     },
     "6": {
       "event_id": 6,
@@ -134,7 +249,37 @@
         "points": 76,
         "new_dancers": 6,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1992,
+          "month": 2,
+          "unique_dancers": 6,
+          "points": 40,
+          "new_dancers": 4
+        },
+        {
+          "year": 1993,
+          "month": 2,
+          "unique_dancers": 1,
+          "points": 6,
+          "new_dancers": 0
+        },
+        {
+          "year": 1994,
+          "month": 2,
+          "unique_dancers": 9,
+          "points": 74,
+          "new_dancers": 2
+        },
+        {
+          "year": 1995,
+          "month": 2,
+          "unique_dancers": 10,
+          "points": 76,
+          "new_dancers": 6
+        }
+      ]
     },
     "7": {
       "event_id": 7,
@@ -152,7 +297,44 @@
         "points": 236,
         "new_dancers": 6,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1999,
+          "month": 10,
+          "unique_dancers": 40,
+          "points": 200,
+          "new_dancers": 1
+        },
+        {
+          "year": 2000,
+          "month": 10,
+          "unique_dancers": 64,
+          "points": 23,
+          "new_dancers": 6
+        },
+        {
+          "year": 2001,
+          "month": 10,
+          "unique_dancers": 62,
+          "points": 222,
+          "new_dancers": 5
+        },
+        {
+          "year": 2002,
+          "month": 10,
+          "unique_dancers": 47,
+          "points": 203,
+          "new_dancers": 4
+        },
+        {
+          "year": 2003,
+          "month": 10,
+          "unique_dancers": 67,
+          "points": 236,
+          "new_dancers": 6
+        }
+      ]
     },
     "8": {
       "event_id": 8,
@@ -191,7 +373,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 10,
+          "unique_dancers": 160,
+          "points": 632,
+          "new_dancers": 6
+        },
+        {
+          "year": 2022,
+          "month": 10,
+          "unique_dancers": 122,
+          "points": 558,
+          "new_dancers": 2
+        },
+        {
+          "year": 2023,
+          "month": 10,
+          "unique_dancers": 146,
+          "points": 621,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 150,
+          "points": 671,
+          "new_dancers": 7
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 158,
+          "points": 742,
+          "new_dancers": 22
+        }
+      ]
     },
     "9": {
       "event_id": 9,
@@ -226,7 +445,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 3,
+          "unique_dancers": 117,
+          "points": 398,
+          "new_dancers": 13
+        },
+        {
+          "year": 2019,
+          "month": 3,
+          "unique_dancers": 119,
+          "points": 419,
+          "new_dancers": 16
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 119,
+          "points": 441,
+          "new_dancers": 19
+        },
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 109,
+          "points": 500,
+          "new_dancers": 17
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 94,
+          "points": 399,
+          "new_dancers": 11
+        }
+      ]
     },
     "10": {
       "event_id": 10,
@@ -261,7 +517,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 9,
+          "unique_dancers": 110,
+          "points": 392,
+          "new_dancers": 13
+        },
+        {
+          "year": 2018,
+          "month": 9,
+          "unique_dancers": 88,
+          "points": 299,
+          "new_dancers": 10
+        },
+        {
+          "year": 2019,
+          "month": 9,
+          "unique_dancers": 103,
+          "points": 348,
+          "new_dancers": 13
+        },
+        {
+          "year": 2022,
+          "month": 9,
+          "unique_dancers": 82,
+          "points": 287,
+          "new_dancers": 10
+        },
+        {
+          "year": 2023,
+          "month": 9,
+          "unique_dancers": 102,
+          "points": 372,
+          "new_dancers": 19
+        }
+      ]
     },
     "11": {
       "event_id": 11,
@@ -279,7 +572,30 @@
         "points": 160,
         "new_dancers": 4,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1997,
+          "month": 5,
+          "unique_dancers": 42,
+          "points": 202,
+          "new_dancers": 7
+        },
+        {
+          "year": 1998,
+          "month": 5,
+          "unique_dancers": 65,
+          "points": 36,
+          "new_dancers": 8
+        },
+        {
+          "year": 1999,
+          "month": 5,
+          "unique_dancers": 24,
+          "points": 160,
+          "new_dancers": 4
+        }
+      ]
     },
     "12": {
       "event_id": 12,
@@ -318,7 +634,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 2,
+          "unique_dancers": 124,
+          "points": 478,
+          "new_dancers": 13
+        },
+        {
+          "year": 2023,
+          "month": 2,
+          "unique_dancers": 118,
+          "points": 441,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 2,
+          "unique_dancers": 123,
+          "points": 467,
+          "new_dancers": 7
+        },
+        {
+          "year": 2025,
+          "month": 2,
+          "unique_dancers": 118,
+          "points": 551,
+          "new_dancers": 5
+        },
+        {
+          "year": 2026,
+          "month": 2,
+          "unique_dancers": 121,
+          "points": 552,
+          "new_dancers": 5
+        }
+      ]
     },
     "13": {
       "event_id": 13,
@@ -357,7 +710,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 1997,
+          "month": 3,
+          "unique_dancers": 41,
+          "points": 121,
+          "new_dancers": 4
+        },
+        {
+          "year": 1998,
+          "month": 3,
+          "unique_dancers": 46,
+          "points": 160,
+          "new_dancers": 11
+        },
+        {
+          "year": 2010,
+          "month": 3,
+          "unique_dancers": 115,
+          "points": 419,
+          "new_dancers": 25
+        },
+        {
+          "year": 2012,
+          "month": 3,
+          "unique_dancers": 134,
+          "points": 505,
+          "new_dancers": 15
+        }
+      ]
     },
     "14": {
       "event_id": 14,
@@ -375,7 +758,44 @@
         "points": 152,
         "new_dancers": 4,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1995,
+          "month": 2,
+          "unique_dancers": 29,
+          "points": 140,
+          "new_dancers": 17
+        },
+        {
+          "year": 1996,
+          "month": 2,
+          "unique_dancers": 36,
+          "points": 6,
+          "new_dancers": 9
+        },
+        {
+          "year": 1997,
+          "month": 2,
+          "unique_dancers": 40,
+          "points": 201,
+          "new_dancers": 10
+        },
+        {
+          "year": 1998,
+          "month": 2,
+          "unique_dancers": 66,
+          "points": 226,
+          "new_dancers": 20
+        },
+        {
+          "year": 1999,
+          "month": 2,
+          "unique_dancers": 22,
+          "points": 152,
+          "new_dancers": 4
+        }
+      ]
     },
     "15": {
       "event_id": 15,
@@ -402,7 +822,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2014,
+          "month": 9,
+          "unique_dancers": 94,
+          "points": 361,
+          "new_dancers": 3
+        },
+        {
+          "year": 2015,
+          "month": 9,
+          "unique_dancers": 61,
+          "points": 227,
+          "new_dancers": 3
+        },
+        {
+          "year": 2016,
+          "month": 9,
+          "unique_dancers": 49,
+          "points": 198,
+          "new_dancers": 6
+        },
+        {
+          "year": 2017,
+          "month": 9,
+          "unique_dancers": 43,
+          "points": 158,
+          "new_dancers": 1
+        },
+        {
+          "year": 2018,
+          "month": 9,
+          "unique_dancers": 18,
+          "points": 46,
+          "new_dancers": 0
+        }
+      ]
     },
     "16": {
       "event_id": 16,
@@ -420,7 +877,23 @@
         "points": 21,
         "new_dancers": 7,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1992,
+          "month": 3,
+          "unique_dancers": 16,
+          "points": 89,
+          "new_dancers": 14
+        },
+        {
+          "year": 2001,
+          "month": 3,
+          "unique_dancers": 52,
+          "points": 21,
+          "new_dancers": 7
+        }
+      ]
     },
     "17": {
       "event_id": 17,
@@ -438,7 +911,16 @@
         "points": 40,
         "new_dancers": 2,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1996,
+          "month": 7,
+          "unique_dancers": 6,
+          "points": 40,
+          "new_dancers": 2
+        }
+      ]
     },
     "18": {
       "event_id": 18,
@@ -477,7 +959,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 4,
+          "unique_dancers": 134,
+          "points": 497,
+          "new_dancers": 12
+        },
+        {
+          "year": 2023,
+          "month": 4,
+          "unique_dancers": 154,
+          "points": 615,
+          "new_dancers": 16
+        },
+        {
+          "year": 2024,
+          "month": 4,
+          "unique_dancers": 144,
+          "points": 632,
+          "new_dancers": 15
+        },
+        {
+          "year": 2025,
+          "month": 4,
+          "unique_dancers": 140,
+          "points": 673,
+          "new_dancers": 19
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 137,
+          "points": 677,
+          "new_dancers": 17
+        }
+      ]
     },
     "19": {
       "event_id": 19,
@@ -508,7 +1027,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2006,
+          "month": 5,
+          "unique_dancers": 49,
+          "points": 169,
+          "new_dancers": 8
+        },
+        {
+          "year": 2007,
+          "month": 5,
+          "unique_dancers": 39,
+          "points": 0,
+          "new_dancers": 8
+        },
+        {
+          "year": 2008,
+          "month": 5,
+          "unique_dancers": 39,
+          "points": 164,
+          "new_dancers": 10
+        },
+        {
+          "year": 2009,
+          "month": 5,
+          "unique_dancers": 40,
+          "points": 120,
+          "new_dancers": 10
+        },
+        {
+          "year": 2010,
+          "month": 5,
+          "unique_dancers": 38,
+          "points": 117,
+          "new_dancers": 6
+        }
+      ]
     },
     "20": {
       "event_id": 20,
@@ -543,7 +1099,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 5,
+          "unique_dancers": 76,
+          "points": 270,
+          "new_dancers": 6
+        },
+        {
+          "year": 2016,
+          "month": 5,
+          "unique_dancers": 72,
+          "points": 270,
+          "new_dancers": 5
+        },
+        {
+          "year": 2017,
+          "month": 5,
+          "unique_dancers": 82,
+          "points": 310,
+          "new_dancers": 9
+        },
+        {
+          "year": 2018,
+          "month": 5,
+          "unique_dancers": 74,
+          "points": 242,
+          "new_dancers": 4
+        },
+        {
+          "year": 2019,
+          "month": 5,
+          "unique_dancers": 107,
+          "points": 369,
+          "new_dancers": 8
+        }
+      ]
     },
     "21": {
       "event_id": 21,
@@ -561,7 +1154,30 @@
         "points": 172,
         "new_dancers": 8,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1996,
+          "month": 4,
+          "unique_dancers": 36,
+          "points": 192,
+          "new_dancers": 14
+        },
+        {
+          "year": 1997,
+          "month": 4,
+          "unique_dancers": 44,
+          "points": 204,
+          "new_dancers": 15
+        },
+        {
+          "year": 1998,
+          "month": 4,
+          "unique_dancers": 30,
+          "points": 172,
+          "new_dancers": 8
+        }
+      ]
     },
     "22": {
       "event_id": 22,
@@ -596,7 +1212,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 5,
+          "unique_dancers": 132,
+          "points": 490,
+          "new_dancers": 12
+        },
+        {
+          "year": 2023,
+          "month": 5,
+          "unique_dancers": 141,
+          "points": 584,
+          "new_dancers": 14
+        },
+        {
+          "year": 2024,
+          "month": 5,
+          "unique_dancers": 140,
+          "points": 563,
+          "new_dancers": 10
+        },
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 132,
+          "points": 571,
+          "new_dancers": 18
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 120,
+          "points": 518,
+          "new_dancers": 15
+        }
+      ]
     },
     "23": {
       "event_id": 23,
@@ -614,7 +1267,16 @@
         "points": 196,
         "new_dancers": 6,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1999,
+          "month": 8,
+          "unique_dancers": 38,
+          "points": 196,
+          "new_dancers": 6
+        }
+      ]
     },
     "24": {
       "event_id": 24,
@@ -632,7 +1294,16 @@
         "points": 187,
         "new_dancers": 9,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1996,
+          "month": 8,
+          "unique_dancers": 37,
+          "points": 187,
+          "new_dancers": 9
+        }
+      ]
     },
     "25": {
       "event_id": 25,
@@ -671,7 +1342,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 6,
+          "unique_dancers": 149,
+          "points": 599,
+          "new_dancers": 10
+        },
+        {
+          "year": 2023,
+          "month": 6,
+          "unique_dancers": 140,
+          "points": 600,
+          "new_dancers": 4
+        },
+        {
+          "year": 2024,
+          "month": 6,
+          "unique_dancers": 141,
+          "points": 633,
+          "new_dancers": 10
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 131,
+          "points": 684,
+          "new_dancers": 7
+        },
+        {
+          "year": 2026,
+          "month": 6,
+          "unique_dancers": 131,
+          "points": 701,
+          "new_dancers": 6
+        }
+      ]
     },
     "26": {
       "event_id": 26,
@@ -689,7 +1397,16 @@
         "points": 80,
         "new_dancers": 12,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1999,
+          "month": 2,
+          "unique_dancers": 12,
+          "points": 80,
+          "new_dancers": 12
+        }
+      ]
     },
     "27": {
       "event_id": 27,
@@ -707,7 +1424,37 @@
         "points": 200,
         "new_dancers": 4,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1994,
+          "month": 9,
+          "unique_dancers": 31,
+          "points": 151,
+          "new_dancers": 17
+        },
+        {
+          "year": 1995,
+          "month": 9,
+          "unique_dancers": 30,
+          "points": 151,
+          "new_dancers": 9
+        },
+        {
+          "year": 1996,
+          "month": 9,
+          "unique_dancers": 39,
+          "points": 197,
+          "new_dancers": 8
+        },
+        {
+          "year": 1997,
+          "month": 9,
+          "unique_dancers": 40,
+          "points": 200,
+          "new_dancers": 4
+        }
+      ]
     },
     "28": {
       "event_id": 28,
@@ -725,7 +1472,44 @@
         "points": 150,
         "new_dancers": 2,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1997,
+          "month": 1,
+          "unique_dancers": 19,
+          "points": 121,
+          "new_dancers": 6
+        },
+        {
+          "year": 1998,
+          "month": 1,
+          "unique_dancers": 41,
+          "points": 170,
+          "new_dancers": 11
+        },
+        {
+          "year": 1999,
+          "month": 1,
+          "unique_dancers": 27,
+          "points": 150,
+          "new_dancers": 4
+        },
+        {
+          "year": 2000,
+          "month": 1,
+          "unique_dancers": 35,
+          "points": 190,
+          "new_dancers": 5
+        },
+        {
+          "year": 2004,
+          "month": 1,
+          "unique_dancers": 26,
+          "points": 150,
+          "new_dancers": 2
+        }
+      ]
     },
     "29": {
       "event_id": 29,
@@ -743,7 +1527,44 @@
         "points": 92,
         "new_dancers": 0,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1998,
+          "month": 8,
+          "unique_dancers": 16,
+          "points": 92,
+          "new_dancers": 9
+        },
+        {
+          "year": 1999,
+          "month": 8,
+          "unique_dancers": 20,
+          "points": 100,
+          "new_dancers": 6
+        },
+        {
+          "year": 2000,
+          "month": 8,
+          "unique_dancers": 20,
+          "points": 100,
+          "new_dancers": 9
+        },
+        {
+          "year": 2001,
+          "month": 8,
+          "unique_dancers": 28,
+          "points": 108,
+          "new_dancers": 11
+        },
+        {
+          "year": 2003,
+          "month": 8,
+          "unique_dancers": 16,
+          "points": 92,
+          "new_dancers": 0
+        }
+      ]
     },
     "30": {
       "event_id": 30,
@@ -761,7 +1582,23 @@
         "points": 120,
         "new_dancers": 6,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2002,
+          "month": 3,
+          "unique_dancers": 20,
+          "points": 98,
+          "new_dancers": 6
+        },
+        {
+          "year": 2003,
+          "month": 3,
+          "unique_dancers": 18,
+          "points": 120,
+          "new_dancers": 6
+        }
+      ]
     },
     "31": {
       "event_id": 31,
@@ -796,7 +1633,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 11,
+          "unique_dancers": 65,
+          "points": 236,
+          "new_dancers": 6
+        },
+        {
+          "year": 2022,
+          "month": 11,
+          "unique_dancers": 65,
+          "points": 240,
+          "new_dancers": 5
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 59,
+          "points": 213,
+          "new_dancers": 4
+        },
+        {
+          "year": 2024,
+          "month": 11,
+          "unique_dancers": 49,
+          "points": 166,
+          "new_dancers": 2
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 51,
+          "points": 177,
+          "new_dancers": 7
+        }
+      ]
     },
     "32": {
       "event_id": 32,
@@ -814,7 +1688,44 @@
         "points": 126,
         "new_dancers": 11,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2001,
+          "month": 7,
+          "unique_dancers": 36,
+          "points": 116,
+          "new_dancers": 30
+        },
+        {
+          "year": 2002,
+          "month": 7,
+          "unique_dancers": 40,
+          "points": 120,
+          "new_dancers": 25
+        },
+        {
+          "year": 2003,
+          "month": 7,
+          "unique_dancers": 20,
+          "points": 100,
+          "new_dancers": 6
+        },
+        {
+          "year": 2004,
+          "month": 7,
+          "unique_dancers": 40,
+          "points": 120,
+          "new_dancers": 16
+        },
+        {
+          "year": 2007,
+          "month": 7,
+          "unique_dancers": 30,
+          "points": 126,
+          "new_dancers": 11
+        }
+      ]
     },
     "33": {
       "event_id": 33,
@@ -832,7 +1743,23 @@
         "points": 76,
         "new_dancers": 3,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1994,
+          "month": 12,
+          "unique_dancers": 10,
+          "points": 50,
+          "new_dancers": 1
+        },
+        {
+          "year": 1995,
+          "month": 12,
+          "unique_dancers": 11,
+          "points": 76,
+          "new_dancers": 3
+        }
+      ]
     },
     "34": {
       "event_id": 34,
@@ -850,7 +1777,23 @@
         "points": 50,
         "new_dancers": 8,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1998,
+          "month": 9,
+          "unique_dancers": 59,
+          "points": 262,
+          "new_dancers": 22
+        },
+        {
+          "year": 2001,
+          "month": 9,
+          "unique_dancers": 40,
+          "points": 50,
+          "new_dancers": 8
+        }
+      ]
     },
     "35": {
       "event_id": 35,
@@ -868,7 +1811,23 @@
         "points": 58,
         "new_dancers": 10,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1995,
+          "month": 11,
+          "unique_dancers": 22,
+          "points": 120,
+          "new_dancers": 16
+        },
+        {
+          "year": 1996,
+          "month": 11,
+          "unique_dancers": 17,
+          "points": 58,
+          "new_dancers": 10
+        }
+      ]
     },
     "36": {
       "event_id": 36,
@@ -886,7 +1845,37 @@
         "points": 27,
         "new_dancers": 11,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1997,
+          "month": 12,
+          "unique_dancers": 18,
+          "points": 120,
+          "new_dancers": 5
+        },
+        {
+          "year": 1998,
+          "month": 12,
+          "unique_dancers": 55,
+          "points": 210,
+          "new_dancers": 18
+        },
+        {
+          "year": 1999,
+          "month": 12,
+          "unique_dancers": 39,
+          "points": 20,
+          "new_dancers": 6
+        },
+        {
+          "year": 2000,
+          "month": 12,
+          "unique_dancers": 61,
+          "points": 27,
+          "new_dancers": 11
+        }
+      ]
     },
     "38": {
       "event_id": 38,
@@ -904,7 +1893,23 @@
         "points": 234,
         "new_dancers": 8,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1999,
+          "month": 1,
+          "unique_dancers": 56,
+          "points": 256,
+          "new_dancers": 9
+        },
+        {
+          "year": 2000,
+          "month": 1,
+          "unique_dancers": 58,
+          "points": 234,
+          "new_dancers": 8
+        }
+      ]
     },
     "40": {
       "event_id": 40,
@@ -922,7 +1927,44 @@
         "points": 106,
         "new_dancers": 0,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2000,
+          "month": 4,
+          "unique_dancers": 68,
+          "points": 188,
+          "new_dancers": 18
+        },
+        {
+          "year": 2001,
+          "month": 4,
+          "unique_dancers": 69,
+          "points": 230,
+          "new_dancers": 22
+        },
+        {
+          "year": 2002,
+          "month": 4,
+          "unique_dancers": 77,
+          "points": 238,
+          "new_dancers": 15
+        },
+        {
+          "year": 2003,
+          "month": 4,
+          "unique_dancers": 20,
+          "points": 60,
+          "new_dancers": 2
+        },
+        {
+          "year": 2004,
+          "month": 4,
+          "unique_dancers": 29,
+          "points": 106,
+          "new_dancers": 0
+        }
+      ]
     },
     "41": {
       "event_id": 41,
@@ -940,7 +1982,23 @@
         "points": 197,
         "new_dancers": 9,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2000,
+          "month": 10,
+          "unique_dancers": 42,
+          "points": 8,
+          "new_dancers": 25
+        },
+        {
+          "year": 2002,
+          "month": 10,
+          "unique_dancers": 46,
+          "points": 197,
+          "new_dancers": 9
+        }
+      ]
     },
     "42": {
       "event_id": 42,
@@ -975,7 +2033,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 1,
+          "unique_dancers": 115,
+          "points": 434,
+          "new_dancers": 15
+        },
+        {
+          "year": 2023,
+          "month": 1,
+          "unique_dancers": 122,
+          "points": 473,
+          "new_dancers": 16
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 96,
+          "points": 347,
+          "new_dancers": 13
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 112,
+          "points": 413,
+          "new_dancers": 13
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 92,
+          "points": 351,
+          "new_dancers": 13
+        }
+      ]
     },
     "43": {
       "event_id": 43,
@@ -1010,7 +2105,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 10,
+          "unique_dancers": 75,
+          "points": 250,
+          "new_dancers": 4
+        },
+        {
+          "year": 2022,
+          "month": 10,
+          "unique_dancers": 66,
+          "points": 228,
+          "new_dancers": 3
+        },
+        {
+          "year": 2023,
+          "month": 10,
+          "unique_dancers": 77,
+          "points": 291,
+          "new_dancers": 3
+        },
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 79,
+          "points": 274,
+          "new_dancers": 7
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 78,
+          "points": 297,
+          "new_dancers": 6
+        }
+      ]
     },
     "44": {
       "event_id": 44,
@@ -1045,7 +2177,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 7,
+          "unique_dancers": 60,
+          "points": 200,
+          "new_dancers": 8
+        },
+        {
+          "year": 2016,
+          "month": 7,
+          "unique_dancers": 65,
+          "points": 226,
+          "new_dancers": 6
+        },
+        {
+          "year": 2017,
+          "month": 7,
+          "unique_dancers": 57,
+          "points": 200,
+          "new_dancers": 2
+        },
+        {
+          "year": 2018,
+          "month": 7,
+          "unique_dancers": 59,
+          "points": 204,
+          "new_dancers": 1
+        },
+        {
+          "year": 2019,
+          "month": 7,
+          "unique_dancers": 69,
+          "points": 228,
+          "new_dancers": 2
+        }
+      ]
     },
     "45": {
       "event_id": 45,
@@ -1063,7 +2232,30 @@
         "points": 234,
         "new_dancers": 20,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1997,
+          "month": 10,
+          "unique_dancers": 34,
+          "points": 114,
+          "new_dancers": 2
+        },
+        {
+          "year": 1999,
+          "month": 10,
+          "unique_dancers": 46,
+          "points": 200,
+          "new_dancers": 3
+        },
+        {
+          "year": 2000,
+          "month": 10,
+          "unique_dancers": 74,
+          "points": 234,
+          "new_dancers": 20
+        }
+      ]
     },
     "46": {
       "event_id": 46,
@@ -1081,7 +2273,16 @@
         "points": 108,
         "new_dancers": 13,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1996,
+          "month": 5,
+          "unique_dancers": 31,
+          "points": 108,
+          "new_dancers": 13
+        }
+      ]
     },
     "47": {
       "event_id": 47,
@@ -1120,7 +2321,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 7,
+          "unique_dancers": 87,
+          "points": 337,
+          "new_dancers": 1
+        },
+        {
+          "year": 2022,
+          "month": 7,
+          "unique_dancers": 127,
+          "points": 447,
+          "new_dancers": 15
+        },
+        {
+          "year": 2023,
+          "month": 8,
+          "unique_dancers": 118,
+          "points": 431,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 165,
+          "points": 716,
+          "new_dancers": 21
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 129,
+          "points": 569,
+          "new_dancers": 15
+        }
+      ]
     },
     "48": {
       "event_id": 48,
@@ -1155,7 +2393,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 9,
+          "unique_dancers": 71,
+          "points": 224,
+          "new_dancers": 4
+        },
+        {
+          "year": 2022,
+          "month": 9,
+          "unique_dancers": 32,
+          "points": 106,
+          "new_dancers": 4
+        },
+        {
+          "year": 2023,
+          "month": 9,
+          "unique_dancers": 57,
+          "points": 189,
+          "new_dancers": 1
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 58,
+          "points": 187,
+          "new_dancers": 7
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 69,
+          "points": 294,
+          "new_dancers": 8
+        }
+      ]
     },
     "49": {
       "event_id": 49,
@@ -1173,7 +2448,44 @@
         "points": 281,
         "new_dancers": 16,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1994,
+          "month": 5,
+          "unique_dancers": 24,
+          "points": 160,
+          "new_dancers": 12
+        },
+        {
+          "year": 1995,
+          "month": 5,
+          "unique_dancers": 38,
+          "points": 202,
+          "new_dancers": 22
+        },
+        {
+          "year": 1996,
+          "month": 5,
+          "unique_dancers": 39,
+          "points": 198,
+          "new_dancers": 12
+        },
+        {
+          "year": 1997,
+          "month": 5,
+          "unique_dancers": 58,
+          "points": 264,
+          "new_dancers": 15
+        },
+        {
+          "year": 1998,
+          "month": 5,
+          "unique_dancers": 76,
+          "points": 281,
+          "new_dancers": 16
+        }
+      ]
     },
     "50": {
       "event_id": 50,
@@ -1191,7 +2503,23 @@
         "points": 273,
         "new_dancers": 4,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2002,
+          "month": 3,
+          "unique_dancers": 86,
+          "points": 287,
+          "new_dancers": 6
+        },
+        {
+          "year": 2003,
+          "month": 3,
+          "unique_dancers": 75,
+          "points": 273,
+          "new_dancers": 4
+        }
+      ]
     },
     "51": {
       "event_id": 51,
@@ -1226,7 +2554,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 8,
+          "unique_dancers": 90,
+          "points": 359,
+          "new_dancers": 11
+        },
+        {
+          "year": 2016,
+          "month": 8,
+          "unique_dancers": 111,
+          "points": 391,
+          "new_dancers": 16
+        },
+        {
+          "year": 2017,
+          "month": 7,
+          "unique_dancers": 89,
+          "points": 343,
+          "new_dancers": 7
+        },
+        {
+          "year": 2018,
+          "month": 8,
+          "unique_dancers": 83,
+          "points": 253,
+          "new_dancers": 3
+        },
+        {
+          "year": 2019,
+          "month": 8,
+          "unique_dancers": 76,
+          "points": 248,
+          "new_dancers": 6
+        }
+      ]
     },
     "52": {
       "event_id": 52,
@@ -1244,7 +2609,44 @@
         "points": 212,
         "new_dancers": 4,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1999,
+          "month": 7,
+          "unique_dancers": 24,
+          "points": 160,
+          "new_dancers": 2
+        },
+        {
+          "year": 2000,
+          "month": 7,
+          "unique_dancers": 62,
+          "points": 220,
+          "new_dancers": 14
+        },
+        {
+          "year": 2001,
+          "month": 7,
+          "unique_dancers": 66,
+          "points": 226,
+          "new_dancers": 14
+        },
+        {
+          "year": 2002,
+          "month": 7,
+          "unique_dancers": 56,
+          "points": 220,
+          "new_dancers": 8
+        },
+        {
+          "year": 2003,
+          "month": 7,
+          "unique_dancers": 52,
+          "points": 212,
+          "new_dancers": 4
+        }
+      ]
     },
     "53": {
       "event_id": 53,
@@ -1283,7 +2685,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 8,
+          "unique_dancers": 115,
+          "points": 427,
+          "new_dancers": 9
+        },
+        {
+          "year": 2018,
+          "month": 8,
+          "unique_dancers": 134,
+          "points": 469,
+          "new_dancers": 15
+        },
+        {
+          "year": 2019,
+          "month": 8,
+          "unique_dancers": 131,
+          "points": 466,
+          "new_dancers": 12
+        },
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 125,
+          "points": 493,
+          "new_dancers": 15
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 123,
+          "points": 558,
+          "new_dancers": 16
+        }
+      ]
     },
     "54": {
       "event_id": 54,
@@ -1301,7 +2740,23 @@
         "points": 176,
         "new_dancers": 14,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2001,
+          "month": 9,
+          "unique_dancers": 21,
+          "points": 160,
+          "new_dancers": 14
+        },
+        {
+          "year": 2002,
+          "month": 9,
+          "unique_dancers": 28,
+          "points": 176,
+          "new_dancers": 14
+        }
+      ]
     },
     "55": {
       "event_id": 55,
@@ -1319,7 +2774,16 @@
         "points": 222,
         "new_dancers": 13,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1998,
+          "month": 9,
+          "unique_dancers": 62,
+          "points": 222,
+          "new_dancers": 13
+        }
+      ]
     },
     "56": {
       "event_id": 56,
@@ -1337,7 +2801,23 @@
         "points": 34,
         "new_dancers": 13,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1999,
+          "month": 4,
+          "unique_dancers": 67,
+          "points": 219,
+          "new_dancers": 11
+        },
+        {
+          "year": 2000,
+          "month": 4,
+          "unique_dancers": 77,
+          "points": 34,
+          "new_dancers": 13
+        }
+      ]
     },
     "57": {
       "event_id": 57,
@@ -1355,7 +2835,30 @@
         "points": 80,
         "new_dancers": 6,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1996,
+          "month": 8,
+          "unique_dancers": 22,
+          "points": 110,
+          "new_dancers": 13
+        },
+        {
+          "year": 1997,
+          "month": 8,
+          "unique_dancers": 12,
+          "points": 80,
+          "new_dancers": 7
+        },
+        {
+          "year": 1998,
+          "month": 8,
+          "unique_dancers": 12,
+          "points": 80,
+          "new_dancers": 6
+        }
+      ]
     },
     "58": {
       "event_id": 58,
@@ -1373,7 +2876,44 @@
         "points": 226,
         "new_dancers": 6,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1999,
+          "month": 1,
+          "unique_dancers": 26,
+          "points": 150,
+          "new_dancers": 4
+        },
+        {
+          "year": 2000,
+          "month": 1,
+          "unique_dancers": 60,
+          "points": 225,
+          "new_dancers": 11
+        },
+        {
+          "year": 2001,
+          "month": 1,
+          "unique_dancers": 60,
+          "points": 224,
+          "new_dancers": 9
+        },
+        {
+          "year": 2002,
+          "month": 1,
+          "unique_dancers": 47,
+          "points": 220,
+          "new_dancers": 12
+        },
+        {
+          "year": 2003,
+          "month": 1,
+          "unique_dancers": 52,
+          "points": 226,
+          "new_dancers": 6
+        }
+      ]
     },
     "59": {
       "event_id": 59,
@@ -1408,7 +2948,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 8,
+          "unique_dancers": 120,
+          "points": 428,
+          "new_dancers": 18
+        },
+        {
+          "year": 2022,
+          "month": 8,
+          "unique_dancers": 121,
+          "points": 454,
+          "new_dancers": 16
+        },
+        {
+          "year": 2023,
+          "month": 8,
+          "unique_dancers": 140,
+          "points": 603,
+          "new_dancers": 25
+        },
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 154,
+          "points": 664,
+          "new_dancers": 25
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 133,
+          "points": 618,
+          "new_dancers": 17
+        }
+      ]
     },
     "60": {
       "event_id": 60,
@@ -1426,7 +3003,44 @@
         "points": 51,
         "new_dancers": 4,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1993,
+          "month": 4,
+          "unique_dancers": 2,
+          "points": 20,
+          "new_dancers": 1
+        },
+        {
+          "year": 1994,
+          "month": 4,
+          "unique_dancers": 3,
+          "points": 30,
+          "new_dancers": 1
+        },
+        {
+          "year": 1995,
+          "month": 4,
+          "unique_dancers": 3,
+          "points": 30,
+          "new_dancers": 0
+        },
+        {
+          "year": 1996,
+          "month": 4,
+          "unique_dancers": 29,
+          "points": 146,
+          "new_dancers": 8
+        },
+        {
+          "year": 1997,
+          "month": 4,
+          "unique_dancers": 25,
+          "points": 51,
+          "new_dancers": 4
+        }
+      ]
     },
     "61": {
       "event_id": 61,
@@ -1465,7 +3079,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 5,
+          "unique_dancers": 104,
+          "points": 482,
+          "new_dancers": 2
+        },
+        {
+          "year": 2016,
+          "month": 5,
+          "unique_dancers": 126,
+          "points": 554,
+          "new_dancers": 6
+        },
+        {
+          "year": 2017,
+          "month": 5,
+          "unique_dancers": 117,
+          "points": 486,
+          "new_dancers": 6
+        },
+        {
+          "year": 2018,
+          "month": 5,
+          "unique_dancers": 111,
+          "points": 427,
+          "new_dancers": 6
+        },
+        {
+          "year": 2019,
+          "month": 5,
+          "unique_dancers": 108,
+          "points": 403,
+          "new_dancers": 6
+        }
+      ]
     },
     "62": {
       "event_id": 62,
@@ -1504,7 +3155,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 1,
+          "unique_dancers": 88,
+          "points": 291,
+          "new_dancers": 8
+        },
+        {
+          "year": 2023,
+          "month": 1,
+          "unique_dancers": 103,
+          "points": 409,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 110,
+          "points": 434,
+          "new_dancers": 11
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 107,
+          "points": 470,
+          "new_dancers": 4
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 136,
+          "points": 582,
+          "new_dancers": 18
+        }
+      ]
     },
     "63": {
       "event_id": 63,
@@ -1539,7 +3227,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2014,
+          "month": 11,
+          "unique_dancers": 88,
+          "points": 296,
+          "new_dancers": 11
+        },
+        {
+          "year": 2015,
+          "month": 11,
+          "unique_dancers": 96,
+          "points": 334,
+          "new_dancers": 10
+        },
+        {
+          "year": 2016,
+          "month": 11,
+          "unique_dancers": 100,
+          "points": 340,
+          "new_dancers": 14
+        },
+        {
+          "year": 2017,
+          "month": 11,
+          "unique_dancers": 100,
+          "points": 361,
+          "new_dancers": 16
+        },
+        {
+          "year": 2018,
+          "month": 11,
+          "unique_dancers": 86,
+          "points": 272,
+          "new_dancers": 16
+        }
+      ]
     },
     "64": {
       "event_id": 64,
@@ -1557,7 +3282,30 @@
         "points": 112,
         "new_dancers": 12,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1997,
+          "month": 6,
+          "unique_dancers": 17,
+          "points": 110,
+          "new_dancers": 14
+        },
+        {
+          "year": 1998,
+          "month": 6,
+          "unique_dancers": 18,
+          "points": 120,
+          "new_dancers": 12
+        },
+        {
+          "year": 1999,
+          "month": 6,
+          "unique_dancers": 16,
+          "points": 112,
+          "new_dancers": 12
+        }
+      ]
     },
     "65": {
       "event_id": 65,
@@ -1596,7 +3344,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 10,
+          "unique_dancers": 86,
+          "points": 350,
+          "new_dancers": 2
+        },
+        {
+          "year": 2022,
+          "month": 10,
+          "unique_dancers": 118,
+          "points": 454,
+          "new_dancers": 10
+        },
+        {
+          "year": 2023,
+          "month": 10,
+          "unique_dancers": 122,
+          "points": 470,
+          "new_dancers": 14
+        },
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 124,
+          "points": 470,
+          "new_dancers": 19
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 104,
+          "points": 405,
+          "new_dancers": 10
+        }
+      ]
     },
     "67": {
       "event_id": 67,
@@ -1631,7 +3416,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2010,
+          "month": 1,
+          "unique_dancers": 72,
+          "points": 284,
+          "new_dancers": 7
+        },
+        {
+          "year": 2011,
+          "month": 1,
+          "unique_dancers": 81,
+          "points": 318,
+          "new_dancers": 0
+        },
+        {
+          "year": 2012,
+          "month": 1,
+          "unique_dancers": 113,
+          "points": 470,
+          "new_dancers": 6
+        },
+        {
+          "year": 2013,
+          "month": 1,
+          "unique_dancers": 97,
+          "points": 461,
+          "new_dancers": 8
+        },
+        {
+          "year": 2014,
+          "month": 1,
+          "unique_dancers": 91,
+          "points": 374,
+          "new_dancers": 5
+        }
+      ]
     },
     "68": {
       "event_id": 68,
@@ -1670,7 +3492,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 12,
+          "unique_dancers": 124,
+          "points": 434,
+          "new_dancers": 5
+        },
+        {
+          "year": 2022,
+          "month": 11,
+          "unique_dancers": 135,
+          "points": 491,
+          "new_dancers": 2
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 147,
+          "points": 576,
+          "new_dancers": 4
+        },
+        {
+          "year": 2024,
+          "month": 12,
+          "unique_dancers": 151,
+          "points": 631,
+          "new_dancers": 6
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 135,
+          "points": 626,
+          "new_dancers": 8
+        }
+      ]
     },
     "69": {
       "event_id": 69,
@@ -1688,7 +3547,16 @@
         "points": 0,
         "new_dancers": 9,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1999,
+          "month": 9,
+          "unique_dancers": 48,
+          "points": 0,
+          "new_dancers": 9
+        }
+      ]
     },
     "70": {
       "event_id": 70,
@@ -1723,7 +3591,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2006,
+          "month": 9,
+          "unique_dancers": 43,
+          "points": 163,
+          "new_dancers": 6
+        },
+        {
+          "year": 2007,
+          "month": 9,
+          "unique_dancers": 39,
+          "points": 168,
+          "new_dancers": 6
+        },
+        {
+          "year": 2008,
+          "month": 9,
+          "unique_dancers": 47,
+          "points": 185,
+          "new_dancers": 11
+        },
+        {
+          "year": 2009,
+          "month": 9,
+          "unique_dancers": 67,
+          "points": 211,
+          "new_dancers": 15
+        },
+        {
+          "year": 2010,
+          "month": 11,
+          "unique_dancers": 60,
+          "points": 190,
+          "new_dancers": 7
+        }
+      ]
     },
     "71": {
       "event_id": 71,
@@ -1741,7 +3646,37 @@
         "points": 18,
         "new_dancers": 4,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1997,
+          "month": 7,
+          "unique_dancers": 62,
+          "points": 182,
+          "new_dancers": 9
+        },
+        {
+          "year": 1998,
+          "month": 7,
+          "unique_dancers": 58,
+          "points": 19,
+          "new_dancers": 7
+        },
+        {
+          "year": 1999,
+          "month": 7,
+          "unique_dancers": 47,
+          "points": 11,
+          "new_dancers": 5
+        },
+        {
+          "year": 2000,
+          "month": 7,
+          "unique_dancers": 56,
+          "points": 18,
+          "new_dancers": 4
+        }
+      ]
     },
     "72": {
       "event_id": 72,
@@ -1759,7 +3694,23 @@
         "points": 132,
         "new_dancers": 14,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 1994,
+          "month": 7,
+          "unique_dancers": 31,
+          "points": 151,
+          "new_dancers": 17
+        },
+        {
+          "year": 1995,
+          "month": 7,
+          "unique_dancers": 26,
+          "points": 132,
+          "new_dancers": 14
+        }
+      ]
     },
     "73": {
       "event_id": 73,
@@ -1786,7 +3737,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2005,
+          "month": 5,
+          "unique_dancers": 44,
+          "points": 247,
+          "new_dancers": 6
+        },
+        {
+          "year": 2007,
+          "month": 5,
+          "unique_dancers": 52,
+          "points": 246,
+          "new_dancers": 11
+        },
+        {
+          "year": 2008,
+          "month": 5,
+          "unique_dancers": 49,
+          "points": 250,
+          "new_dancers": 8
+        },
+        {
+          "year": 2010,
+          "month": 5,
+          "unique_dancers": 53,
+          "points": 211,
+          "new_dancers": 10
+        },
+        {
+          "year": 2011,
+          "month": 7,
+          "unique_dancers": 23,
+          "points": 89,
+          "new_dancers": 4
+        }
+      ]
     },
     "75": {
       "event_id": 75,
@@ -1821,7 +3809,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 1,
+          "unique_dancers": 46,
+          "points": 139,
+          "new_dancers": 9
+        },
+        {
+          "year": 2023,
+          "month": 1,
+          "unique_dancers": 70,
+          "points": 297,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 72,
+          "points": 263,
+          "new_dancers": 6
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 50,
+          "points": 167,
+          "new_dancers": 7
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 69,
+          "points": 271,
+          "new_dancers": 9
+        }
+      ]
     },
     "76": {
       "event_id": 76,
@@ -1860,7 +3885,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 6,
+          "unique_dancers": 89,
+          "points": 304,
+          "new_dancers": 10
+        },
+        {
+          "year": 2019,
+          "month": 6,
+          "unique_dancers": 95,
+          "points": 328,
+          "new_dancers": 3
+        },
+        {
+          "year": 2024,
+          "month": 6,
+          "unique_dancers": 88,
+          "points": 341,
+          "new_dancers": 15
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 102,
+          "points": 448,
+          "new_dancers": 14
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 88,
+          "points": 367,
+          "new_dancers": 9
+        }
+      ]
     },
     "77": {
       "event_id": 77,
@@ -1895,7 +3957,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 8,
+          "unique_dancers": 50,
+          "points": 170,
+          "new_dancers": 8
+        },
+        {
+          "year": 2022,
+          "month": 8,
+          "unique_dancers": 37,
+          "points": 127,
+          "new_dancers": 2
+        },
+        {
+          "year": 2023,
+          "month": 8,
+          "unique_dancers": 42,
+          "points": 146,
+          "new_dancers": 7
+        },
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 36,
+          "points": 117,
+          "new_dancers": 8
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 57,
+          "points": 177,
+          "new_dancers": 6
+        }
+      ]
     },
     "78": {
       "event_id": 78,
@@ -1913,7 +4012,30 @@
         "points": 174,
         "new_dancers": 4,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2002,
+          "month": 9,
+          "unique_dancers": 50,
+          "points": 172,
+          "new_dancers": 12
+        },
+        {
+          "year": 2003,
+          "month": 9,
+          "unique_dancers": 56,
+          "points": 216,
+          "new_dancers": 12
+        },
+        {
+          "year": 2004,
+          "month": 9,
+          "unique_dancers": 54,
+          "points": 174,
+          "new_dancers": 4
+        }
+      ]
     },
     "79": {
       "event_id": 79,
@@ -1952,7 +4074,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 11,
+          "unique_dancers": 85,
+          "points": 302,
+          "new_dancers": 15
+        },
+        {
+          "year": 2018,
+          "month": 11,
+          "unique_dancers": 100,
+          "points": 343,
+          "new_dancers": 13
+        },
+        {
+          "year": 2019,
+          "month": 11,
+          "unique_dancers": 93,
+          "points": 324,
+          "new_dancers": 9
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 96,
+          "points": 357,
+          "new_dancers": 16
+        },
+        {
+          "year": 2024,
+          "month": 11,
+          "unique_dancers": 121,
+          "points": 498,
+          "new_dancers": 20
+        }
+      ]
     },
     "80": {
       "event_id": 80,
@@ -1979,7 +4138,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2003,
+          "month": 11,
+          "unique_dancers": 38,
+          "points": 195,
+          "new_dancers": 2
+        },
+        {
+          "year": 2004,
+          "month": 11,
+          "unique_dancers": 53,
+          "points": 211,
+          "new_dancers": 4
+        },
+        {
+          "year": 2005,
+          "month": 11,
+          "unique_dancers": 58,
+          "points": 219,
+          "new_dancers": 5
+        },
+        {
+          "year": 2006,
+          "month": 11,
+          "unique_dancers": 54,
+          "points": 220,
+          "new_dancers": 5
+        },
+        {
+          "year": 2007,
+          "month": 11,
+          "unique_dancers": 29,
+          "points": 108,
+          "new_dancers": 6
+        }
+      ]
     },
     "81": {
       "event_id": 81,
@@ -1997,7 +4193,44 @@
         "points": 275,
         "new_dancers": 7,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2002,
+          "month": 10,
+          "unique_dancers": 46,
+          "points": 166,
+          "new_dancers": 20
+        },
+        {
+          "year": 2003,
+          "month": 10,
+          "unique_dancers": 118,
+          "points": 414,
+          "new_dancers": 45
+        },
+        {
+          "year": 2004,
+          "month": 10,
+          "unique_dancers": 66,
+          "points": 226,
+          "new_dancers": 13
+        },
+        {
+          "year": 2005,
+          "month": 10,
+          "unique_dancers": 59,
+          "points": 256,
+          "new_dancers": 4
+        },
+        {
+          "year": 2006,
+          "month": 10,
+          "unique_dancers": 73,
+          "points": 275,
+          "new_dancers": 7
+        }
+      ]
     },
     "82": {
       "event_id": 82,
@@ -2020,7 +4253,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2003,
+          "month": 2,
+          "unique_dancers": 21,
+          "points": 102,
+          "new_dancers": 11
+        },
+        {
+          "year": 2004,
+          "month": 2,
+          "unique_dancers": 12,
+          "points": 52,
+          "new_dancers": 3
+        },
+        {
+          "year": 2005,
+          "month": 2,
+          "unique_dancers": 10,
+          "points": 50,
+          "new_dancers": 6
+        },
+        {
+          "year": 2006,
+          "month": 2,
+          "unique_dancers": 10,
+          "points": 50,
+          "new_dancers": 4
+        },
+        {
+          "year": 2007,
+          "month": 2,
+          "unique_dancers": 5,
+          "points": 32,
+          "new_dancers": 2
+        }
+      ]
     },
     "83": {
       "event_id": 83,
@@ -2038,7 +4308,16 @@
         "points": 154,
         "new_dancers": 10,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2003,
+          "month": 5,
+          "unique_dancers": 34,
+          "points": 154,
+          "new_dancers": 10
+        }
+      ]
     },
     "84": {
       "event_id": 84,
@@ -2073,7 +4352,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2008,
+          "month": 7,
+          "unique_dancers": 29,
+          "points": 120,
+          "new_dancers": 11
+        },
+        {
+          "year": 2009,
+          "month": 7,
+          "unique_dancers": 49,
+          "points": 157,
+          "new_dancers": 15
+        },
+        {
+          "year": 2010,
+          "month": 7,
+          "unique_dancers": 59,
+          "points": 187,
+          "new_dancers": 13
+        },
+        {
+          "year": 2011,
+          "month": 7,
+          "unique_dancers": 69,
+          "points": 237,
+          "new_dancers": 10
+        },
+        {
+          "year": 2012,
+          "month": 7,
+          "unique_dancers": 60,
+          "points": 209,
+          "new_dancers": 4
+        }
+      ]
     },
     "85": {
       "event_id": 85,
@@ -2091,7 +4407,37 @@
         "points": 160,
         "new_dancers": 6,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2003,
+          "month": 6,
+          "unique_dancers": 40,
+          "points": 160,
+          "new_dancers": 10
+        },
+        {
+          "year": 2004,
+          "month": 6,
+          "unique_dancers": 39,
+          "points": 158,
+          "new_dancers": 6
+        },
+        {
+          "year": 2005,
+          "month": 6,
+          "unique_dancers": 54,
+          "points": 213,
+          "new_dancers": 14
+        },
+        {
+          "year": 2006,
+          "month": 6,
+          "unique_dancers": 40,
+          "points": 160,
+          "new_dancers": 6
+        }
+      ]
     },
     "86": {
       "event_id": 86,
@@ -2118,7 +4464,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2004,
+          "month": 7,
+          "unique_dancers": 17,
+          "points": 88,
+          "new_dancers": 5
+        },
+        {
+          "year": 2005,
+          "month": 7,
+          "unique_dancers": 10,
+          "points": 50,
+          "new_dancers": 1
+        },
+        {
+          "year": 2007,
+          "month": 7,
+          "unique_dancers": 16,
+          "points": 66,
+          "new_dancers": 6
+        },
+        {
+          "year": 2008,
+          "month": 7,
+          "unique_dancers": 29,
+          "points": 122,
+          "new_dancers": 1
+        },
+        {
+          "year": 2009,
+          "month": 7,
+          "unique_dancers": 19,
+          "points": 58,
+          "new_dancers": 7
+        }
+      ]
     },
     "87": {
       "event_id": 87,
@@ -2149,7 +4532,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 12,
+          "unique_dancers": 59,
+          "points": 200,
+          "new_dancers": 3
+        },
+        {
+          "year": 2022,
+          "month": 11,
+          "unique_dancers": 46,
+          "points": 169,
+          "new_dancers": 1
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 38,
+          "points": 125,
+          "new_dancers": 3
+        },
+        {
+          "year": 2024,
+          "month": 12,
+          "unique_dancers": 70,
+          "points": 253,
+          "new_dancers": 11
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 50,
+          "points": 165,
+          "new_dancers": 6
+        }
+      ]
     },
     "88": {
       "event_id": 88,
@@ -2167,7 +4587,16 @@
         "points": 211,
         "new_dancers": 17,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2003,
+          "month": 11,
+          "unique_dancers": 51,
+          "points": 211,
+          "new_dancers": 17
+        }
+      ]
     },
     "89": {
       "event_id": 89,
@@ -2185,7 +4614,30 @@
         "points": 206,
         "new_dancers": 5,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2003,
+          "month": 10,
+          "unique_dancers": 54,
+          "points": 258,
+          "new_dancers": 22
+        },
+        {
+          "year": 2004,
+          "month": 10,
+          "unique_dancers": 51,
+          "points": 208,
+          "new_dancers": 6
+        },
+        {
+          "year": 2005,
+          "month": 10,
+          "unique_dancers": 49,
+          "points": 206,
+          "new_dancers": 5
+        }
+      ]
     },
     "90": {
       "event_id": 90,
@@ -2203,7 +4655,16 @@
         "points": 158,
         "new_dancers": 20,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2003,
+          "month": 4,
+          "unique_dancers": 38,
+          "points": 158,
+          "new_dancers": 20
+        }
+      ]
     },
     "91": {
       "event_id": 91,
@@ -2242,7 +4703,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2007,
+          "month": 3,
+          "unique_dancers": 74,
+          "points": 299,
+          "new_dancers": 5
+        },
+        {
+          "year": 2008,
+          "month": 3,
+          "unique_dancers": 107,
+          "points": 440,
+          "new_dancers": 31
+        },
+        {
+          "year": 2009,
+          "month": 3,
+          "unique_dancers": 69,
+          "points": 272,
+          "new_dancers": 3
+        },
+        {
+          "year": 2010,
+          "month": 3,
+          "unique_dancers": 86,
+          "points": 340,
+          "new_dancers": 16
+        },
+        {
+          "year": 2011,
+          "month": 4,
+          "unique_dancers": 93,
+          "points": 335,
+          "new_dancers": 14
+        }
+      ]
     },
     "92": {
       "event_id": 92,
@@ -2281,7 +4779,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 3,
+          "unique_dancers": 170,
+          "points": 778,
+          "new_dancers": 21
+        },
+        {
+          "year": 2022,
+          "month": 3,
+          "unique_dancers": 153,
+          "points": 576,
+          "new_dancers": 21
+        },
+        {
+          "year": 2023,
+          "month": 3,
+          "unique_dancers": 185,
+          "points": 917,
+          "new_dancers": 23
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 191,
+          "points": 956,
+          "new_dancers": 17
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 180,
+          "points": 974,
+          "new_dancers": 23
+        }
+      ]
     },
     "93": {
       "event_id": 93,
@@ -2304,7 +4839,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2004,
+          "month": 5,
+          "unique_dancers": 12,
+          "points": 52,
+          "new_dancers": 1
+        },
+        {
+          "year": 2005,
+          "month": 5,
+          "unique_dancers": 20,
+          "points": 60,
+          "new_dancers": 2
+        },
+        {
+          "year": 2006,
+          "month": 5,
+          "unique_dancers": 13,
+          "points": 53,
+          "new_dancers": 0
+        },
+        {
+          "year": 2007,
+          "month": 5,
+          "unique_dancers": 10,
+          "points": 56,
+          "new_dancers": 0
+        }
+      ]
     },
     "94": {
       "event_id": 94,
@@ -2322,7 +4887,16 @@
         "points": 50,
         "new_dancers": 7,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2004,
+          "month": 6,
+          "unique_dancers": 10,
+          "points": 50,
+          "new_dancers": 7
+        }
+      ]
     },
     "95": {
       "event_id": 95,
@@ -2353,7 +4927,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2008,
+          "month": 6,
+          "unique_dancers": 50,
+          "points": 196,
+          "new_dancers": 14
+        },
+        {
+          "year": 2009,
+          "month": 6,
+          "unique_dancers": 48,
+          "points": 156,
+          "new_dancers": 11
+        },
+        {
+          "year": 2010,
+          "month": 9,
+          "unique_dancers": 63,
+          "points": 234,
+          "new_dancers": 10
+        },
+        {
+          "year": 2011,
+          "month": 9,
+          "unique_dancers": 60,
+          "points": 208,
+          "new_dancers": 11
+        },
+        {
+          "year": 2012,
+          "month": 9,
+          "unique_dancers": 82,
+          "points": 288,
+          "new_dancers": 10
+        }
+      ]
     },
     "96": {
       "event_id": 96,
@@ -2388,7 +4999,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 6,
+          "unique_dancers": 133,
+          "points": 517,
+          "new_dancers": 14
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 156,
+          "points": 657,
+          "new_dancers": 20
+        },
+        {
+          "year": 2024,
+          "month": 6,
+          "unique_dancers": 165,
+          "points": 734,
+          "new_dancers": 23
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 155,
+          "points": 773,
+          "new_dancers": 18
+        },
+        {
+          "year": 2026,
+          "month": 6,
+          "unique_dancers": 132,
+          "points": 581,
+          "new_dancers": 9
+        }
+      ]
     },
     "97": {
       "event_id": 97,
@@ -2419,7 +5067,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2007,
+          "month": 7,
+          "unique_dancers": 55,
+          "points": 232,
+          "new_dancers": 15
+        },
+        {
+          "year": 2008,
+          "month": 7,
+          "unique_dancers": 54,
+          "points": 233,
+          "new_dancers": 15
+        },
+        {
+          "year": 2009,
+          "month": 7,
+          "unique_dancers": 57,
+          "points": 187,
+          "new_dancers": 14
+        },
+        {
+          "year": 2010,
+          "month": 7,
+          "unique_dancers": 77,
+          "points": 297,
+          "new_dancers": 8
+        },
+        {
+          "year": 2011,
+          "month": 8,
+          "unique_dancers": 48,
+          "points": 155,
+          "new_dancers": 9
+        }
+      ]
     },
     "98": {
       "event_id": 98,
@@ -2437,7 +5122,16 @@
         "points": 141,
         "new_dancers": 14,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2004,
+          "month": 8,
+          "unique_dancers": 28,
+          "points": 141,
+          "new_dancers": 14
+        }
+      ]
     },
     "100": {
       "event_id": 100,
@@ -2464,7 +5158,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2007,
+          "month": 9,
+          "unique_dancers": 10,
+          "points": 42,
+          "new_dancers": 1
+        },
+        {
+          "year": 2008,
+          "month": 9,
+          "unique_dancers": 10,
+          "points": 42,
+          "new_dancers": 3
+        },
+        {
+          "year": 2010,
+          "month": 9,
+          "unique_dancers": 16,
+          "points": 54,
+          "new_dancers": 3
+        },
+        {
+          "year": 2013,
+          "month": 9,
+          "unique_dancers": 40,
+          "points": 130,
+          "new_dancers": 6
+        },
+        {
+          "year": 2014,
+          "month": 9,
+          "unique_dancers": 24,
+          "points": 79,
+          "new_dancers": 6
+        }
+      ]
     },
     "101": {
       "event_id": 101,
@@ -2482,7 +5213,16 @@
         "points": 50,
         "new_dancers": 0,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2004,
+          "month": 1,
+          "unique_dancers": 10,
+          "points": 50,
+          "new_dancers": 0
+        }
+      ]
     },
     "102": {
       "event_id": 102,
@@ -2500,7 +5240,16 @@
         "points": 110,
         "new_dancers": 9,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2005,
+          "month": 1,
+          "unique_dancers": 30,
+          "points": 110,
+          "new_dancers": 9
+        }
+      ]
     },
     "103": {
       "event_id": 103,
@@ -2518,7 +5267,16 @@
         "points": 156,
         "new_dancers": 16,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2005,
+          "month": 2,
+          "unique_dancers": 36,
+          "points": 156,
+          "new_dancers": 16
+        }
+      ]
     },
     "104": {
       "event_id": 104,
@@ -2553,7 +5311,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2007,
+          "month": 4,
+          "unique_dancers": 70,
+          "points": 266,
+          "new_dancers": 9
+        },
+        {
+          "year": 2008,
+          "month": 4,
+          "unique_dancers": 55,
+          "points": 238,
+          "new_dancers": 4
+        },
+        {
+          "year": 2009,
+          "month": 4,
+          "unique_dancers": 66,
+          "points": 230,
+          "new_dancers": 4
+        },
+        {
+          "year": 2010,
+          "month": 4,
+          "unique_dancers": 69,
+          "points": 260,
+          "new_dancers": 5
+        },
+        {
+          "year": 2011,
+          "month": 4,
+          "unique_dancers": 58,
+          "points": 190,
+          "new_dancers": 3
+        }
+      ]
     },
     "105": {
       "event_id": 105,
@@ -2588,7 +5383,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 5,
+          "unique_dancers": 35,
+          "points": 111,
+          "new_dancers": 11
+        },
+        {
+          "year": 2023,
+          "month": 5,
+          "unique_dancers": 54,
+          "points": 177,
+          "new_dancers": 10
+        },
+        {
+          "year": 2024,
+          "month": 5,
+          "unique_dancers": 47,
+          "points": 146,
+          "new_dancers": 9
+        },
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 47,
+          "points": 148,
+          "new_dancers": 9
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 53,
+          "points": 180,
+          "new_dancers": 8
+        }
+      ]
     },
     "106": {
       "event_id": 106,
@@ -2606,7 +5438,23 @@
         "points": 145,
         "new_dancers": 5,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2005,
+          "month": 4,
+          "unique_dancers": 27,
+          "points": 142,
+          "new_dancers": 9
+        },
+        {
+          "year": 2006,
+          "month": 4,
+          "unique_dancers": 28,
+          "points": 145,
+          "new_dancers": 5
+        }
+      ]
     },
     "107": {
       "event_id": 107,
@@ -2637,7 +5485,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2005,
+          "month": 4,
+          "unique_dancers": 50,
+          "points": 170,
+          "new_dancers": 4
+        },
+        {
+          "year": 2006,
+          "month": 4,
+          "unique_dancers": 46,
+          "points": 166,
+          "new_dancers": 4
+        },
+        {
+          "year": 2007,
+          "month": 4,
+          "unique_dancers": 40,
+          "points": 154,
+          "new_dancers": 5
+        }
+      ]
     },
     "108": {
       "event_id": 108,
@@ -2655,7 +5526,23 @@
         "points": 50,
         "new_dancers": 4,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2005,
+          "month": 5,
+          "unique_dancers": 12,
+          "points": 52,
+          "new_dancers": 2
+        },
+        {
+          "year": 2006,
+          "month": 5,
+          "unique_dancers": 10,
+          "points": 50,
+          "new_dancers": 4
+        }
+      ]
     },
     "109": {
       "event_id": 109,
@@ -2686,7 +5573,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 7,
+          "unique_dancers": 26,
+          "points": 58,
+          "new_dancers": 3
+        },
+        {
+          "year": 2022,
+          "month": 6,
+          "unique_dancers": 44,
+          "points": 120,
+          "new_dancers": 15
+        },
+        {
+          "year": 2024,
+          "month": 6,
+          "unique_dancers": 46,
+          "points": 131,
+          "new_dancers": 11
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 65,
+          "points": 230,
+          "new_dancers": 13
+        },
+        {
+          "year": 2026,
+          "month": 6,
+          "unique_dancers": 67,
+          "points": 230,
+          "new_dancers": 13
+        }
+      ]
     },
     "110": {
       "event_id": 110,
@@ -2709,7 +5633,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2005,
+          "month": 7,
+          "unique_dancers": 20,
+          "points": 100,
+          "new_dancers": 4
+        },
+        {
+          "year": 2006,
+          "month": 7,
+          "unique_dancers": 43,
+          "points": 163,
+          "new_dancers": 4
+        },
+        {
+          "year": 2007,
+          "month": 7,
+          "unique_dancers": 18,
+          "points": 84,
+          "new_dancers": 6
+        }
+      ]
     },
     "111": {
       "event_id": 111,
@@ -2727,7 +5674,23 @@
         "points": 212,
         "new_dancers": 7,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2005,
+          "month": 8,
+          "unique_dancers": 50,
+          "points": 170,
+          "new_dancers": 3
+        },
+        {
+          "year": 2006,
+          "month": 8,
+          "unique_dancers": 51,
+          "points": 212,
+          "new_dancers": 7
+        }
+      ]
     },
     "112": {
       "event_id": 112,
@@ -2745,7 +5708,23 @@
         "points": 46,
         "new_dancers": 2,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2005,
+          "month": 10,
+          "unique_dancers": 20,
+          "points": 100,
+          "new_dancers": 3
+        },
+        {
+          "year": 2006,
+          "month": 10,
+          "unique_dancers": 9,
+          "points": 46,
+          "new_dancers": 2
+        }
+      ]
     },
     "113": {
       "event_id": 113,
@@ -2763,7 +5742,23 @@
         "points": 100,
         "new_dancers": 3,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2005,
+          "month": 11,
+          "unique_dancers": 29,
+          "points": 147,
+          "new_dancers": 14
+        },
+        {
+          "year": 2006,
+          "month": 11,
+          "unique_dancers": 20,
+          "points": 100,
+          "new_dancers": 3
+        }
+      ]
     },
     "114": {
       "event_id": 114,
@@ -2794,7 +5789,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2006,
+          "month": 3,
+          "unique_dancers": 43,
+          "points": 183,
+          "new_dancers": 3
+        },
+        {
+          "year": 2007,
+          "month": 3,
+          "unique_dancers": 39,
+          "points": 169,
+          "new_dancers": 1
+        }
+      ]
     },
     "115": {
       "event_id": 115,
@@ -2821,7 +5832,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2006,
+          "month": 2,
+          "unique_dancers": 35,
+          "points": 135,
+          "new_dancers": 9
+        },
+        {
+          "year": 2007,
+          "month": 2,
+          "unique_dancers": 40,
+          "points": 154,
+          "new_dancers": 4
+        },
+        {
+          "year": 2008,
+          "month": 2,
+          "unique_dancers": 16,
+          "points": 66,
+          "new_dancers": 4
+        },
+        {
+          "year": 2010,
+          "month": 2,
+          "unique_dancers": 29,
+          "points": 87,
+          "new_dancers": 12
+        }
+      ]
     },
     "116": {
       "event_id": 116,
@@ -2852,7 +5893,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2009,
+          "month": 4,
+          "unique_dancers": 20,
+          "points": 70,
+          "new_dancers": 9
+        },
+        {
+          "year": 2010,
+          "month": 4,
+          "unique_dancers": 10,
+          "points": 30,
+          "new_dancers": 3
+        },
+        {
+          "year": 2024,
+          "month": 4,
+          "unique_dancers": 44,
+          "points": 148,
+          "new_dancers": 12
+        },
+        {
+          "year": 2025,
+          "month": 4,
+          "unique_dancers": 58,
+          "points": 221,
+          "new_dancers": 13
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 67,
+          "points": 264,
+          "new_dancers": 13
+        }
+      ]
     },
     "117": {
       "event_id": 117,
@@ -2883,7 +5961,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 6,
+          "unique_dancers": 39,
+          "points": 119,
+          "new_dancers": 4
+        },
+        {
+          "year": 2023,
+          "month": 6,
+          "unique_dancers": 55,
+          "points": 170,
+          "new_dancers": 10
+        },
+        {
+          "year": 2024,
+          "month": 6,
+          "unique_dancers": 38,
+          "points": 119,
+          "new_dancers": 8
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 53,
+          "points": 177,
+          "new_dancers": 10
+        },
+        {
+          "year": 2026,
+          "month": 6,
+          "unique_dancers": 48,
+          "points": 173,
+          "new_dancers": 7
+        }
+      ]
     },
     "119": {
       "event_id": 119,
@@ -2918,7 +6033,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 8,
+          "unique_dancers": 52,
+          "points": 152,
+          "new_dancers": 10
+        },
+        {
+          "year": 2022,
+          "month": 8,
+          "unique_dancers": 60,
+          "points": 174,
+          "new_dancers": 9
+        },
+        {
+          "year": 2023,
+          "month": 8,
+          "unique_dancers": 60,
+          "points": 189,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 61,
+          "points": 188,
+          "new_dancers": 8
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 65,
+          "points": 208,
+          "new_dancers": 8
+        }
+      ]
     },
     "120": {
       "event_id": 120,
@@ -2945,7 +6097,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 8,
+          "unique_dancers": 38,
+          "points": 118,
+          "new_dancers": 10
+        },
+        {
+          "year": 2022,
+          "month": 8,
+          "unique_dancers": 56,
+          "points": 171,
+          "new_dancers": 8
+        },
+        {
+          "year": 2023,
+          "month": 8,
+          "unique_dancers": 57,
+          "points": 176,
+          "new_dancers": 12
+        },
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 39,
+          "points": 117,
+          "new_dancers": 9
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 23,
+          "points": 73,
+          "new_dancers": 4
+        }
+      ]
     },
     "121": {
       "event_id": 121,
@@ -2976,7 +6165,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 5,
+          "unique_dancers": 62,
+          "points": 214,
+          "new_dancers": 3
+        },
+        {
+          "year": 2023,
+          "month": 5,
+          "unique_dancers": 57,
+          "points": 208,
+          "new_dancers": 7
+        },
+        {
+          "year": 2024,
+          "month": 5,
+          "unique_dancers": 54,
+          "points": 170,
+          "new_dancers": 12
+        },
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 43,
+          "points": 119,
+          "new_dancers": 10
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 41,
+          "points": 129,
+          "new_dancers": 8
+        }
+      ]
     },
     "122": {
       "event_id": 122,
@@ -3003,7 +6229,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2006,
+          "month": 8,
+          "unique_dancers": 34,
+          "points": 133,
+          "new_dancers": 5
+        },
+        {
+          "year": 2007,
+          "month": 8,
+          "unique_dancers": 29,
+          "points": 120,
+          "new_dancers": 4
+        },
+        {
+          "year": 2008,
+          "month": 8,
+          "unique_dancers": 18,
+          "points": 79,
+          "new_dancers": 2
+        }
+      ]
     },
     "123": {
       "event_id": 123,
@@ -3030,7 +6279,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2006,
+          "month": 7,
+          "unique_dancers": 38,
+          "points": 158,
+          "new_dancers": 3
+        },
+        {
+          "year": 2007,
+          "month": 7,
+          "unique_dancers": 30,
+          "points": 126,
+          "new_dancers": 4
+        }
+      ]
     },
     "124": {
       "event_id": 124,
@@ -3048,7 +6313,16 @@
         "points": 139,
         "new_dancers": 10,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2006,
+          "month": 10,
+          "unique_dancers": 39,
+          "points": 139,
+          "new_dancers": 10
+        }
+      ]
     },
     "125": {
       "event_id": 125,
@@ -3083,7 +6357,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 10,
+          "unique_dancers": 111,
+          "points": 396,
+          "new_dancers": 7
+        },
+        {
+          "year": 2022,
+          "month": 10,
+          "unique_dancers": 114,
+          "points": 448,
+          "new_dancers": 14
+        },
+        {
+          "year": 2023,
+          "month": 10,
+          "unique_dancers": 122,
+          "points": 480,
+          "new_dancers": 23
+        },
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 137,
+          "points": 618,
+          "new_dancers": 23
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 122,
+          "points": 544,
+          "new_dancers": 22
+        }
+      ]
     },
     "126": {
       "event_id": 126,
@@ -3122,7 +6433,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2008,
+          "month": 10,
+          "unique_dancers": 60,
+          "points": 258,
+          "new_dancers": 8
+        },
+        {
+          "year": 2009,
+          "month": 10,
+          "unique_dancers": 88,
+          "points": 288,
+          "new_dancers": 13
+        },
+        {
+          "year": 2010,
+          "month": 12,
+          "unique_dancers": 76,
+          "points": 302,
+          "new_dancers": 9
+        },
+        {
+          "year": 2011,
+          "month": 12,
+          "unique_dancers": 88,
+          "points": 317,
+          "new_dancers": 10
+        },
+        {
+          "year": 2012,
+          "month": 12,
+          "unique_dancers": 97,
+          "points": 378,
+          "new_dancers": 16
+        }
+      ]
     },
     "127": {
       "event_id": 127,
@@ -3149,7 +6497,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2006,
+          "month": 10,
+          "unique_dancers": 20,
+          "points": 100,
+          "new_dancers": 1
+        },
+        {
+          "year": 2007,
+          "month": 10,
+          "unique_dancers": 10,
+          "points": 42,
+          "new_dancers": 2
+        },
+        {
+          "year": 2008,
+          "month": 10,
+          "unique_dancers": 30,
+          "points": 126,
+          "new_dancers": 9
+        }
+      ]
     },
     "128": {
       "event_id": 128,
@@ -3167,7 +6538,16 @@
         "points": 58,
         "new_dancers": 7,
         "tiers": {}
-      }
+      },
+      "history": [
+        {
+          "year": 2006,
+          "month": 10,
+          "unique_dancers": 18,
+          "points": 58,
+          "new_dancers": 7
+        }
+      ]
     },
     "129": {
       "event_id": 129,
@@ -3198,7 +6578,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2006,
+          "month": 11,
+          "unique_dancers": 40,
+          "points": 160,
+          "new_dancers": 7
+        },
+        {
+          "year": 2008,
+          "month": 11,
+          "unique_dancers": 38,
+          "points": 149,
+          "new_dancers": 4
+        },
+        {
+          "year": 2009,
+          "month": 11,
+          "unique_dancers": 38,
+          "points": 126,
+          "new_dancers": 7
+        }
+      ]
     },
     "130": {
       "event_id": 130,
@@ -3221,7 +6624,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2006,
+          "month": 9,
+          "unique_dancers": 10,
+          "points": 50,
+          "new_dancers": 7
+        },
+        {
+          "year": 2007,
+          "month": 9,
+          "unique_dancers": 10,
+          "points": 42,
+          "new_dancers": 5
+        },
+        {
+          "year": 2008,
+          "month": 9,
+          "unique_dancers": 10,
+          "points": 42,
+          "new_dancers": 6
+        },
+        {
+          "year": 2009,
+          "month": 9,
+          "unique_dancers": 8,
+          "points": 27,
+          "new_dancers": 2
+        },
+        {
+          "year": 2010,
+          "month": 9,
+          "unique_dancers": 10,
+          "points": 30,
+          "new_dancers": 6
+        }
+      ]
     },
     "131": {
       "event_id": 131,
@@ -3256,7 +6696,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 9,
+          "unique_dancers": 80,
+          "points": 290,
+          "new_dancers": 10
+        },
+        {
+          "year": 2022,
+          "month": 9,
+          "unique_dancers": 77,
+          "points": 263,
+          "new_dancers": 10
+        },
+        {
+          "year": 2023,
+          "month": 9,
+          "unique_dancers": 80,
+          "points": 289,
+          "new_dancers": 9
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 105,
+          "points": 408,
+          "new_dancers": 6
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 101,
+          "points": 431,
+          "new_dancers": 11
+        }
+      ]
     },
     "132": {
       "event_id": 132,
@@ -3291,7 +6768,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 4,
+          "unique_dancers": 75,
+          "points": 257,
+          "new_dancers": 12
+        },
+        {
+          "year": 2019,
+          "month": 4,
+          "unique_dancers": 50,
+          "points": 161,
+          "new_dancers": 9
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 61,
+          "points": 199,
+          "new_dancers": 19
+        },
+        {
+          "year": 2025,
+          "month": 4,
+          "unique_dancers": 62,
+          "points": 231,
+          "new_dancers": 13
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 73,
+          "points": 284,
+          "new_dancers": 8
+        }
+      ]
     },
     "134": {
       "event_id": 134,
@@ -3326,7 +6840,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 4,
+          "unique_dancers": 84,
+          "points": 296,
+          "new_dancers": 2
+        },
+        {
+          "year": 2019,
+          "month": 4,
+          "unique_dancers": 64,
+          "points": 231,
+          "new_dancers": 5
+        },
+        {
+          "year": 2022,
+          "month": 5,
+          "unique_dancers": 51,
+          "points": 162,
+          "new_dancers": 4
+        },
+        {
+          "year": 2023,
+          "month": 5,
+          "unique_dancers": 55,
+          "points": 188,
+          "new_dancers": 3
+        },
+        {
+          "year": 2024,
+          "month": 5,
+          "unique_dancers": 58,
+          "points": 189,
+          "new_dancers": 9
+        }
+      ]
     },
     "135": {
       "event_id": 135,
@@ -3365,7 +6916,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 9,
+          "unique_dancers": 96,
+          "points": 468,
+          "new_dancers": 3
+        },
+        {
+          "year": 2022,
+          "month": 9,
+          "unique_dancers": 126,
+          "points": 594,
+          "new_dancers": 6
+        },
+        {
+          "year": 2023,
+          "month": 9,
+          "unique_dancers": 126,
+          "points": 601,
+          "new_dancers": 8
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 141,
+          "points": 617,
+          "new_dancers": 4
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 128,
+          "points": 635,
+          "new_dancers": 7
+        }
+      ]
     },
     "136": {
       "event_id": 136,
@@ -3388,7 +6976,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2007,
+          "month": 10,
+          "unique_dancers": 8,
+          "points": 39,
+          "new_dancers": 1
+        },
+        {
+          "year": 2009,
+          "month": 10,
+          "unique_dancers": 8,
+          "points": 27,
+          "new_dancers": 2
+        }
+      ]
     },
     "137": {
       "event_id": 137,
@@ -3423,7 +7027,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 8,
+          "unique_dancers": 92,
+          "points": 342,
+          "new_dancers": 6
+        },
+        {
+          "year": 2018,
+          "month": 8,
+          "unique_dancers": 60,
+          "points": 216,
+          "new_dancers": 2
+        },
+        {
+          "year": 2019,
+          "month": 11,
+          "unique_dancers": 52,
+          "points": 170,
+          "new_dancers": 3
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 56,
+          "points": 202,
+          "new_dancers": 6
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 83,
+          "points": 347,
+          "new_dancers": 8
+        }
+      ]
     },
     "138": {
       "event_id": 138,
@@ -3446,7 +7087,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2007,
+          "month": 11,
+          "unique_dancers": 35,
+          "points": 149,
+          "new_dancers": 9
+        },
+        {
+          "year": 2008,
+          "month": 11,
+          "unique_dancers": 27,
+          "points": 122,
+          "new_dancers": 5
+        }
+      ]
     },
     "139": {
       "event_id": 139,
@@ -3481,7 +7138,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2007,
+          "month": 12,
+          "unique_dancers": 69,
+          "points": 264,
+          "new_dancers": 7
+        },
+        {
+          "year": 2009,
+          "month": 12,
+          "unique_dancers": 80,
+          "points": 270,
+          "new_dancers": 4
+        },
+        {
+          "year": 2010,
+          "month": 1,
+          "unique_dancers": 89,
+          "points": 298,
+          "new_dancers": 7
+        },
+        {
+          "year": 2011,
+          "month": 1,
+          "unique_dancers": 69,
+          "points": 257,
+          "new_dancers": 6
+        }
+      ]
     },
     "140": {
       "event_id": 140,
@@ -3504,7 +7191,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2007,
+          "month": 12,
+          "unique_dancers": 20,
+          "points": 84,
+          "new_dancers": 12
+        }
+      ]
     },
     "141": {
       "event_id": 141,
@@ -3543,7 +7239,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 1,
+          "unique_dancers": 107,
+          "points": 370,
+          "new_dancers": 10
+        },
+        {
+          "year": 2020,
+          "month": 1,
+          "unique_dancers": 111,
+          "points": 382,
+          "new_dancers": 8
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 132,
+          "points": 543,
+          "new_dancers": 25
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 144,
+          "points": 631,
+          "new_dancers": 20
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 142,
+          "points": 618,
+          "new_dancers": 19
+        }
+      ]
     },
     "142": {
       "event_id": 142,
@@ -3582,7 +7315,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 3,
+          "unique_dancers": 110,
+          "points": 411,
+          "new_dancers": 19
+        },
+        {
+          "year": 2023,
+          "month": 3,
+          "unique_dancers": 123,
+          "points": 491,
+          "new_dancers": 8
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 131,
+          "points": 559,
+          "new_dancers": 22
+        },
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 160,
+          "points": 764,
+          "new_dancers": 20
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 154,
+          "points": 732,
+          "new_dancers": 20
+        }
+      ]
     },
     "143": {
       "event_id": 143,
@@ -3617,7 +7387,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 3,
+          "unique_dancers": 59,
+          "points": 182,
+          "new_dancers": 4
+        },
+        {
+          "year": 2019,
+          "month": 3,
+          "unique_dancers": 52,
+          "points": 160,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 74,
+          "points": 317,
+          "new_dancers": 2
+        },
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 86,
+          "points": 386,
+          "new_dancers": 5
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 83,
+          "points": 317,
+          "new_dancers": 11
+        }
+      ]
     },
     "144": {
       "event_id": 144,
@@ -3644,7 +7451,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 5,
+          "unique_dancers": 64,
+          "points": 214,
+          "new_dancers": 10
+        },
+        {
+          "year": 2022,
+          "month": 5,
+          "unique_dancers": 34,
+          "points": 98,
+          "new_dancers": 8
+        },
+        {
+          "year": 2024,
+          "month": 5,
+          "unique_dancers": 22,
+          "points": 65,
+          "new_dancers": 6
+        },
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 42,
+          "points": 136,
+          "new_dancers": 7
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 51,
+          "points": 228,
+          "new_dancers": 5
+        }
+      ]
     },
     "145": {
       "event_id": 145,
@@ -3675,7 +7519,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2008,
+          "month": 5,
+          "unique_dancers": 40,
+          "points": 176,
+          "new_dancers": 15
+        },
+        {
+          "year": 2009,
+          "month": 5,
+          "unique_dancers": 48,
+          "points": 160,
+          "new_dancers": 12
+        },
+        {
+          "year": 2010,
+          "month": 5,
+          "unique_dancers": 40,
+          "points": 130,
+          "new_dancers": 6
+        }
+      ]
     },
     "146": {
       "event_id": 146,
@@ -3710,7 +7577,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2008,
+          "month": 7,
+          "unique_dancers": 38,
+          "points": 147,
+          "new_dancers": 2
+        },
+        {
+          "year": 2009,
+          "month": 7,
+          "unique_dancers": 30,
+          "points": 90,
+          "new_dancers": 6
+        },
+        {
+          "year": 2011,
+          "month": 7,
+          "unique_dancers": 54,
+          "points": 179,
+          "new_dancers": 10
+        },
+        {
+          "year": 2012,
+          "month": 7,
+          "unique_dancers": 60,
+          "points": 226,
+          "new_dancers": 5
+        }
+      ]
     },
     "147": {
       "event_id": 147,
@@ -3745,7 +7642,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 7,
+          "unique_dancers": 79,
+          "points": 287,
+          "new_dancers": 11
+        },
+        {
+          "year": 2019,
+          "month": 7,
+          "unique_dancers": 62,
+          "points": 182,
+          "new_dancers": 5
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 52,
+          "points": 160,
+          "new_dancers": 8
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 74,
+          "points": 282,
+          "new_dancers": 14
+        },
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 78,
+          "points": 321,
+          "new_dancers": 15
+        }
+      ]
     },
     "148": {
       "event_id": 148,
@@ -3776,7 +7710,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 7,
+          "unique_dancers": 26,
+          "points": 76,
+          "new_dancers": 0
+        },
+        {
+          "year": 2022,
+          "month": 7,
+          "unique_dancers": 56,
+          "points": 179,
+          "new_dancers": 6
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 50,
+          "points": 160,
+          "new_dancers": 9
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 34,
+          "points": 99,
+          "new_dancers": 9
+        },
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 37,
+          "points": 141,
+          "new_dancers": 9
+        }
+      ]
     },
     "149": {
       "event_id": 149,
@@ -3811,7 +7782,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 7,
+          "unique_dancers": 40,
+          "points": 127,
+          "new_dancers": 1
+        },
+        {
+          "year": 2022,
+          "month": 7,
+          "unique_dancers": 24,
+          "points": 68,
+          "new_dancers": 0
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 71,
+          "points": 257,
+          "new_dancers": 11
+        },
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 83,
+          "points": 319,
+          "new_dancers": 11
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 99,
+          "points": 413,
+          "new_dancers": 21
+        }
+      ]
     },
     "150": {
       "event_id": 150,
@@ -3842,7 +7850,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2008,
+          "month": 10,
+          "unique_dancers": 34,
+          "points": 145,
+          "new_dancers": 1
+        }
+      ]
     },
     "151": {
       "event_id": 151,
@@ -3873,7 +7890,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2008,
+          "month": 11,
+          "unique_dancers": 10,
+          "points": 42,
+          "new_dancers": 3
+        },
+        {
+          "year": 2009,
+          "month": 11,
+          "unique_dancers": 20,
+          "points": 60,
+          "new_dancers": 3
+        },
+        {
+          "year": 2010,
+          "month": 11,
+          "unique_dancers": 19,
+          "points": 73,
+          "new_dancers": 4
+        },
+        {
+          "year": 2011,
+          "month": 11,
+          "unique_dancers": 36,
+          "points": 112,
+          "new_dancers": 6
+        }
+      ]
     },
     "152": {
       "event_id": 152,
@@ -3904,7 +7951,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2009,
+          "month": 12,
+          "unique_dancers": 29,
+          "points": 89,
+          "new_dancers": 0
+        },
+        {
+          "year": 2012,
+          "month": 1,
+          "unique_dancers": 39,
+          "points": 135,
+          "new_dancers": 2
+        },
+        {
+          "year": 2015,
+          "month": 1,
+          "unique_dancers": 45,
+          "points": 150,
+          "new_dancers": 5
+        }
+      ]
     },
     "153": {
       "event_id": 153,
@@ -3939,7 +8009,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 3,
+          "unique_dancers": 77,
+          "points": 260,
+          "new_dancers": 12
+        },
+        {
+          "year": 2023,
+          "month": 3,
+          "unique_dancers": 93,
+          "points": 331,
+          "new_dancers": 22
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 110,
+          "points": 412,
+          "new_dancers": 22
+        },
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 110,
+          "points": 501,
+          "new_dancers": 17
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 101,
+          "points": 389,
+          "new_dancers": 16
+        }
+      ]
     },
     "154": {
       "event_id": 154,
@@ -3978,7 +8085,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 4,
+          "unique_dancers": 92,
+          "points": 345,
+          "new_dancers": 2
+        },
+        {
+          "year": 2018,
+          "month": 4,
+          "unique_dancers": 95,
+          "points": 336,
+          "new_dancers": 1
+        },
+        {
+          "year": 2019,
+          "month": 4,
+          "unique_dancers": 85,
+          "points": 296,
+          "new_dancers": 3
+        },
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 138,
+          "points": 670,
+          "new_dancers": 20
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 154,
+          "points": 755,
+          "new_dancers": 19
+        }
+      ]
     },
     "155": {
       "event_id": 155,
@@ -4005,7 +8149,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2009,
+          "month": 7,
+          "unique_dancers": 20,
+          "points": 70,
+          "new_dancers": 17
+        },
+        {
+          "year": 2010,
+          "month": 7,
+          "unique_dancers": 30,
+          "points": 100,
+          "new_dancers": 10
+        },
+        {
+          "year": 2011,
+          "month": 7,
+          "unique_dancers": 30,
+          "points": 100,
+          "new_dancers": 10
+        }
+      ]
     },
     "156": {
       "event_id": 156,
@@ -4036,7 +8203,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 7,
+          "unique_dancers": 14,
+          "points": 34,
+          "new_dancers": 3
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 29,
+          "points": 95,
+          "new_dancers": 0
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 39,
+          "points": 125,
+          "new_dancers": 6
+        },
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 41,
+          "points": 148,
+          "new_dancers": 2
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 47,
+          "points": 171,
+          "new_dancers": 4
+        }
+      ]
     },
     "157": {
       "event_id": 157,
@@ -4071,7 +8275,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 8,
+          "unique_dancers": 30,
+          "points": 102,
+          "new_dancers": 9
+        },
+        {
+          "year": 2022,
+          "month": 8,
+          "unique_dancers": 35,
+          "points": 98,
+          "new_dancers": 5
+        },
+        {
+          "year": 2023,
+          "month": 8,
+          "unique_dancers": 49,
+          "points": 157,
+          "new_dancers": 10
+        },
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 63,
+          "points": 215,
+          "new_dancers": 7
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 75,
+          "points": 273,
+          "new_dancers": 9
+        }
+      ]
     },
     "159": {
       "event_id": 159,
@@ -4098,7 +8339,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2011,
+          "month": 8,
+          "unique_dancers": 44,
+          "points": 152,
+          "new_dancers": 8
+        },
+        {
+          "year": 2012,
+          "month": 8,
+          "unique_dancers": 40,
+          "points": 130,
+          "new_dancers": 12
+        },
+        {
+          "year": 2013,
+          "month": 8,
+          "unique_dancers": 39,
+          "points": 127,
+          "new_dancers": 6
+        },
+        {
+          "year": 2014,
+          "month": 8,
+          "unique_dancers": 30,
+          "points": 100,
+          "new_dancers": 2
+        },
+        {
+          "year": 2015,
+          "month": 8,
+          "unique_dancers": 19,
+          "points": 56,
+          "new_dancers": 3
+        }
+      ]
     },
     "160": {
       "event_id": 160,
@@ -4129,7 +8407,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2008,
+          "month": 7,
+          "unique_dancers": 30,
+          "points": 1,
+          "new_dancers": 2
+        },
+        {
+          "year": 2009,
+          "month": 7,
+          "unique_dancers": 33,
+          "points": 120,
+          "new_dancers": 5
+        }
+      ]
     },
     "161": {
       "event_id": 161,
@@ -4160,7 +8454,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2010,
+          "month": 4,
+          "unique_dancers": 28,
+          "points": 84,
+          "new_dancers": 4
+        },
+        {
+          "year": 2011,
+          "month": 4,
+          "unique_dancers": 39,
+          "points": 129,
+          "new_dancers": 6
+        }
+      ]
     },
     "162": {
       "event_id": 162,
@@ -4195,7 +8505,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 6,
+          "unique_dancers": 100,
+          "points": 347,
+          "new_dancers": 6
+        },
+        {
+          "year": 2023,
+          "month": 6,
+          "unique_dancers": 86,
+          "points": 311,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 6,
+          "unique_dancers": 93,
+          "points": 347,
+          "new_dancers": 12
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 91,
+          "points": 399,
+          "new_dancers": 2
+        },
+        {
+          "year": 2026,
+          "month": 6,
+          "unique_dancers": 86,
+          "points": 360,
+          "new_dancers": 8
+        }
+      ]
     },
     "163": {
       "event_id": 163,
@@ -4226,7 +8573,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2010,
+          "month": 5,
+          "unique_dancers": 30,
+          "points": 90,
+          "new_dancers": 4
+        },
+        {
+          "year": 2011,
+          "month": 5,
+          "unique_dancers": 49,
+          "points": 158,
+          "new_dancers": 13
+        },
+        {
+          "year": 2012,
+          "month": 5,
+          "unique_dancers": 59,
+          "points": 220,
+          "new_dancers": 15
+        },
+        {
+          "year": 2013,
+          "month": 5,
+          "unique_dancers": 65,
+          "points": 210,
+          "new_dancers": 17
+        },
+        {
+          "year": 2014,
+          "month": 5,
+          "unique_dancers": 49,
+          "points": 157,
+          "new_dancers": 16
+        }
+      ]
     },
     "164": {
       "event_id": 164,
@@ -4261,7 +8645,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 7,
+          "unique_dancers": 85,
+          "points": 296,
+          "new_dancers": 12
+        },
+        {
+          "year": 2019,
+          "month": 7,
+          "unique_dancers": 73,
+          "points": 215,
+          "new_dancers": 17
+        },
+        {
+          "year": 2023,
+          "month": 8,
+          "unique_dancers": 73,
+          "points": 266,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 120,
+          "points": 473,
+          "new_dancers": 18
+        },
+        {
+          "year": 2026,
+          "month": 8,
+          "unique_dancers": 73,
+          "points": 293,
+          "new_dancers": 9
+        }
+      ]
     },
     "165": {
       "event_id": 165,
@@ -4300,7 +8721,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 9,
+          "unique_dancers": 39,
+          "points": 118,
+          "new_dancers": 1
+        },
+        {
+          "year": 2022,
+          "month": 10,
+          "unique_dancers": 61,
+          "points": 193,
+          "new_dancers": 10
+        },
+        {
+          "year": 2023,
+          "month": 9,
+          "unique_dancers": 101,
+          "points": 415,
+          "new_dancers": 16
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 134,
+          "points": 570,
+          "new_dancers": 24
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 123,
+          "points": 538,
+          "new_dancers": 16
+        }
+      ]
     },
     "166": {
       "event_id": 166,
@@ -4331,7 +8789,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2013,
+          "month": 11,
+          "unique_dancers": 68,
+          "points": 230,
+          "new_dancers": 3
+        },
+        {
+          "year": 2015,
+          "month": 11,
+          "unique_dancers": 55,
+          "points": 190,
+          "new_dancers": 5
+        },
+        {
+          "year": 2017,
+          "month": 11,
+          "unique_dancers": 50,
+          "points": 170,
+          "new_dancers": 4
+        },
+        {
+          "year": 2018,
+          "month": 11,
+          "unique_dancers": 40,
+          "points": 126,
+          "new_dancers": 5
+        },
+        {
+          "year": 2019,
+          "month": 11,
+          "unique_dancers": 49,
+          "points": 149,
+          "new_dancers": 3
+        }
+      ]
     },
     "167": {
       "event_id": 167,
@@ -4366,7 +8861,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 9,
+          "unique_dancers": 35,
+          "points": 96,
+          "new_dancers": 3
+        },
+        {
+          "year": 2022,
+          "month": 9,
+          "unique_dancers": 41,
+          "points": 120,
+          "new_dancers": 9
+        },
+        {
+          "year": 2023,
+          "month": 9,
+          "unique_dancers": 44,
+          "points": 151,
+          "new_dancers": 4
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 66,
+          "points": 266,
+          "new_dancers": 10
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 64,
+          "points": 260,
+          "new_dancers": 6
+        }
+      ]
     },
     "168": {
       "event_id": 168,
@@ -4397,7 +8929,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2011,
+          "month": 2,
+          "unique_dancers": 30,
+          "points": 112,
+          "new_dancers": 10
+        },
+        {
+          "year": 2012,
+          "month": 2,
+          "unique_dancers": 29,
+          "points": 98,
+          "new_dancers": 8
+        },
+        {
+          "year": 2013,
+          "month": 2,
+          "unique_dancers": 30,
+          "points": 100,
+          "new_dancers": 4
+        },
+        {
+          "year": 2014,
+          "month": 2,
+          "unique_dancers": 52,
+          "points": 162,
+          "new_dancers": 8
+        }
+      ]
     },
     "169": {
       "event_id": 169,
@@ -4432,7 +8994,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 3,
+          "unique_dancers": 74,
+          "points": 249,
+          "new_dancers": 20
+        },
+        {
+          "year": 2016,
+          "month": 2,
+          "unique_dancers": 68,
+          "points": 227,
+          "new_dancers": 10
+        },
+        {
+          "year": 2017,
+          "month": 2,
+          "unique_dancers": 65,
+          "points": 224,
+          "new_dancers": 6
+        },
+        {
+          "year": 2018,
+          "month": 2,
+          "unique_dancers": 62,
+          "points": 181,
+          "new_dancers": 7
+        },
+        {
+          "year": 2019,
+          "month": 2,
+          "unique_dancers": 63,
+          "points": 196,
+          "new_dancers": 4
+        }
+      ]
     },
     "170": {
       "event_id": 170,
@@ -4467,7 +9066,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2016,
+          "month": 3,
+          "unique_dancers": 69,
+          "points": 251,
+          "new_dancers": 5
+        },
+        {
+          "year": 2017,
+          "month": 4,
+          "unique_dancers": 55,
+          "points": 196,
+          "new_dancers": 4
+        },
+        {
+          "year": 2018,
+          "month": 3,
+          "unique_dancers": 64,
+          "points": 226,
+          "new_dancers": 8
+        },
+        {
+          "year": 2019,
+          "month": 3,
+          "unique_dancers": 67,
+          "points": 216,
+          "new_dancers": 9
+        },
+        {
+          "year": 2021,
+          "month": 4,
+          "unique_dancers": 65,
+          "points": 206,
+          "new_dancers": 8
+        }
+      ]
     },
     "171": {
       "event_id": 171,
@@ -4494,7 +9130,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2011,
+          "month": 2,
+          "unique_dancers": 37,
+          "points": 127,
+          "new_dancers": 9
+        }
+      ]
     },
     "172": {
       "event_id": 172,
@@ -4521,7 +9166,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2011,
+          "month": 4,
+          "unique_dancers": 39,
+          "points": 132,
+          "new_dancers": 2
+        },
+        {
+          "year": 2012,
+          "month": 4,
+          "unique_dancers": 35,
+          "points": 130,
+          "new_dancers": 4
+        },
+        {
+          "year": 2013,
+          "month": 4,
+          "unique_dancers": 38,
+          "points": 133,
+          "new_dancers": 4
+        },
+        {
+          "year": 2014,
+          "month": 5,
+          "unique_dancers": 19,
+          "points": 58,
+          "new_dancers": 3
+        }
+      ]
     },
     "173": {
       "event_id": 173,
@@ -4548,7 +9223,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2011,
+          "month": 5,
+          "unique_dancers": 30,
+          "points": 90,
+          "new_dancers": 23
+        }
+      ]
     },
     "174": {
       "event_id": 174,
@@ -4583,7 +9267,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 6,
+          "unique_dancers": 30,
+          "points": 97,
+          "new_dancers": 6
+        },
+        {
+          "year": 2023,
+          "month": 5,
+          "unique_dancers": 44,
+          "points": 160,
+          "new_dancers": 4
+        },
+        {
+          "year": 2024,
+          "month": 5,
+          "unique_dancers": 63,
+          "points": 236,
+          "new_dancers": 6
+        },
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 63,
+          "points": 236,
+          "new_dancers": 4
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 54,
+          "points": 230,
+          "new_dancers": 2
+        }
+      ]
     },
     "175": {
       "event_id": 175,
@@ -4622,7 +9343,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 5,
+          "unique_dancers": 129,
+          "points": 513,
+          "new_dancers": 19
+        },
+        {
+          "year": 2023,
+          "month": 5,
+          "unique_dancers": 156,
+          "points": 678,
+          "new_dancers": 12
+        },
+        {
+          "year": 2024,
+          "month": 5,
+          "unique_dancers": 182,
+          "points": 824,
+          "new_dancers": 20
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 140,
+          "points": 663,
+          "new_dancers": 8
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 140,
+          "points": 648,
+          "new_dancers": 14
+        }
+      ]
     },
     "177": {
       "event_id": 177,
@@ -4657,7 +9415,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 9,
+          "unique_dancers": 82,
+          "points": 276,
+          "new_dancers": 5
+        },
+        {
+          "year": 2019,
+          "month": 9,
+          "unique_dancers": 79,
+          "points": 268,
+          "new_dancers": 7
+        },
+        {
+          "year": 2023,
+          "month": 9,
+          "unique_dancers": 69,
+          "points": 247,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 67,
+          "points": 227,
+          "new_dancers": 5
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 74,
+          "points": 279,
+          "new_dancers": 11
+        }
+      ]
     },
     "178": {
       "event_id": 178,
@@ -4692,7 +9487,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 10,
+          "unique_dancers": 83,
+          "points": 284,
+          "new_dancers": 8
+        },
+        {
+          "year": 2019,
+          "month": 10,
+          "unique_dancers": 75,
+          "points": 274,
+          "new_dancers": 15
+        },
+        {
+          "year": 2023,
+          "month": 10,
+          "unique_dancers": 75,
+          "points": 273,
+          "new_dancers": 16
+        },
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 91,
+          "points": 337,
+          "new_dancers": 21
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 92,
+          "points": 395,
+          "new_dancers": 17
+        }
+      ]
     },
     "179": {
       "event_id": 179,
@@ -4727,7 +9559,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 10,
+          "unique_dancers": 26,
+          "points": 82,
+          "new_dancers": 10
+        },
+        {
+          "year": 2022,
+          "month": 10,
+          "unique_dancers": 34,
+          "points": 133,
+          "new_dancers": 8
+        },
+        {
+          "year": 2023,
+          "month": 10,
+          "unique_dancers": 44,
+          "points": 160,
+          "new_dancers": 4
+        },
+        {
+          "year": 2024,
+          "month": 11,
+          "unique_dancers": 54,
+          "points": 197,
+          "new_dancers": 6
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 57,
+          "points": 230,
+          "new_dancers": 6
+        }
+      ]
     },
     "180": {
       "event_id": 180,
@@ -4758,7 +9627,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2011,
+          "month": 10,
+          "unique_dancers": 40,
+          "points": 130,
+          "new_dancers": 20
+        },
+        {
+          "year": 2012,
+          "month": 10,
+          "unique_dancers": 42,
+          "points": 153,
+          "new_dancers": 14
+        },
+        {
+          "year": 2013,
+          "month": 10,
+          "unique_dancers": 56,
+          "points": 181,
+          "new_dancers": 14
+        },
+        {
+          "year": 2014,
+          "month": 10,
+          "unique_dancers": 55,
+          "points": 196,
+          "new_dancers": 2
+        },
+        {
+          "year": 2015,
+          "month": 10,
+          "unique_dancers": 50,
+          "points": 191,
+          "new_dancers": 4
+        }
+      ]
     },
     "181": {
       "event_id": 181,
@@ -4797,7 +9703,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 11,
+          "unique_dancers": 125,
+          "points": 475,
+          "new_dancers": 18
+        },
+        {
+          "year": 2022,
+          "month": 11,
+          "unique_dancers": 132,
+          "points": 510,
+          "new_dancers": 11
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 155,
+          "points": 669,
+          "new_dancers": 20
+        },
+        {
+          "year": 2024,
+          "month": 11,
+          "unique_dancers": 164,
+          "points": 724,
+          "new_dancers": 20
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 142,
+          "points": 688,
+          "new_dancers": 21
+        }
+      ]
     },
     "183": {
       "event_id": 183,
@@ -4832,7 +9775,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 1,
+          "unique_dancers": 68,
+          "points": 214,
+          "new_dancers": 5
+        },
+        {
+          "year": 2023,
+          "month": 1,
+          "unique_dancers": 72,
+          "points": 273,
+          "new_dancers": 1
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 97,
+          "points": 390,
+          "new_dancers": 14
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 90,
+          "points": 371,
+          "new_dancers": 6
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 94,
+          "points": 364,
+          "new_dancers": 14
+        }
+      ]
     },
     "184": {
       "event_id": 184,
@@ -4871,7 +9851,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 1,
+          "unique_dancers": 135,
+          "points": 594,
+          "new_dancers": 29
+        },
+        {
+          "year": 2023,
+          "month": 1,
+          "unique_dancers": 165,
+          "points": 868,
+          "new_dancers": 26
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 173,
+          "points": 918,
+          "new_dancers": 20
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 163,
+          "points": 894,
+          "new_dancers": 25
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 161,
+          "points": 903,
+          "new_dancers": 19
+        }
+      ]
     },
     "185": {
       "event_id": 185,
@@ -4906,7 +9923,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2014,
+          "month": 2,
+          "unique_dancers": 60,
+          "points": 227,
+          "new_dancers": 14
+        },
+        {
+          "year": 2015,
+          "month": 2,
+          "unique_dancers": 70,
+          "points": 255,
+          "new_dancers": 4
+        },
+        {
+          "year": 2016,
+          "month": 2,
+          "unique_dancers": 76,
+          "points": 277,
+          "new_dancers": 8
+        },
+        {
+          "year": 2017,
+          "month": 2,
+          "unique_dancers": 88,
+          "points": 330,
+          "new_dancers": 2
+        },
+        {
+          "year": 2018,
+          "month": 2,
+          "unique_dancers": 74,
+          "points": 241,
+          "new_dancers": 0
+        }
+      ]
     },
     "186": {
       "event_id": 186,
@@ -4945,7 +9999,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 3,
+          "unique_dancers": 113,
+          "points": 400,
+          "new_dancers": 23
+        },
+        {
+          "year": 2023,
+          "month": 3,
+          "unique_dancers": 141,
+          "points": 590,
+          "new_dancers": 27
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 163,
+          "points": 688,
+          "new_dancers": 22
+        },
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 144,
+          "points": 683,
+          "new_dancers": 26
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 133,
+          "points": 597,
+          "new_dancers": 25
+        }
+      ]
     },
     "187": {
       "event_id": 187,
@@ -4984,7 +10075,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 4,
+          "unique_dancers": 115,
+          "points": 433,
+          "new_dancers": 10
+        },
+        {
+          "year": 2023,
+          "month": 4,
+          "unique_dancers": 131,
+          "points": 499,
+          "new_dancers": 15
+        },
+        {
+          "year": 2024,
+          "month": 4,
+          "unique_dancers": 130,
+          "points": 478,
+          "new_dancers": 10
+        },
+        {
+          "year": 2025,
+          "month": 4,
+          "unique_dancers": 131,
+          "points": 570,
+          "new_dancers": 10
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 115,
+          "points": 444,
+          "new_dancers": 16
+        }
+      ]
     },
     "188": {
       "event_id": 188,
@@ -5015,7 +10143,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 6,
+          "unique_dancers": 49,
+          "points": 167,
+          "new_dancers": 7
+        },
+        {
+          "year": 2016,
+          "month": 6,
+          "unique_dancers": 50,
+          "points": 170,
+          "new_dancers": 2
+        },
+        {
+          "year": 2017,
+          "month": 6,
+          "unique_dancers": 42,
+          "points": 144,
+          "new_dancers": 5
+        },
+        {
+          "year": 2018,
+          "month": 6,
+          "unique_dancers": 35,
+          "points": 107,
+          "new_dancers": 8
+        },
+        {
+          "year": 2019,
+          "month": 6,
+          "unique_dancers": 42,
+          "points": 128,
+          "new_dancers": 9
+        }
+      ]
     },
     "189": {
       "event_id": 189,
@@ -5038,7 +10203,16 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2012,
+          "month": 7,
+          "unique_dancers": 20,
+          "points": 70,
+          "new_dancers": 8
+        }
+      ]
     },
     "190": {
       "event_id": 190,
@@ -5073,7 +10247,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2012,
+          "month": 9,
+          "unique_dancers": 52,
+          "points": 182,
+          "new_dancers": 12
+        },
+        {
+          "year": 2013,
+          "month": 9,
+          "unique_dancers": 68,
+          "points": 220,
+          "new_dancers": 6
+        },
+        {
+          "year": 2014,
+          "month": 9,
+          "unique_dancers": 72,
+          "points": 262,
+          "new_dancers": 9
+        },
+        {
+          "year": 2015,
+          "month": 9,
+          "unique_dancers": 79,
+          "points": 260,
+          "new_dancers": 7
+        }
+      ]
     },
     "191": {
       "event_id": 191,
@@ -5104,7 +10308,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2012,
+          "month": 9,
+          "unique_dancers": 34,
+          "points": 125,
+          "new_dancers": 17
+        },
+        {
+          "year": 2013,
+          "month": 9,
+          "unique_dancers": 50,
+          "points": 182,
+          "new_dancers": 14
+        }
+      ]
     },
     "192": {
       "event_id": 192,
@@ -5135,7 +10355,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2012,
+          "month": 10,
+          "unique_dancers": 68,
+          "points": 246,
+          "new_dancers": 19
+        },
+        {
+          "year": 2013,
+          "month": 10,
+          "unique_dancers": 69,
+          "points": 251,
+          "new_dancers": 17
+        }
+      ]
     },
     "194": {
       "event_id": 194,
@@ -5170,7 +10406,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 11,
+          "unique_dancers": 55,
+          "points": 174,
+          "new_dancers": 10
+        },
+        {
+          "year": 2021,
+          "month": 10,
+          "unique_dancers": 59,
+          "points": 195,
+          "new_dancers": 3
+        },
+        {
+          "year": 2022,
+          "month": 11,
+          "unique_dancers": 57,
+          "points": 192,
+          "new_dancers": 7
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 74,
+          "points": 271,
+          "new_dancers": 12
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 85,
+          "points": 397,
+          "new_dancers": 10
+        }
+      ]
     },
     "195": {
       "event_id": 195,
@@ -5201,7 +10474,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2016,
+          "month": 1,
+          "unique_dancers": 118,
+          "points": 478,
+          "new_dancers": 16
+        },
+        {
+          "year": 2017,
+          "month": 1,
+          "unique_dancers": 106,
+          "points": 392,
+          "new_dancers": 9
+        },
+        {
+          "year": 2018,
+          "month": 1,
+          "unique_dancers": 106,
+          "points": 373,
+          "new_dancers": 14
+        },
+        {
+          "year": 2019,
+          "month": 1,
+          "unique_dancers": 59,
+          "points": 208,
+          "new_dancers": 7
+        },
+        {
+          "year": 2020,
+          "month": 1,
+          "unique_dancers": 46,
+          "points": 139,
+          "new_dancers": 2
+        }
+      ]
     },
     "196": {
       "event_id": 196,
@@ -5236,7 +10546,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 1,
+          "unique_dancers": 120,
+          "points": 402,
+          "new_dancers": 9
+        },
+        {
+          "year": 2023,
+          "month": 1,
+          "unique_dancers": 104,
+          "points": 356,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 113,
+          "points": 435,
+          "new_dancers": 11
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 118,
+          "points": 553,
+          "new_dancers": 25
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 109,
+          "points": 431,
+          "new_dancers": 22
+        }
+      ]
     },
     "197": {
       "event_id": 197,
@@ -5267,7 +10614,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 3,
+          "unique_dancers": 27,
+          "points": 84,
+          "new_dancers": 6
+        },
+        {
+          "year": 2023,
+          "month": 3,
+          "unique_dancers": 52,
+          "points": 181,
+          "new_dancers": 7
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 57,
+          "points": 234,
+          "new_dancers": 13
+        },
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 58,
+          "points": 255,
+          "new_dancers": 14
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 58,
+          "points": 213,
+          "new_dancers": 14
+        }
+      ]
     },
     "199": {
       "event_id": 199,
@@ -5306,7 +10690,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2013,
+          "month": 4,
+          "unique_dancers": 88,
+          "points": 324,
+          "new_dancers": 7
+        }
+      ]
     },
     "200": {
       "event_id": 200,
@@ -5341,7 +10734,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 1,
+          "unique_dancers": 106,
+          "points": 402,
+          "new_dancers": 7
+        },
+        {
+          "year": 2020,
+          "month": 1,
+          "unique_dancers": 98,
+          "points": 401,
+          "new_dancers": 1
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 113,
+          "points": 414,
+          "new_dancers": 22
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 104,
+          "points": 432,
+          "new_dancers": 14
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 100,
+          "points": 426,
+          "new_dancers": 16
+        }
+      ]
     },
     "201": {
       "event_id": 201,
@@ -5372,7 +10802,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2013,
+          "month": 4,
+          "unique_dancers": 35,
+          "points": 110,
+          "new_dancers": 3
+        },
+        {
+          "year": 2014,
+          "month": 5,
+          "unique_dancers": 40,
+          "points": 130,
+          "new_dancers": 3
+        },
+        {
+          "year": 2015,
+          "month": 5,
+          "unique_dancers": 55,
+          "points": 185,
+          "new_dancers": 7
+        },
+        {
+          "year": 2016,
+          "month": 5,
+          "unique_dancers": 30,
+          "points": 90,
+          "new_dancers": 1
+        }
+      ]
     },
     "203": {
       "event_id": 203,
@@ -5403,7 +10863,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 4,
+          "unique_dancers": 50,
+          "points": 150,
+          "new_dancers": 3
+        },
+        {
+          "year": 2023,
+          "month": 4,
+          "unique_dancers": 70,
+          "points": 296,
+          "new_dancers": 10
+        },
+        {
+          "year": 2024,
+          "month": 4,
+          "unique_dancers": 91,
+          "points": 417,
+          "new_dancers": 15
+        },
+        {
+          "year": 2025,
+          "month": 4,
+          "unique_dancers": 82,
+          "points": 371,
+          "new_dancers": 12
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 91,
+          "points": 414,
+          "new_dancers": 13
+        }
+      ]
     },
     "204": {
       "event_id": 204,
@@ -5434,7 +10931,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2013,
+          "month": 5,
+          "unique_dancers": 39,
+          "points": 151,
+          "new_dancers": 12
+        },
+        {
+          "year": 2014,
+          "month": 5,
+          "unique_dancers": 60,
+          "points": 222,
+          "new_dancers": 8
+        }
+      ]
     },
     "205": {
       "event_id": 205,
@@ -5469,7 +10982,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 5,
+          "unique_dancers": 72,
+          "points": 266,
+          "new_dancers": 6
+        },
+        {
+          "year": 2023,
+          "month": 5,
+          "unique_dancers": 98,
+          "points": 370,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 5,
+          "unique_dancers": 102,
+          "points": 393,
+          "new_dancers": 13
+        },
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 109,
+          "points": 455,
+          "new_dancers": 18
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 98,
+          "points": 451,
+          "new_dancers": 7
+        }
+      ]
     },
     "206": {
       "event_id": 206,
@@ -5504,7 +11054,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 5,
+          "unique_dancers": 81,
+          "points": 264,
+          "new_dancers": 8
+        },
+        {
+          "year": 2023,
+          "month": 6,
+          "unique_dancers": 80,
+          "points": 284,
+          "new_dancers": 17
+        },
+        {
+          "year": 2024,
+          "month": 6,
+          "unique_dancers": 104,
+          "points": 414,
+          "new_dancers": 20
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 93,
+          "points": 380,
+          "new_dancers": 14
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 89,
+          "points": 370,
+          "new_dancers": 5
+        }
+      ]
     },
     "207": {
       "event_id": 207,
@@ -5539,7 +11126,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 6,
+          "unique_dancers": 57,
+          "points": 183,
+          "new_dancers": 18
+        },
+        {
+          "year": 2018,
+          "month": 6,
+          "unique_dancers": 55,
+          "points": 162,
+          "new_dancers": 4
+        },
+        {
+          "year": 2019,
+          "month": 6,
+          "unique_dancers": 43,
+          "points": 120,
+          "new_dancers": 2
+        },
+        {
+          "year": 2024,
+          "month": 6,
+          "unique_dancers": 60,
+          "points": 196,
+          "new_dancers": 10
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 51,
+          "points": 160,
+          "new_dancers": 9
+        }
+      ]
     },
     "208": {
       "event_id": 208,
@@ -5570,7 +11194,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2013,
+          "month": 7,
+          "unique_dancers": 44,
+          "points": 176,
+          "new_dancers": 6
+        }
+      ]
     },
     "209": {
       "event_id": 209,
@@ -5605,7 +11238,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2013,
+          "month": 7,
+          "unique_dancers": 80,
+          "points": 298,
+          "new_dancers": 9
+        },
+        {
+          "year": 2014,
+          "month": 7,
+          "unique_dancers": 104,
+          "points": 402,
+          "new_dancers": 11
+        },
+        {
+          "year": 2015,
+          "month": 7,
+          "unique_dancers": 69,
+          "points": 284,
+          "new_dancers": 4
+        }
+      ]
     },
     "210": {
       "event_id": 210,
@@ -5640,7 +11296,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2013,
+          "month": 10,
+          "unique_dancers": 40,
+          "points": 130,
+          "new_dancers": 18
+        },
+        {
+          "year": 2023,
+          "month": 4,
+          "unique_dancers": 72,
+          "points": 228,
+          "new_dancers": 12
+        },
+        {
+          "year": 2024,
+          "month": 4,
+          "unique_dancers": 133,
+          "points": 548,
+          "new_dancers": 20
+        },
+        {
+          "year": 2025,
+          "month": 4,
+          "unique_dancers": 112,
+          "points": 504,
+          "new_dancers": 14
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 115,
+          "points": 486,
+          "new_dancers": 17
+        }
+      ]
     },
     "211": {
       "event_id": 211,
@@ -5679,7 +11372,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 10,
+          "unique_dancers": 122,
+          "points": 498,
+          "new_dancers": 15
+        },
+        {
+          "year": 2022,
+          "month": 10,
+          "unique_dancers": 137,
+          "points": 513,
+          "new_dancers": 16
+        },
+        {
+          "year": 2023,
+          "month": 10,
+          "unique_dancers": 139,
+          "points": 603,
+          "new_dancers": 22
+        },
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 150,
+          "points": 682,
+          "new_dancers": 21
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 138,
+          "points": 683,
+          "new_dancers": 17
+        }
+      ]
     },
     "212": {
       "event_id": 212,
@@ -5714,7 +11444,44 @@
             "Follower": 4
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 12,
+          "unique_dancers": 125,
+          "points": 489,
+          "new_dancers": 5
+        },
+        {
+          "year": 2022,
+          "month": 12,
+          "unique_dancers": 126,
+          "points": 603,
+          "new_dancers": 5
+        },
+        {
+          "year": 2023,
+          "month": 12,
+          "unique_dancers": 126,
+          "points": 634,
+          "new_dancers": 4
+        },
+        {
+          "year": 2024,
+          "month": 12,
+          "unique_dancers": 130,
+          "points": 582,
+          "new_dancers": 1
+        },
+        {
+          "year": 2025,
+          "month": 12,
+          "unique_dancers": 113,
+          "points": 598,
+          "new_dancers": 7
+        }
+      ]
     },
     "213": {
       "event_id": 213,
@@ -5745,7 +11512,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 12,
+          "unique_dancers": 43,
+          "points": 148,
+          "new_dancers": 2
+        },
+        {
+          "year": 2018,
+          "month": 12,
+          "unique_dancers": 51,
+          "points": 165,
+          "new_dancers": 5
+        },
+        {
+          "year": 2019,
+          "month": 12,
+          "unique_dancers": 48,
+          "points": 154,
+          "new_dancers": 7
+        },
+        {
+          "year": 2020,
+          "month": 12,
+          "unique_dancers": 20,
+          "points": 46,
+          "new_dancers": 2
+        },
+        {
+          "year": 2022,
+          "month": 12,
+          "unique_dancers": 32,
+          "points": 97,
+          "new_dancers": 3
+        }
+      ]
     },
     "214": {
       "event_id": 214,
@@ -5780,7 +11584,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2016,
+          "month": 1,
+          "unique_dancers": 92,
+          "points": 339,
+          "new_dancers": 15
+        },
+        {
+          "year": 2017,
+          "month": 1,
+          "unique_dancers": 85,
+          "points": 323,
+          "new_dancers": 17
+        },
+        {
+          "year": 2017,
+          "month": 12,
+          "unique_dancers": 95,
+          "points": 342,
+          "new_dancers": 14
+        },
+        {
+          "year": 2019,
+          "month": 1,
+          "unique_dancers": 89,
+          "points": 287,
+          "new_dancers": 7
+        },
+        {
+          "year": 2020,
+          "month": 1,
+          "unique_dancers": 105,
+          "points": 375,
+          "new_dancers": 9
+        }
+      ]
     },
     "215": {
       "event_id": 215,
@@ -5815,7 +11656,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 2,
+          "unique_dancers": 76,
+          "points": 252,
+          "new_dancers": 9
+        },
+        {
+          "year": 2023,
+          "month": 2,
+          "unique_dancers": 88,
+          "points": 342,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 2,
+          "unique_dancers": 95,
+          "points": 361,
+          "new_dancers": 9
+        },
+        {
+          "year": 2025,
+          "month": 2,
+          "unique_dancers": 107,
+          "points": 453,
+          "new_dancers": 25
+        },
+        {
+          "year": 2026,
+          "month": 2,
+          "unique_dancers": 91,
+          "points": 403,
+          "new_dancers": 9
+        }
+      ]
     },
     "216": {
       "event_id": 216,
@@ -5846,7 +11724,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2014,
+          "month": 3,
+          "unique_dancers": 38,
+          "points": 138,
+          "new_dancers": 29
+        },
+        {
+          "year": 2015,
+          "month": 3,
+          "unique_dancers": 30,
+          "points": 100,
+          "new_dancers": 15
+        },
+        {
+          "year": 2016,
+          "month": 3,
+          "unique_dancers": 38,
+          "points": 124,
+          "new_dancers": 7
+        },
+        {
+          "year": 2018,
+          "month": 9,
+          "unique_dancers": 24,
+          "points": 72,
+          "new_dancers": 8
+        },
+        {
+          "year": 2019,
+          "month": 9,
+          "unique_dancers": 24,
+          "points": 66,
+          "new_dancers": 6
+        }
+      ]
     },
     "217": {
       "event_id": 217,
@@ -5881,7 +11796,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2016,
+          "month": 3,
+          "unique_dancers": 40,
+          "points": 139,
+          "new_dancers": 3
+        },
+        {
+          "year": 2017,
+          "month": 4,
+          "unique_dancers": 61,
+          "points": 210,
+          "new_dancers": 9
+        },
+        {
+          "year": 2018,
+          "month": 4,
+          "unique_dancers": 42,
+          "points": 126,
+          "new_dancers": 2
+        },
+        {
+          "year": 2019,
+          "month": 4,
+          "unique_dancers": 34,
+          "points": 90,
+          "new_dancers": 2
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 51,
+          "points": 177,
+          "new_dancers": 3
+        }
+      ]
     },
     "218": {
       "event_id": 218,
@@ -5916,7 +11868,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 4,
+          "unique_dancers": 72,
+          "points": 288,
+          "new_dancers": 10
+        },
+        {
+          "year": 2023,
+          "month": 4,
+          "unique_dancers": 91,
+          "points": 394,
+          "new_dancers": 15
+        },
+        {
+          "year": 2024,
+          "month": 4,
+          "unique_dancers": 122,
+          "points": 511,
+          "new_dancers": 36
+        },
+        {
+          "year": 2025,
+          "month": 4,
+          "unique_dancers": 113,
+          "points": 533,
+          "new_dancers": 31
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 115,
+          "points": 556,
+          "new_dancers": 18
+        }
+      ]
     },
     "219": {
       "event_id": 219,
@@ -5951,7 +11940,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 5,
+          "unique_dancers": 49,
+          "points": 158,
+          "new_dancers": 12
+        },
+        {
+          "year": 2016,
+          "month": 5,
+          "unique_dancers": 80,
+          "points": 282,
+          "new_dancers": 20
+        },
+        {
+          "year": 2017,
+          "month": 5,
+          "unique_dancers": 79,
+          "points": 281,
+          "new_dancers": 16
+        },
+        {
+          "year": 2018,
+          "month": 5,
+          "unique_dancers": 60,
+          "points": 185,
+          "new_dancers": 10
+        },
+        {
+          "year": 2019,
+          "month": 5,
+          "unique_dancers": 69,
+          "points": 224,
+          "new_dancers": 11
+        }
+      ]
     },
     "220": {
       "event_id": 220,
@@ -5986,7 +12012,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 6,
+          "unique_dancers": 119,
+          "points": 453,
+          "new_dancers": 30
+        },
+        {
+          "year": 2023,
+          "month": 6,
+          "unique_dancers": 128,
+          "points": 536,
+          "new_dancers": 30
+        },
+        {
+          "year": 2024,
+          "month": 6,
+          "unique_dancers": 130,
+          "points": 558,
+          "new_dancers": 25
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 112,
+          "points": 543,
+          "new_dancers": 25
+        },
+        {
+          "year": 2026,
+          "month": 6,
+          "unique_dancers": 108,
+          "points": 482,
+          "new_dancers": 16
+        }
+      ]
     },
     "221": {
       "event_id": 221,
@@ -6021,7 +12084,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 5,
+          "unique_dancers": 62,
+          "points": 205,
+          "new_dancers": 9
+        },
+        {
+          "year": 2019,
+          "month": 5,
+          "unique_dancers": 59,
+          "points": 164,
+          "new_dancers": 7
+        },
+        {
+          "year": 2024,
+          "month": 5,
+          "unique_dancers": 54,
+          "points": 188,
+          "new_dancers": 4
+        },
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 61,
+          "points": 199,
+          "new_dancers": 14
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 78,
+          "points": 305,
+          "new_dancers": 6
+        }
+      ]
     },
     "222": {
       "event_id": 222,
@@ -6056,7 +12156,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 6,
+          "unique_dancers": 113,
+          "points": 414,
+          "new_dancers": 20
+        },
+        {
+          "year": 2023,
+          "month": 6,
+          "unique_dancers": 105,
+          "points": 406,
+          "new_dancers": 12
+        },
+        {
+          "year": 2024,
+          "month": 6,
+          "unique_dancers": 114,
+          "points": 467,
+          "new_dancers": 14
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 118,
+          "points": 512,
+          "new_dancers": 20
+        },
+        {
+          "year": 2026,
+          "month": 6,
+          "unique_dancers": 115,
+          "points": 489,
+          "new_dancers": 19
+        }
+      ]
     },
     "223": {
       "event_id": 223,
@@ -6087,7 +12224,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2014,
+          "month": 6,
+          "unique_dancers": 40,
+          "points": 130,
+          "new_dancers": 15
+        },
+        {
+          "year": 2016,
+          "month": 6,
+          "unique_dancers": 54,
+          "points": 179,
+          "new_dancers": 17
+        }
+      ]
     },
     "224": {
       "event_id": 224,
@@ -6122,7 +12275,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 7,
+          "unique_dancers": 95,
+          "points": 328,
+          "new_dancers": 11
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 88,
+          "points": 321,
+          "new_dancers": 23
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 112,
+          "points": 449,
+          "new_dancers": 19
+        },
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 111,
+          "points": 497,
+          "new_dancers": 23
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 103,
+          "points": 427,
+          "new_dancers": 15
+        }
+      ]
     },
     "225": {
       "event_id": 225,
@@ -6161,7 +12351,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 7,
+          "unique_dancers": 157,
+          "points": 690,
+          "new_dancers": 15
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 173,
+          "points": 810,
+          "new_dancers": 28
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 158,
+          "points": 715,
+          "new_dancers": 19
+        },
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 144,
+          "points": 748,
+          "new_dancers": 21
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 146,
+          "points": 732,
+          "new_dancers": 17
+        }
+      ]
     },
     "226": {
       "event_id": 226,
@@ -6188,7 +12415,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2014,
+          "month": 7,
+          "unique_dancers": 40,
+          "points": 152,
+          "new_dancers": 6
+        },
+        {
+          "year": 2015,
+          "month": 7,
+          "unique_dancers": 56,
+          "points": 192,
+          "new_dancers": 14
+        },
+        {
+          "year": 2016,
+          "month": 7,
+          "unique_dancers": 46,
+          "points": 167,
+          "new_dancers": 4
+        },
+        {
+          "year": 2017,
+          "month": 7,
+          "unique_dancers": 33,
+          "points": 127,
+          "new_dancers": 2
+        },
+        {
+          "year": 2018,
+          "month": 7,
+          "unique_dancers": 17,
+          "points": 35,
+          "new_dancers": 1
+        }
+      ]
     },
     "227": {
       "event_id": 227,
@@ -6223,7 +12487,44 @@
             "Follower": 4
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 8,
+          "unique_dancers": 113,
+          "points": 573,
+          "new_dancers": 6
+        },
+        {
+          "year": 2022,
+          "month": 8,
+          "unique_dancers": 128,
+          "points": 548,
+          "new_dancers": 2
+        },
+        {
+          "year": 2023,
+          "month": 8,
+          "unique_dancers": 128,
+          "points": 582,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 138,
+          "points": 671,
+          "new_dancers": 4
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 116,
+          "points": 652,
+          "new_dancers": 6
+        }
+      ]
     },
     "228": {
       "event_id": 228,
@@ -6258,7 +12559,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2014,
+          "month": 8,
+          "unique_dancers": 58,
+          "points": 206,
+          "new_dancers": 4
+        },
+        {
+          "year": 2015,
+          "month": 8,
+          "unique_dancers": 65,
+          "points": 218,
+          "new_dancers": 13
+        }
+      ]
     },
     "229": {
       "event_id": 229,
@@ -6293,7 +12610,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 11,
+          "unique_dancers": 109,
+          "points": 401,
+          "new_dancers": 18
+        },
+        {
+          "year": 2022,
+          "month": 11,
+          "unique_dancers": 116,
+          "points": 486,
+          "new_dancers": 20
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 126,
+          "points": 543,
+          "new_dancers": 20
+        },
+        {
+          "year": 2024,
+          "month": 11,
+          "unique_dancers": 131,
+          "points": 626,
+          "new_dancers": 24
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 140,
+          "points": 715,
+          "new_dancers": 22
+        }
+      ]
     },
     "230": {
       "event_id": 230,
@@ -6324,7 +12678,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2014,
+          "month": 9,
+          "unique_dancers": 37,
+          "points": 143,
+          "new_dancers": 7
+        },
+        {
+          "year": 2015,
+          "month": 9,
+          "unique_dancers": 39,
+          "points": 129,
+          "new_dancers": 4
+        },
+        {
+          "year": 2016,
+          "month": 9,
+          "unique_dancers": 40,
+          "points": 130,
+          "new_dancers": 5
+        }
+      ]
     },
     "231": {
       "event_id": 231,
@@ -6359,7 +12736,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 9,
+          "unique_dancers": 116,
+          "points": 466,
+          "new_dancers": 18
+        },
+        {
+          "year": 2022,
+          "month": 9,
+          "unique_dancers": 127,
+          "points": 464,
+          "new_dancers": 23
+        },
+        {
+          "year": 2023,
+          "month": 9,
+          "unique_dancers": 149,
+          "points": 594,
+          "new_dancers": 16
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 135,
+          "points": 610,
+          "new_dancers": 22
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 136,
+          "points": 620,
+          "new_dancers": 22
+        }
+      ]
     },
     "232": {
       "event_id": 232,
@@ -6390,7 +12804,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 9,
+          "unique_dancers": 43,
+          "points": 148,
+          "new_dancers": 13
+        },
+        {
+          "year": 2016,
+          "month": 9,
+          "unique_dancers": 50,
+          "points": 170,
+          "new_dancers": 17
+        },
+        {
+          "year": 2017,
+          "month": 9,
+          "unique_dancers": 58,
+          "points": 197,
+          "new_dancers": 11
+        },
+        {
+          "year": 2018,
+          "month": 9,
+          "unique_dancers": 51,
+          "points": 164,
+          "new_dancers": 15
+        },
+        {
+          "year": 2019,
+          "month": 9,
+          "unique_dancers": 48,
+          "points": 140,
+          "new_dancers": 10
+        }
+      ]
     },
     "233": {
       "event_id": 233,
@@ -6429,7 +12880,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 9,
+          "unique_dancers": 106,
+          "points": 358,
+          "new_dancers": 11
+        },
+        {
+          "year": 2022,
+          "month": 9,
+          "unique_dancers": 112,
+          "points": 414,
+          "new_dancers": 11
+        },
+        {
+          "year": 2023,
+          "month": 9,
+          "unique_dancers": 128,
+          "points": 491,
+          "new_dancers": 18
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 149,
+          "points": 574,
+          "new_dancers": 21
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 136,
+          "points": 607,
+          "new_dancers": 13
+        }
+      ]
     },
     "234": {
       "event_id": 234,
@@ -6464,7 +12952,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 9,
+          "unique_dancers": 84,
+          "points": 257,
+          "new_dancers": 7
+        },
+        {
+          "year": 2021,
+          "month": 9,
+          "unique_dancers": 81,
+          "points": 259,
+          "new_dancers": 2
+        },
+        {
+          "year": 2022,
+          "month": 9,
+          "unique_dancers": 65,
+          "points": 224,
+          "new_dancers": 3
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 74,
+          "points": 270,
+          "new_dancers": 8
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 60,
+          "points": 207,
+          "new_dancers": 2
+        }
+      ]
     },
     "236": {
       "event_id": 236,
@@ -6503,7 +13028,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 11,
+          "unique_dancers": 115,
+          "points": 424,
+          "new_dancers": 27
+        },
+        {
+          "year": 2022,
+          "month": 10,
+          "unique_dancers": 113,
+          "points": 414,
+          "new_dancers": 24
+        },
+        {
+          "year": 2023,
+          "month": 10,
+          "unique_dancers": 126,
+          "points": 524,
+          "new_dancers": 16
+        },
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 136,
+          "points": 581,
+          "new_dancers": 19
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 133,
+          "points": 638,
+          "new_dancers": 20
+        }
+      ]
     },
     "237": {
       "event_id": 237,
@@ -6530,7 +13092,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2014,
+          "month": 10,
+          "unique_dancers": 35,
+          "points": 126,
+          "new_dancers": 8
+        },
+        {
+          "year": 2015,
+          "month": 10,
+          "unique_dancers": 30,
+          "points": 100,
+          "new_dancers": 2
+        },
+        {
+          "year": 2016,
+          "month": 11,
+          "unique_dancers": 48,
+          "points": 154,
+          "new_dancers": 12
+        },
+        {
+          "year": 2017,
+          "month": 11,
+          "unique_dancers": 29,
+          "points": 97,
+          "new_dancers": 4
+        }
+      ]
     },
     "238": {
       "event_id": 238,
@@ -6565,7 +13157,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 12,
+          "unique_dancers": 73,
+          "points": 228,
+          "new_dancers": 7
+        },
+        {
+          "year": 2022,
+          "month": 12,
+          "unique_dancers": 72,
+          "points": 228,
+          "new_dancers": 13
+        },
+        {
+          "year": 2023,
+          "month": 12,
+          "unique_dancers": 77,
+          "points": 287,
+          "new_dancers": 17
+        },
+        {
+          "year": 2024,
+          "month": 12,
+          "unique_dancers": 104,
+          "points": 396,
+          "new_dancers": 24
+        },
+        {
+          "year": 2025,
+          "month": 12,
+          "unique_dancers": 99,
+          "points": 462,
+          "new_dancers": 18
+        }
+      ]
     },
     "239": {
       "event_id": 239,
@@ -6600,7 +13229,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2014,
+          "month": 12,
+          "unique_dancers": 99,
+          "points": 360,
+          "new_dancers": 20
+        },
+        {
+          "year": 2015,
+          "month": 12,
+          "unique_dancers": 113,
+          "points": 432,
+          "new_dancers": 15
+        }
+      ]
     },
     "240": {
       "event_id": 240,
@@ -6635,7 +13280,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 1,
+          "unique_dancers": 63,
+          "points": 183,
+          "new_dancers": 9
+        },
+        {
+          "year": 2023,
+          "month": 1,
+          "unique_dancers": 77,
+          "points": 307,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 92,
+          "points": 356,
+          "new_dancers": 8
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 97,
+          "points": 402,
+          "new_dancers": 10
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 104,
+          "points": 483,
+          "new_dancers": 16
+        }
+      ]
     },
     "241": {
       "event_id": 241,
@@ -6666,7 +13348,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 1,
+          "unique_dancers": 40,
+          "points": 130,
+          "new_dancers": 16
+        },
+        {
+          "year": 2016,
+          "month": 1,
+          "unique_dancers": 35,
+          "points": 110,
+          "new_dancers": 5
+        },
+        {
+          "year": 2017,
+          "month": 1,
+          "unique_dancers": 54,
+          "points": 195,
+          "new_dancers": 3
+        }
+      ]
     },
     "242": {
       "event_id": 242,
@@ -6701,7 +13406,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 1,
+          "unique_dancers": 80,
+          "points": 270,
+          "new_dancers": 14
+        },
+        {
+          "year": 2023,
+          "month": 1,
+          "unique_dancers": 97,
+          "points": 376,
+          "new_dancers": 20
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 72,
+          "points": 321,
+          "new_dancers": 7
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 91,
+          "points": 405,
+          "new_dancers": 20
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 72,
+          "points": 286,
+          "new_dancers": 12
+        }
+      ]
     },
     "243": {
       "event_id": 243,
@@ -6728,7 +13470,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 2,
+          "unique_dancers": 39,
+          "points": 129,
+          "new_dancers": 18
+        }
+      ]
     },
     "244": {
       "event_id": 244,
@@ -6763,7 +13514,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 2,
+          "unique_dancers": 102,
+          "points": 362,
+          "new_dancers": 5
+        },
+        {
+          "year": 2023,
+          "month": 2,
+          "unique_dancers": 112,
+          "points": 454,
+          "new_dancers": 17
+        },
+        {
+          "year": 2024,
+          "month": 2,
+          "unique_dancers": 130,
+          "points": 530,
+          "new_dancers": 19
+        },
+        {
+          "year": 2025,
+          "month": 2,
+          "unique_dancers": 135,
+          "points": 597,
+          "new_dancers": 23
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 125,
+          "points": 581,
+          "new_dancers": 17
+        }
+      ]
     },
     "245": {
       "event_id": 245,
@@ -6794,7 +13582,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 3,
+          "unique_dancers": 50,
+          "points": 160,
+          "new_dancers": 14
+        },
+        {
+          "year": 2016,
+          "month": 2,
+          "unique_dancers": 49,
+          "points": 157,
+          "new_dancers": 15
+        }
+      ]
     },
     "246": {
       "event_id": 246,
@@ -6829,7 +13633,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 3,
+          "unique_dancers": 42,
+          "points": 147,
+          "new_dancers": 4
+        },
+        {
+          "year": 2016,
+          "month": 4,
+          "unique_dancers": 40,
+          "points": 130,
+          "new_dancers": 5
+        },
+        {
+          "year": 2017,
+          "month": 3,
+          "unique_dancers": 49,
+          "points": 175,
+          "new_dancers": 5
+        },
+        {
+          "year": 2018,
+          "month": 3,
+          "unique_dancers": 38,
+          "points": 116,
+          "new_dancers": 3
+        },
+        {
+          "year": 2019,
+          "month": 3,
+          "unique_dancers": 46,
+          "points": 130,
+          "new_dancers": 5
+        }
+      ]
     },
     "247": {
       "event_id": 247,
@@ -6856,7 +13697,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 4,
+          "unique_dancers": 39,
+          "points": 128,
+          "new_dancers": 12
+        },
+        {
+          "year": 2016,
+          "month": 4,
+          "unique_dancers": 50,
+          "points": 160,
+          "new_dancers": 16
+        },
+        {
+          "year": 2017,
+          "month": 3,
+          "unique_dancers": 40,
+          "points": 130,
+          "new_dancers": 14
+        }
+      ]
     },
     "253": {
       "event_id": 253,
@@ -6895,7 +13759,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 5,
+          "unique_dancers": 92,
+          "points": 361,
+          "new_dancers": 11
+        },
+        {
+          "year": 2023,
+          "month": 5,
+          "unique_dancers": 97,
+          "points": 378,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 4,
+          "unique_dancers": 112,
+          "points": 505,
+          "new_dancers": 10
+        },
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 133,
+          "points": 638,
+          "new_dancers": 19
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 134,
+          "points": 686,
+          "new_dancers": 20
+        }
+      ]
     },
     "254": {
       "event_id": 254,
@@ -6930,7 +13831,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 6,
+          "unique_dancers": 65,
+          "points": 206,
+          "new_dancers": 10
+        },
+        {
+          "year": 2022,
+          "month": 9,
+          "unique_dancers": 63,
+          "points": 207,
+          "new_dancers": 9
+        },
+        {
+          "year": 2023,
+          "month": 9,
+          "unique_dancers": 91,
+          "points": 357,
+          "new_dancers": 15
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 127,
+          "points": 569,
+          "new_dancers": 20
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 119,
+          "points": 630,
+          "new_dancers": 21
+        }
+      ]
     },
     "255": {
       "event_id": 255,
@@ -6957,7 +13895,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 7,
+          "unique_dancers": 42,
+          "points": 126,
+          "new_dancers": 8
+        },
+        {
+          "year": 2019,
+          "month": 6,
+          "unique_dancers": 34,
+          "points": 114,
+          "new_dancers": 2
+        },
+        {
+          "year": 2022,
+          "month": 6,
+          "unique_dancers": 32,
+          "points": 98,
+          "new_dancers": 6
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 39,
+          "points": 136,
+          "new_dancers": 5
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 17,
+          "points": 54,
+          "new_dancers": 1
+        }
+      ]
     },
     "256": {
       "event_id": 256,
@@ -6992,7 +13967,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 8,
+          "unique_dancers": 49,
+          "points": 172,
+          "new_dancers": 13
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 57,
+          "points": 201,
+          "new_dancers": 14
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 58,
+          "points": 217,
+          "new_dancers": 17
+        },
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 76,
+          "points": 314,
+          "new_dancers": 21
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 90,
+          "points": 391,
+          "new_dancers": 15
+        }
+      ]
     },
     "257": {
       "event_id": 257,
@@ -7027,7 +14039,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2015,
+          "month": 10,
+          "unique_dancers": 110,
+          "points": 414,
+          "new_dancers": 30
+        },
+        {
+          "year": 2016,
+          "month": 10,
+          "unique_dancers": 95,
+          "points": 336,
+          "new_dancers": 22
+        },
+        {
+          "year": 2017,
+          "month": 10,
+          "unique_dancers": 89,
+          "points": 321,
+          "new_dancers": 24
+        }
+      ]
     },
     "258": {
       "event_id": 258,
@@ -7062,7 +14097,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 2,
+          "unique_dancers": 77,
+          "points": 277,
+          "new_dancers": 3
+        },
+        {
+          "year": 2020,
+          "month": 2,
+          "unique_dancers": 78,
+          "points": 257,
+          "new_dancers": 1
+        },
+        {
+          "year": 2024,
+          "month": 2,
+          "unique_dancers": 66,
+          "points": 239,
+          "new_dancers": 3
+        },
+        {
+          "year": 2025,
+          "month": 2,
+          "unique_dancers": 64,
+          "points": 269,
+          "new_dancers": 3
+        },
+        {
+          "year": 2026,
+          "month": 2,
+          "unique_dancers": 64,
+          "points": 246,
+          "new_dancers": 2
+        }
+      ]
     },
     "259": {
       "event_id": 259,
@@ -7101,7 +14173,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 4,
+          "unique_dancers": 71,
+          "points": 252,
+          "new_dancers": 6
+        },
+        {
+          "year": 2023,
+          "month": 4,
+          "unique_dancers": 104,
+          "points": 403,
+          "new_dancers": 10
+        },
+        {
+          "year": 2024,
+          "month": 4,
+          "unique_dancers": 114,
+          "points": 433,
+          "new_dancers": 17
+        },
+        {
+          "year": 2025,
+          "month": 4,
+          "unique_dancers": 142,
+          "points": 597,
+          "new_dancers": 24
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 136,
+          "points": 621,
+          "new_dancers": 13
+        }
+      ]
     },
     "260": {
       "event_id": 260,
@@ -7132,7 +14241,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2016,
+          "month": 7,
+          "unique_dancers": 39,
+          "points": 128,
+          "new_dancers": 9
+        }
+      ]
     },
     "261": {
       "event_id": 261,
@@ -7163,7 +14281,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 7,
+          "unique_dancers": 46,
+          "points": 152,
+          "new_dancers": 8
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 65,
+          "points": 238,
+          "new_dancers": 15
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 82,
+          "points": 345,
+          "new_dancers": 18
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 96,
+          "points": 421,
+          "new_dancers": 19
+        },
+        {
+          "year": 2026,
+          "month": 6,
+          "unique_dancers": 75,
+          "points": 309,
+          "new_dancers": 13
+        }
+      ]
     },
     "262": {
       "event_id": 262,
@@ -7198,7 +14353,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2016,
+          "month": 7,
+          "unique_dancers": 50,
+          "points": 160,
+          "new_dancers": 14
+        },
+        {
+          "year": 2017,
+          "month": 7,
+          "unique_dancers": 70,
+          "points": 230,
+          "new_dancers": 11
+        },
+        {
+          "year": 2018,
+          "month": 7,
+          "unique_dancers": 43,
+          "points": 119,
+          "new_dancers": 9
+        }
+      ]
     },
     "263": {
       "event_id": 263,
@@ -7229,7 +14407,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2016,
+          "month": 8,
+          "unique_dancers": 62,
+          "points": 223,
+          "new_dancers": 11
+        },
+        {
+          "year": 2017,
+          "month": 8,
+          "unique_dancers": 85,
+          "points": 302,
+          "new_dancers": 15
+        },
+        {
+          "year": 2018,
+          "month": 8,
+          "unique_dancers": 91,
+          "points": 362,
+          "new_dancers": 15
+        },
+        {
+          "year": 2019,
+          "month": 8,
+          "unique_dancers": 102,
+          "points": 404,
+          "new_dancers": 15
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 79,
+          "points": 294,
+          "new_dancers": 21
+        }
+      ]
     },
     "264": {
       "event_id": 264,
@@ -7264,7 +14479,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 8,
+          "unique_dancers": 72,
+          "points": 214,
+          "new_dancers": 11
+        },
+        {
+          "year": 2022,
+          "month": 8,
+          "unique_dancers": 74,
+          "points": 272,
+          "new_dancers": 9
+        },
+        {
+          "year": 2023,
+          "month": 8,
+          "unique_dancers": 98,
+          "points": 409,
+          "new_dancers": 12
+        },
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 112,
+          "points": 497,
+          "new_dancers": 16
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 102,
+          "points": 504,
+          "new_dancers": 10
+        }
+      ]
     },
     "265": {
       "event_id": 265,
@@ -7295,7 +14547,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2016,
+          "month": 9,
+          "unique_dancers": 75,
+          "points": 258,
+          "new_dancers": 7
+        },
+        {
+          "year": 2017,
+          "month": 9,
+          "unique_dancers": 83,
+          "points": 280,
+          "new_dancers": 12
+        },
+        {
+          "year": 2018,
+          "month": 12,
+          "unique_dancers": 85,
+          "points": 280,
+          "new_dancers": 7
+        },
+        {
+          "year": 2019,
+          "month": 12,
+          "unique_dancers": 40,
+          "points": 111,
+          "new_dancers": 5
+        }
+      ]
     },
     "266": {
       "event_id": 266,
@@ -7326,7 +14608,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2016,
+          "month": 9,
+          "unique_dancers": 49,
+          "points": 167,
+          "new_dancers": 6
+        },
+        {
+          "year": 2018,
+          "month": 9,
+          "unique_dancers": 33,
+          "points": 88,
+          "new_dancers": 1
+        }
+      ]
     },
     "267": {
       "event_id": 267,
@@ -7361,7 +14659,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 10,
+          "unique_dancers": 42,
+          "points": 129,
+          "new_dancers": 4
+        },
+        {
+          "year": 2022,
+          "month": 10,
+          "unique_dancers": 50,
+          "points": 162,
+          "new_dancers": 3
+        },
+        {
+          "year": 2023,
+          "month": 10,
+          "unique_dancers": 80,
+          "points": 305,
+          "new_dancers": 10
+        },
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 79,
+          "points": 316,
+          "new_dancers": 9
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 67,
+          "points": 257,
+          "new_dancers": 5
+        }
+      ]
     },
     "268": {
       "event_id": 268,
@@ -7396,7 +14731,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 6,
+          "unique_dancers": 43,
+          "points": 142,
+          "new_dancers": 5
+        },
+        {
+          "year": 2019,
+          "month": 6,
+          "unique_dancers": 47,
+          "points": 160,
+          "new_dancers": 7
+        },
+        {
+          "year": 2023,
+          "month": 9,
+          "unique_dancers": 51,
+          "points": 209,
+          "new_dancers": 10
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 68,
+          "points": 260,
+          "new_dancers": 5
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 81,
+          "points": 332,
+          "new_dancers": 14
+        }
+      ]
     },
     "269": {
       "event_id": 269,
@@ -7435,7 +14807,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 11,
+          "unique_dancers": 61,
+          "points": 194,
+          "new_dancers": 4
+        },
+        {
+          "year": 2022,
+          "month": 11,
+          "unique_dancers": 80,
+          "points": 296,
+          "new_dancers": 10
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 100,
+          "points": 376,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 11,
+          "unique_dancers": 121,
+          "points": 453,
+          "new_dancers": 24
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 112,
+          "points": 482,
+          "new_dancers": 19
+        }
+      ]
     },
     "270": {
       "event_id": 270,
@@ -7470,7 +14879,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 11,
+          "unique_dancers": 78,
+          "points": 258,
+          "new_dancers": 16
+        },
+        {
+          "year": 2022,
+          "month": 11,
+          "unique_dancers": 115,
+          "points": 379,
+          "new_dancers": 20
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 120,
+          "points": 513,
+          "new_dancers": 13
+        },
+        {
+          "year": 2024,
+          "month": 11,
+          "unique_dancers": 111,
+          "points": 430,
+          "new_dancers": 16
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 100,
+          "points": 442,
+          "new_dancers": 9
+        }
+      ]
     },
     "271": {
       "event_id": 271,
@@ -7505,7 +14951,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 12,
+          "unique_dancers": 67,
+          "points": 193,
+          "new_dancers": 8
+        },
+        {
+          "year": 2022,
+          "month": 12,
+          "unique_dancers": 61,
+          "points": 193,
+          "new_dancers": 8
+        },
+        {
+          "year": 2023,
+          "month": 12,
+          "unique_dancers": 53,
+          "points": 187,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 12,
+          "unique_dancers": 57,
+          "points": 197,
+          "new_dancers": 9
+        },
+        {
+          "year": 2025,
+          "month": 12,
+          "unique_dancers": 60,
+          "points": 207,
+          "new_dancers": 9
+        }
+      ]
     },
     "272": {
       "event_id": 272,
@@ -7544,7 +15027,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 2,
+          "unique_dancers": 104,
+          "points": 380,
+          "new_dancers": 14
+        },
+        {
+          "year": 2023,
+          "month": 2,
+          "unique_dancers": 118,
+          "points": 485,
+          "new_dancers": 21
+        },
+        {
+          "year": 2024,
+          "month": 2,
+          "unique_dancers": 125,
+          "points": 543,
+          "new_dancers": 22
+        },
+        {
+          "year": 2025,
+          "month": 2,
+          "unique_dancers": 123,
+          "points": 626,
+          "new_dancers": 20
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 145,
+          "points": 726,
+          "new_dancers": 26
+        }
+      ]
     },
     "273": {
       "event_id": 273,
@@ -7579,7 +15099,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 2,
+          "unique_dancers": 107,
+          "points": 398,
+          "new_dancers": 7
+        },
+        {
+          "year": 2023,
+          "month": 2,
+          "unique_dancers": 136,
+          "points": 555,
+          "new_dancers": 20
+        },
+        {
+          "year": 2024,
+          "month": 2,
+          "unique_dancers": 157,
+          "points": 677,
+          "new_dancers": 24
+        },
+        {
+          "year": 2025,
+          "month": 2,
+          "unique_dancers": 140,
+          "points": 694,
+          "new_dancers": 18
+        },
+        {
+          "year": 2026,
+          "month": 2,
+          "unique_dancers": 128,
+          "points": 623,
+          "new_dancers": 19
+        }
+      ]
     },
     "274": {
       "event_id": 274,
@@ -7610,7 +15167,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 2,
+          "unique_dancers": 50,
+          "points": 170,
+          "new_dancers": 6
+        }
+      ]
     },
     "275": {
       "event_id": 275,
@@ -7641,7 +15207,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 3,
+          "unique_dancers": 56,
+          "points": 175,
+          "new_dancers": 14
+        },
+        {
+          "year": 2023,
+          "month": 3,
+          "unique_dancers": 60,
+          "points": 224,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 4,
+          "unique_dancers": 59,
+          "points": 216,
+          "new_dancers": 18
+        },
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 65,
+          "points": 300,
+          "new_dancers": 14
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 60,
+          "points": 248,
+          "new_dancers": 10
+        }
+      ]
     },
     "276": {
       "event_id": 276,
@@ -7676,7 +15279,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 4,
+          "unique_dancers": 69,
+          "points": 251,
+          "new_dancers": 18
+        },
+        {
+          "year": 2018,
+          "month": 4,
+          "unique_dancers": 76,
+          "points": 240,
+          "new_dancers": 20
+        },
+        {
+          "year": 2019,
+          "month": 3,
+          "unique_dancers": 80,
+          "points": 257,
+          "new_dancers": 17
+        }
+      ]
     },
     "277": {
       "event_id": 277,
@@ -7707,7 +15333,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 5,
+          "unique_dancers": 42,
+          "points": 160,
+          "new_dancers": 22
+        },
+        {
+          "year": 2018,
+          "month": 5,
+          "unique_dancers": 29,
+          "points": 77,
+          "new_dancers": 12
+        },
+        {
+          "year": 2019,
+          "month": 5,
+          "unique_dancers": 56,
+          "points": 173,
+          "new_dancers": 7
+        }
+      ]
     },
     "278": {
       "event_id": 278,
@@ -7742,7 +15391,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 7,
+          "unique_dancers": 68,
+          "points": 230,
+          "new_dancers": 15
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 64,
+          "points": 249,
+          "new_dancers": 9
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 78,
+          "points": 314,
+          "new_dancers": 13
+        },
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 77,
+          "points": 312,
+          "new_dancers": 8
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 73,
+          "points": 299,
+          "new_dancers": 12
+        }
+      ]
     },
     "280": {
       "event_id": 280,
@@ -7777,7 +15463,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 7,
+          "unique_dancers": 61,
+          "points": 204,
+          "new_dancers": 6
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 71,
+          "points": 258,
+          "new_dancers": 19
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 101,
+          "points": 412,
+          "new_dancers": 12
+        },
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 109,
+          "points": 522,
+          "new_dancers": 27
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 91,
+          "points": 380,
+          "new_dancers": 21
+        }
+      ]
     },
     "281": {
       "event_id": 281,
@@ -7812,7 +15535,16 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 7,
+          "unique_dancers": 77,
+          "points": 269,
+          "new_dancers": 10
+        }
+      ]
     },
     "282": {
       "event_id": 282,
@@ -7851,7 +15583,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 8,
+          "unique_dancers": 103,
+          "points": 354,
+          "new_dancers": 27
+        },
+        {
+          "year": 2022,
+          "month": 8,
+          "unique_dancers": 85,
+          "points": 304,
+          "new_dancers": 8
+        },
+        {
+          "year": 2023,
+          "month": 8,
+          "unique_dancers": 134,
+          "points": 613,
+          "new_dancers": 29
+        },
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 153,
+          "points": 746,
+          "new_dancers": 32
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 157,
+          "points": 774,
+          "new_dancers": 19
+        }
+      ]
     },
     "283": {
       "event_id": 283,
@@ -7882,7 +15651,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 6,
+          "unique_dancers": 35,
+          "points": 110,
+          "new_dancers": 4
+        },
+        {
+          "year": 2017,
+          "month": 8,
+          "unique_dancers": 40,
+          "points": 130,
+          "new_dancers": 12
+        },
+        {
+          "year": 2019,
+          "month": 8,
+          "unique_dancers": 34,
+          "points": 87,
+          "new_dancers": 9
+        },
+        {
+          "year": 2022,
+          "month": 8,
+          "unique_dancers": 45,
+          "points": 130,
+          "new_dancers": 10
+        },
+        {
+          "year": 2023,
+          "month": 8,
+          "unique_dancers": 51,
+          "points": 178,
+          "new_dancers": 5
+        }
+      ]
     },
     "284": {
       "event_id": 284,
@@ -7917,7 +15723,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 9,
+          "unique_dancers": 70,
+          "points": 251,
+          "new_dancers": 14
+        },
+        {
+          "year": 2018,
+          "month": 9,
+          "unique_dancers": 76,
+          "points": 252,
+          "new_dancers": 13
+        },
+        {
+          "year": 2019,
+          "month": 9,
+          "unique_dancers": 96,
+          "points": 324,
+          "new_dancers": 21
+        }
+      ]
     },
     "285": {
       "event_id": 285,
@@ -7952,7 +15781,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 10,
+          "unique_dancers": 52,
+          "points": 176,
+          "new_dancers": 11
+        },
+        {
+          "year": 2018,
+          "month": 10,
+          "unique_dancers": 63,
+          "points": 183,
+          "new_dancers": 8
+        }
+      ]
     },
     "286": {
       "event_id": 286,
@@ -7983,7 +15828,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 10,
+          "unique_dancers": 65,
+          "points": 206,
+          "new_dancers": 10
+        },
+        {
+          "year": 2022,
+          "month": 10,
+          "unique_dancers": 81,
+          "points": 284,
+          "new_dancers": 11
+        },
+        {
+          "year": 2023,
+          "month": 10,
+          "unique_dancers": 116,
+          "points": 479,
+          "new_dancers": 28
+        },
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 105,
+          "points": 427,
+          "new_dancers": 19
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 96,
+          "points": 445,
+          "new_dancers": 22
+        }
+      ]
     },
     "287": {
       "event_id": 287,
@@ -8018,7 +15900,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2017,
+          "month": 11,
+          "unique_dancers": 53,
+          "points": 190,
+          "new_dancers": 1
+        },
+        {
+          "year": 2018,
+          "month": 11,
+          "unique_dancers": 49,
+          "points": 168,
+          "new_dancers": 5
+        }
+      ]
     },
     "288": {
       "event_id": 288,
@@ -8057,7 +15955,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 11,
+          "unique_dancers": 79,
+          "points": 260,
+          "new_dancers": 13
+        },
+        {
+          "year": 2022,
+          "month": 11,
+          "unique_dancers": 102,
+          "points": 353,
+          "new_dancers": 17
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 97,
+          "points": 337,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 11,
+          "unique_dancers": 105,
+          "points": 383,
+          "new_dancers": 15
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 137,
+          "points": 591,
+          "new_dancers": 25
+        }
+      ]
     },
     "289": {
       "event_id": 289,
@@ -8096,7 +16031,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 1,
+          "unique_dancers": 88,
+          "points": 290,
+          "new_dancers": 12
+        },
+        {
+          "year": 2023,
+          "month": 1,
+          "unique_dancers": 121,
+          "points": 424,
+          "new_dancers": 21
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 130,
+          "points": 549,
+          "new_dancers": 21
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 141,
+          "points": 608,
+          "new_dancers": 22
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 154,
+          "points": 748,
+          "new_dancers": 18
+        }
+      ]
     },
     "290": {
       "event_id": 290,
@@ -8131,7 +16103,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 12,
+          "unique_dancers": 46,
+          "points": 130,
+          "new_dancers": 2
+        },
+        {
+          "year": 2022,
+          "month": 12,
+          "unique_dancers": 56,
+          "points": 175,
+          "new_dancers": 9
+        },
+        {
+          "year": 2023,
+          "month": 12,
+          "unique_dancers": 59,
+          "points": 231,
+          "new_dancers": 1
+        },
+        {
+          "year": 2024,
+          "month": 12,
+          "unique_dancers": 94,
+          "points": 365,
+          "new_dancers": 20
+        },
+        {
+          "year": 2025,
+          "month": 12,
+          "unique_dancers": 92,
+          "points": 398,
+          "new_dancers": 8
+        }
+      ]
     },
     "291": {
       "event_id": 291,
@@ -8166,7 +16175,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 1,
+          "unique_dancers": 42,
+          "points": 110,
+          "new_dancers": 11
+        },
+        {
+          "year": 2019,
+          "month": 1,
+          "unique_dancers": 46,
+          "points": 146,
+          "new_dancers": 12
+        },
+        {
+          "year": 2020,
+          "month": 1,
+          "unique_dancers": 54,
+          "points": 152,
+          "new_dancers": 11
+        }
+      ]
     },
     "292": {
       "event_id": 292,
@@ -8201,7 +16233,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 3,
+          "unique_dancers": 102,
+          "points": 359,
+          "new_dancers": 24
+        },
+        {
+          "year": 2023,
+          "month": 3,
+          "unique_dancers": 113,
+          "points": 442,
+          "new_dancers": 18
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 125,
+          "points": 556,
+          "new_dancers": 24
+        },
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 120,
+          "points": 610,
+          "new_dancers": 27
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 114,
+          "points": 580,
+          "new_dancers": 25
+        }
+      ]
     },
     "293": {
       "event_id": 293,
@@ -8236,7 +16305,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 4,
+          "unique_dancers": 83,
+          "points": 306,
+          "new_dancers": 9
+        },
+        {
+          "year": 2023,
+          "month": 4,
+          "unique_dancers": 111,
+          "points": 439,
+          "new_dancers": 17
+        },
+        {
+          "year": 2024,
+          "month": 4,
+          "unique_dancers": 117,
+          "points": 465,
+          "new_dancers": 13
+        },
+        {
+          "year": 2025,
+          "month": 4,
+          "unique_dancers": 113,
+          "points": 476,
+          "new_dancers": 18
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 107,
+          "points": 482,
+          "new_dancers": 23
+        }
+      ]
     },
     "294": {
       "event_id": 294,
@@ -8271,7 +16377,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 10,
+          "unique_dancers": 38,
+          "points": 132,
+          "new_dancers": 3
+        },
+        {
+          "year": 2019,
+          "month": 10,
+          "unique_dancers": 41,
+          "points": 133,
+          "new_dancers": 0
+        }
+      ]
     },
     "296": {
       "event_id": 296,
@@ -8298,7 +16420,16 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 9,
+          "unique_dancers": 37,
+          "points": 107,
+          "new_dancers": 5
+        }
+      ]
     },
     "297": {
       "event_id": 297,
@@ -8333,7 +16464,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 2,
+          "unique_dancers": 37,
+          "points": 99,
+          "new_dancers": 9
+        },
+        {
+          "year": 2023,
+          "month": 2,
+          "unique_dancers": 41,
+          "points": 126,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 2,
+          "unique_dancers": 54,
+          "points": 177,
+          "new_dancers": 16
+        },
+        {
+          "year": 2025,
+          "month": 2,
+          "unique_dancers": 79,
+          "points": 341,
+          "new_dancers": 20
+        },
+        {
+          "year": 2026,
+          "month": 2,
+          "unique_dancers": 79,
+          "points": 331,
+          "new_dancers": 9
+        }
+      ]
     },
     "298": {
       "event_id": 298,
@@ -8364,7 +16532,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 8,
+          "unique_dancers": 32,
+          "points": 104,
+          "new_dancers": 7
+        },
+        {
+          "year": 2019,
+          "month": 8,
+          "unique_dancers": 42,
+          "points": 126,
+          "new_dancers": 13
+        },
+        {
+          "year": 2023,
+          "month": 8,
+          "unique_dancers": 34,
+          "points": 114,
+          "new_dancers": 7
+        },
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 35,
+          "points": 135,
+          "new_dancers": 4
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 37,
+          "points": 137,
+          "new_dancers": 7
+        }
+      ]
     },
     "299": {
       "event_id": 299,
@@ -8399,7 +16604,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 9,
+          "unique_dancers": 51,
+          "points": 163,
+          "new_dancers": 9
+        },
+        {
+          "year": 2019,
+          "month": 8,
+          "unique_dancers": 52,
+          "points": 171,
+          "new_dancers": 6
+        }
+      ]
     },
     "300": {
       "event_id": 300,
@@ -8438,7 +16659,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 9,
+          "unique_dancers": 80,
+          "points": 266,
+          "new_dancers": 11
+        },
+        {
+          "year": 2019,
+          "month": 9,
+          "unique_dancers": 94,
+          "points": 331,
+          "new_dancers": 3
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 112,
+          "points": 405,
+          "new_dancers": 17
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 121,
+          "points": 499,
+          "new_dancers": 24
+        }
+      ]
     },
     "301": {
       "event_id": 301,
@@ -8469,7 +16720,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 1,
+          "unique_dancers": 49,
+          "points": 141,
+          "new_dancers": 3
+        },
+        {
+          "year": 2023,
+          "month": 1,
+          "unique_dancers": 59,
+          "points": 236,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 108,
+          "points": 418,
+          "new_dancers": 19
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 84,
+          "points": 354,
+          "new_dancers": 17
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 89,
+          "points": 393,
+          "new_dancers": 8
+        }
+      ]
     },
     "302": {
       "event_id": 302,
@@ -8500,7 +16788,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 2,
+          "unique_dancers": 38,
+          "points": 108,
+          "new_dancers": 11
+        },
+        {
+          "year": 2020,
+          "month": 2,
+          "unique_dancers": 38,
+          "points": 108,
+          "new_dancers": 4
+        },
+        {
+          "year": 2023,
+          "month": 2,
+          "unique_dancers": 24,
+          "points": 82,
+          "new_dancers": 3
+        },
+        {
+          "year": 2025,
+          "month": 2,
+          "unique_dancers": 40,
+          "points": 136,
+          "new_dancers": 8
+        }
+      ]
     },
     "303": {
       "event_id": 303,
@@ -8535,7 +16853,37 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2018,
+          "month": 7,
+          "unique_dancers": 29,
+          "points": 93,
+          "new_dancers": 2
+        },
+        {
+          "year": 2019,
+          "month": 7,
+          "unique_dancers": 26,
+          "points": 76,
+          "new_dancers": 3
+        },
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 41,
+          "points": 156,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 7,
+          "unique_dancers": 52,
+          "points": 206,
+          "new_dancers": 8
+        }
+      ]
     },
     "304": {
       "event_id": 304,
@@ -8570,7 +16918,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 4,
+          "unique_dancers": 50,
+          "points": 150,
+          "new_dancers": 8
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 108,
+          "points": 467,
+          "new_dancers": 18
+        }
+      ]
     },
     "306": {
       "event_id": 306,
@@ -8597,7 +16961,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 4,
+          "unique_dancers": 31,
+          "points": 94,
+          "new_dancers": 15
+        }
+      ]
     },
     "309": {
       "event_id": 309,
@@ -8632,7 +17005,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 1,
+          "unique_dancers": 73,
+          "points": 228,
+          "new_dancers": 11
+        },
+        {
+          "year": 2023,
+          "month": 1,
+          "unique_dancers": 74,
+          "points": 260,
+          "new_dancers": 6
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 70,
+          "points": 275,
+          "new_dancers": 6
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 105,
+          "points": 467,
+          "new_dancers": 18
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 99,
+          "points": 417,
+          "new_dancers": 14
+        }
+      ]
     },
     "310": {
       "event_id": 310,
@@ -8667,7 +17077,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2020,
+          "month": 2,
+          "unique_dancers": 56,
+          "points": 162,
+          "new_dancers": 8
+        },
+        {
+          "year": 2023,
+          "month": 2,
+          "unique_dancers": 63,
+          "points": 223,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 2,
+          "unique_dancers": 73,
+          "points": 276,
+          "new_dancers": 8
+        },
+        {
+          "year": 2025,
+          "month": 2,
+          "unique_dancers": 67,
+          "points": 262,
+          "new_dancers": 9
+        },
+        {
+          "year": 2026,
+          "month": 2,
+          "unique_dancers": 81,
+          "points": 332,
+          "new_dancers": 15
+        }
+      ]
     },
     "311": {
       "event_id": 311,
@@ -8702,7 +17149,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 5,
+          "unique_dancers": 65,
+          "points": 193,
+          "new_dancers": 12
+        },
+        {
+          "year": 2023,
+          "month": 5,
+          "unique_dancers": 65,
+          "points": 201,
+          "new_dancers": 13
+        }
+      ]
     },
     "312": {
       "event_id": 312,
@@ -8737,7 +17200,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 11,
+          "unique_dancers": 69,
+          "points": 217,
+          "new_dancers": 10
+        },
+        {
+          "year": 2022,
+          "month": 11,
+          "unique_dancers": 74,
+          "points": 238,
+          "new_dancers": 12
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 101,
+          "points": 390,
+          "new_dancers": 13
+        },
+        {
+          "year": 2024,
+          "month": 11,
+          "unique_dancers": 99,
+          "points": 380,
+          "new_dancers": 12
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 94,
+          "points": 383,
+          "new_dancers": 10
+        }
+      ]
     },
     "313": {
       "event_id": 313,
@@ -8772,7 +17272,44 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 9,
+          "unique_dancers": 87,
+          "points": 316,
+          "new_dancers": 22
+        },
+        {
+          "year": 2022,
+          "month": 9,
+          "unique_dancers": 96,
+          "points": 330,
+          "new_dancers": 17
+        },
+        {
+          "year": 2023,
+          "month": 9,
+          "unique_dancers": 112,
+          "points": 436,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 124,
+          "points": 495,
+          "new_dancers": 16
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 106,
+          "points": 505,
+          "new_dancers": 11
+        }
+      ]
     },
     "314": {
       "event_id": 314,
@@ -8807,7 +17344,44 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 3,
+          "unique_dancers": 69,
+          "points": 260,
+          "new_dancers": 8
+        },
+        {
+          "year": 2023,
+          "month": 3,
+          "unique_dancers": 103,
+          "points": 412,
+          "new_dancers": 9
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 119,
+          "points": 483,
+          "new_dancers": 11
+        },
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 116,
+          "points": 516,
+          "new_dancers": 19
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 122,
+          "points": 573,
+          "new_dancers": 14
+        }
+      ]
     },
     "318": {
       "event_id": 318,
@@ -8842,7 +17416,37 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 3,
+          "unique_dancers": 65,
+          "points": 227,
+          "new_dancers": 2
+        },
+        {
+          "year": 2023,
+          "month": 3,
+          "unique_dancers": 90,
+          "points": 377,
+          "new_dancers": 7
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 76,
+          "points": 257,
+          "new_dancers": 10
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 81,
+          "points": 339,
+          "new_dancers": 15
+        }
+      ]
     },
     "322": {
       "event_id": 322,
@@ -8881,7 +17485,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2019,
+          "month": 10,
+          "unique_dancers": 80,
+          "points": 244,
+          "new_dancers": 10
+        },
+        {
+          "year": 2022,
+          "month": 10,
+          "unique_dancers": 81,
+          "points": 259,
+          "new_dancers": 10
+        },
+        {
+          "year": 2023,
+          "month": 10,
+          "unique_dancers": 113,
+          "points": 434,
+          "new_dancers": 15
+        },
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 134,
+          "points": 541,
+          "new_dancers": 22
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 150,
+          "points": 708,
+          "new_dancers": 19
+        }
+      ]
     },
     "323": {
       "event_id": 323,
@@ -8916,7 +17557,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 11,
+          "unique_dancers": 36,
+          "points": 127,
+          "new_dancers": 14
+        },
+        {
+          "year": 2022,
+          "month": 11,
+          "unique_dancers": 39,
+          "points": 129,
+          "new_dancers": 7
+        },
+        {
+          "year": 2023,
+          "month": 11,
+          "unique_dancers": 68,
+          "points": 262,
+          "new_dancers": 11
+        },
+        {
+          "year": 2024,
+          "month": 11,
+          "unique_dancers": 56,
+          "points": 192,
+          "new_dancers": 4
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 66,
+          "points": 235,
+          "new_dancers": 9
+        }
+      ]
     },
     "324": {
       "event_id": 324,
@@ -8951,7 +17629,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2023,
+          "month": 4,
+          "unique_dancers": 56,
+          "points": 203,
+          "new_dancers": 13
+        },
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 69,
+          "points": 244,
+          "new_dancers": 13
+        },
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 82,
+          "points": 335,
+          "new_dancers": 14
+        }
+      ]
     },
     "330": {
       "event_id": 330,
@@ -8986,7 +17687,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2021,
+          "month": 11,
+          "unique_dancers": 27,
+          "points": 86,
+          "new_dancers": 9
+        },
+        {
+          "year": 2022,
+          "month": 11,
+          "unique_dancers": 47,
+          "points": 152,
+          "new_dancers": 6
+        },
+        {
+          "year": 2023,
+          "month": 10,
+          "unique_dancers": 54,
+          "points": 185,
+          "new_dancers": 13
+        },
+        {
+          "year": 2024,
+          "month": 11,
+          "unique_dancers": 51,
+          "points": 184,
+          "new_dancers": 5
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 69,
+          "points": 282,
+          "new_dancers": 13
+        }
+      ]
     },
     "331": {
       "event_id": 331,
@@ -9021,7 +17759,37 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2023,
+          "month": 7,
+          "unique_dancers": 83,
+          "points": 304,
+          "new_dancers": 17
+        },
+        {
+          "year": 2024,
+          "month": 6,
+          "unique_dancers": 97,
+          "points": 354,
+          "new_dancers": 20
+        },
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 85,
+          "points": 329,
+          "new_dancers": 19
+        },
+        {
+          "year": 2026,
+          "month": 6,
+          "unique_dancers": 88,
+          "points": 339,
+          "new_dancers": 21
+        }
+      ]
     },
     "333": {
       "event_id": 333,
@@ -9052,7 +17820,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2024,
+          "month": 3,
+          "unique_dancers": 40,
+          "points": 140,
+          "new_dancers": 8
+        },
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 38,
+          "points": 137,
+          "new_dancers": 9
+        },
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 41,
+          "points": 166,
+          "new_dancers": 5
+        }
+      ]
     },
     "334": {
       "event_id": 334,
@@ -9091,7 +17882,44 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2022,
+          "month": 1,
+          "unique_dancers": 61,
+          "points": 183,
+          "new_dancers": 5
+        },
+        {
+          "year": 2023,
+          "month": 1,
+          "unique_dancers": 117,
+          "points": 396,
+          "new_dancers": 14
+        },
+        {
+          "year": 2024,
+          "month": 1,
+          "unique_dancers": 112,
+          "points": 439,
+          "new_dancers": 18
+        },
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 106,
+          "points": 421,
+          "new_dancers": 12
+        },
+        {
+          "year": 2026,
+          "month": 1,
+          "unique_dancers": 87,
+          "points": 364,
+          "new_dancers": 9
+        }
+      ]
     },
     "336": {
       "event_id": 336,
@@ -9126,7 +17954,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 75,
+          "points": 303,
+          "new_dancers": 18
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 86,
+          "points": 344,
+          "new_dancers": 20
+        }
+      ]
     },
     "338": {
       "event_id": 338,
@@ -9161,7 +18005,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2024,
+          "month": 9,
+          "unique_dancers": 39,
+          "points": 126,
+          "new_dancers": 12
+        },
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 64,
+          "points": 237,
+          "new_dancers": 8
+        }
+      ]
     },
     "339": {
       "event_id": 339,
@@ -9192,7 +18052,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2024,
+          "month": 8,
+          "unique_dancers": 77,
+          "points": 310,
+          "new_dancers": 23
+        },
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 75,
+          "points": 352,
+          "new_dancers": 16
+        }
+      ]
     },
     "340": {
       "event_id": 340,
@@ -9227,7 +18103,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2024,
+          "month": 11,
+          "unique_dancers": 43,
+          "points": 150,
+          "new_dancers": 8
+        },
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 52,
+          "points": 181,
+          "new_dancers": 12
+        }
+      ]
     },
     "342": {
       "event_id": 342,
@@ -9266,7 +18158,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2023,
+          "month": 12,
+          "unique_dancers": 121,
+          "points": 432,
+          "new_dancers": 14
+        },
+        {
+          "year": 2024,
+          "month": 12,
+          "unique_dancers": 110,
+          "points": 416,
+          "new_dancers": 13
+        },
+        {
+          "year": 2025,
+          "month": 12,
+          "unique_dancers": 104,
+          "points": 413,
+          "new_dancers": 9
+        }
+      ]
     },
     "343": {
       "event_id": 343,
@@ -9301,7 +18216,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 2,
+          "unique_dancers": 88,
+          "points": 342,
+          "new_dancers": 10
+        },
+        {
+          "year": 2026,
+          "month": 2,
+          "unique_dancers": 97,
+          "points": 392,
+          "new_dancers": 12
+        }
+      ]
     },
     "344": {
       "event_id": 344,
@@ -9336,7 +18267,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 2,
+          "unique_dancers": 73,
+          "points": 334,
+          "new_dancers": 17
+        },
+        {
+          "year": 2026,
+          "month": 2,
+          "unique_dancers": 75,
+          "points": 354,
+          "new_dancers": 11
+        }
+      ]
     },
     "345": {
       "event_id": 345,
@@ -9371,7 +18318,30 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2024,
+          "month": 4,
+          "unique_dancers": 78,
+          "points": 304,
+          "new_dancers": 16
+        },
+        {
+          "year": 2025,
+          "month": 4,
+          "unique_dancers": 75,
+          "points": 312,
+          "new_dancers": 9
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 77,
+          "points": 303,
+          "new_dancers": 9
+        }
+      ]
     },
     "346": {
       "event_id": 346,
@@ -9406,7 +18376,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 96,
+          "points": 376,
+          "new_dancers": 19
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 99,
+          "points": 414,
+          "new_dancers": 23
+        }
+      ]
     },
     "347": {
       "event_id": 347,
@@ -9441,7 +18427,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 70,
+          "points": 310,
+          "new_dancers": 19
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 72,
+          "points": 280,
+          "new_dancers": 14
+        }
+      ]
     },
     "348": {
       "event_id": 348,
@@ -9476,7 +18478,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 3,
+          "unique_dancers": 100,
+          "points": 416,
+          "new_dancers": 19
+        },
+        {
+          "year": 2026,
+          "month": 2,
+          "unique_dancers": 114,
+          "points": 506,
+          "new_dancers": 23
+        }
+      ]
     },
     "350": {
       "event_id": 350,
@@ -9511,7 +18529,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 83,
+          "points": 316,
+          "new_dancers": 19
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 96,
+          "points": 374,
+          "new_dancers": 11
+        }
+      ]
     },
     "352": {
       "event_id": 352,
@@ -9546,7 +18580,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 4,
+          "unique_dancers": 104,
+          "points": 511,
+          "new_dancers": 21
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 101,
+          "points": 442,
+          "new_dancers": 18
+        }
+      ]
     },
     "354": {
       "event_id": 354,
@@ -9585,7 +18635,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 125,
+          "points": 547,
+          "new_dancers": 16
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 116,
+          "points": 475,
+          "new_dancers": 15
+        }
+      ]
     },
     "355": {
       "event_id": 355,
@@ -9620,7 +18686,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 39,
+          "points": 119,
+          "new_dancers": 4
+        }
+      ]
     },
     "356": {
       "event_id": 356,
@@ -9655,7 +18730,16 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 65,
+          "points": 240,
+          "new_dancers": 9
+        }
+      ]
     },
     "357": {
       "event_id": 357,
@@ -9690,7 +18774,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 105,
+          "points": 430,
+          "new_dancers": 19
+        }
+      ]
     },
     "359": {
       "event_id": 359,
@@ -9725,7 +18818,16 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 90,
+          "points": 355,
+          "new_dancers": 16
+        }
+      ]
     },
     "360": {
       "event_id": 360,
@@ -9760,7 +18862,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 76,
+          "points": 334,
+          "new_dancers": 17
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 81,
+          "points": 324,
+          "new_dancers": 15
+        }
+      ]
     },
     "361": {
       "event_id": 361,
@@ -9795,7 +18913,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 9,
+          "unique_dancers": 66,
+          "points": 261,
+          "new_dancers": 12
+        }
+      ]
     },
     "362": {
       "event_id": 362,
@@ -9830,7 +18957,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 90,
+          "points": 399,
+          "new_dancers": 25
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 94,
+          "points": 405,
+          "new_dancers": 27
+        }
+      ]
     },
     "363": {
       "event_id": 363,
@@ -9861,7 +19004,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 2,
+          "unique_dancers": 43,
+          "points": 139,
+          "new_dancers": 15
+        },
+        {
+          "year": 2026,
+          "month": 2,
+          "unique_dancers": 61,
+          "points": 232,
+          "new_dancers": 11
+        }
+      ]
     },
     "364": {
       "event_id": 364,
@@ -9892,7 +19051,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 54,
+          "points": 192,
+          "new_dancers": 7
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 54,
+          "points": 197,
+          "new_dancers": 12
+        }
+      ]
     },
     "365": {
       "event_id": 365,
@@ -9923,7 +19098,16 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 55,
+          "points": 215,
+          "new_dancers": 13
+        }
+      ]
     },
     "367": {
       "event_id": 367,
@@ -9950,7 +19134,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2024,
+          "month": 10,
+          "unique_dancers": 25,
+          "points": 83,
+          "new_dancers": 18
+        },
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 30,
+          "points": 127,
+          "new_dancers": 14
+        }
+      ]
     },
     "368": {
       "event_id": 368,
@@ -9981,7 +19181,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 66,
+          "points": 264,
+          "new_dancers": 21
+        }
+      ]
     },
     "369": {
       "event_id": 369,
@@ -10020,7 +19229,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 108,
+          "points": 422,
+          "new_dancers": 19
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 106,
+          "points": 405,
+          "new_dancers": 17
+        }
+      ]
     },
     "370": {
       "event_id": 370,
@@ -10055,7 +19280,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 4,
+          "unique_dancers": 108,
+          "points": 496,
+          "new_dancers": 19
+        },
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 103,
+          "points": 458,
+          "new_dancers": 21
+        }
+      ]
     },
     "371": {
       "event_id": 371,
@@ -10086,7 +19327,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 41,
+          "points": 199,
+          "new_dancers": 7
+        },
+        {
+          "year": 2026,
+          "month": 6,
+          "unique_dancers": 48,
+          "points": 188,
+          "new_dancers": 5
+        }
+      ]
     },
     "372": {
       "event_id": 372,
@@ -10121,7 +19378,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 81,
+          "points": 327,
+          "new_dancers": 20
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 81,
+          "points": 310,
+          "new_dancers": 10
+        }
+      ]
     },
     "373": {
       "event_id": 373,
@@ -10160,7 +19433,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 109,
+          "points": 475,
+          "new_dancers": 21
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 111,
+          "points": 495,
+          "new_dancers": 9
+        }
+      ]
     },
     "374": {
       "event_id": 374,
@@ -10191,7 +19480,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 6,
+          "unique_dancers": 83,
+          "points": 335,
+          "new_dancers": 19
+        },
+        {
+          "year": 2026,
+          "month": 6,
+          "unique_dancers": 84,
+          "points": 374,
+          "new_dancers": 17
+        }
+      ]
     },
     "375": {
       "event_id": 375,
@@ -10226,7 +19531,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 121,
+          "points": 582,
+          "new_dancers": 22
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 99,
+          "points": 465,
+          "new_dancers": 22
+        }
+      ]
     },
     "376": {
       "event_id": 376,
@@ -10261,7 +19582,16 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 11,
+          "unique_dancers": 93,
+          "points": 410,
+          "new_dancers": 14
+        }
+      ]
     },
     "377": {
       "event_id": 377,
@@ -10296,7 +19626,16 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 12,
+          "unique_dancers": 96,
+          "points": 415,
+          "new_dancers": 19
+        }
+      ]
     },
     "378": {
       "event_id": 378,
@@ -10331,7 +19670,16 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 78,
+          "points": 264,
+          "new_dancers": 11
+        }
+      ]
     },
     "379": {
       "event_id": 379,
@@ -10366,7 +19714,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 5,
+          "unique_dancers": 89,
+          "points": 393,
+          "new_dancers": 13
+        },
+        {
+          "year": 2026,
+          "month": 5,
+          "unique_dancers": 128,
+          "points": 601,
+          "new_dancers": 22
+        }
+      ]
     },
     "380": {
       "event_id": 380,
@@ -10397,7 +19761,16 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 58,
+          "points": 209,
+          "new_dancers": 10
+        }
+      ]
     },
     "381": {
       "event_id": 381,
@@ -10428,7 +19801,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 1,
+          "unique_dancers": 35,
+          "points": 158,
+          "new_dancers": 4
+        }
+      ]
     },
     "382": {
       "event_id": 382,
@@ -10463,7 +19845,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 88,
+          "points": 383,
+          "new_dancers": 20
+        },
+        {
+          "year": 2026,
+          "month": 8,
+          "unique_dancers": 96,
+          "points": 463,
+          "new_dancers": 10
+        }
+      ]
     },
     "383": {
       "event_id": 383,
@@ -10498,7 +19896,23 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 93,
+          "points": 358,
+          "new_dancers": 22
+        },
+        {
+          "year": 2026,
+          "month": 8,
+          "unique_dancers": 100,
+          "points": 461,
+          "new_dancers": 21
+        }
+      ]
     },
     "384": {
       "event_id": 384,
@@ -10533,7 +19947,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 69,
+          "points": 241,
+          "new_dancers": 18
+        }
+      ]
     },
     "385": {
       "event_id": 385,
@@ -10568,7 +19991,23 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 7,
+          "unique_dancers": 51,
+          "points": 171,
+          "new_dancers": 13
+        },
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 72,
+          "points": 305,
+          "new_dancers": 17
+        }
+      ]
     },
     "386": {
       "event_id": 386,
@@ -10603,7 +20042,16 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2026,
+          "month": 2,
+          "unique_dancers": 105,
+          "points": 512,
+          "new_dancers": 15
+        }
+      ]
     },
     "387": {
       "event_id": 387,
@@ -10638,7 +20086,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2026,
+          "month": 2,
+          "unique_dancers": 72,
+          "points": 270,
+          "new_dancers": 19
+        }
+      ]
     },
     "388": {
       "event_id": 388,
@@ -10673,7 +20130,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 10,
+          "unique_dancers": 75,
+          "points": 280,
+          "new_dancers": 20
+        }
+      ]
     },
     "389": {
       "event_id": 389,
@@ -10708,7 +20174,16 @@
             "Follower": 2
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 106,
+          "points": 512,
+          "new_dancers": 17
+        }
+      ]
     },
     "391": {
       "event_id": 391,
@@ -10739,7 +20214,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2025,
+          "month": 8,
+          "unique_dancers": 70,
+          "points": 262,
+          "new_dancers": 16
+        }
+      ]
     },
     "393": {
       "event_id": 393,
@@ -10774,7 +20258,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2026,
+          "month": 4,
+          "unique_dancers": 81,
+          "points": 321,
+          "new_dancers": 16
+        }
+      ]
     },
     "394": {
       "event_id": 394,
@@ -10809,7 +20302,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2026,
+          "month": 3,
+          "unique_dancers": 60,
+          "points": 266,
+          "new_dancers": 12
+        }
+      ]
     },
     "404": {
       "event_id": 404,
@@ -10840,7 +20342,16 @@
             "Follower": 3
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2026,
+          "month": 7,
+          "unique_dancers": 76,
+          "points": 307,
+          "new_dancers": 16
+        }
+      ]
     },
     "405": {
       "event_id": 405,
@@ -10875,7 +20386,16 @@
             "Follower": 1
           }
         }
-      }
+      },
+      "history": [
+        {
+          "year": 2026,
+          "month": 6,
+          "unique_dancers": 80,
+          "points": 298,
+          "new_dancers": 14
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Segmented control under last-edition date: Metrics ↔ Tiers (default Tiers).
- Metrics: Dancers/Points/New + compact sparkline (series switches with metric click).
- Tiers: table + `i` tip only in this mode; crossfade between panels.
- Refresh companion `event_l2_cards.json` with `history`.

## Test plan
- [x] `python3 scripts/validate_site_data.py`
- [ ] Open a registry event → Tiers by default; switch to Metrics; sparkline updates when clicking Dancers/Points/New
- [ ] Switch events in the same day → mode remembered; close day island → resets to Tiers
- [ ] Trial / no scored data → empty right as before
- [ ] Mobile still uses the same segmented control


Made with [Cursor](https://cursor.com)