### PR TITLE
Raise Pages deploy-pages timeout to 30m

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -51,3 +51,6 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          # Default 10m aborts while Pages is still in deployment_queued and can wedge the SHA.
+          timeout: 1800000


### PR DESCRIPTION
## Summary
- Set `actions/deploy-pages` `timeout` from the default 10 minutes to 30 minutes.
- Reduces false aborts while Pages sits in `deployment_queued`, which can cancel the deployment and wedge the commit SHA.

## Test plan
- [ ] Merge and watch Deploy to GitHub Pages: deploy step should be allowed to wait longer than 10m
- [ ] Confirm live `events-calendar.html` picks up `css?v=20260806e` after a successful deploy

Made with [Cursor](https://cursor.com)