### PR TITLE
L2 card: spacing, tip placement, chart axis padding

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260806e">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260806f">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -1477,7 +1477,9 @@
       return tiers && tiers[div] && tiers[div].Leader != null && tiers[div].Follower != null;
     });
     if (!rows.length) return "";
+    var tipHtml = buildInfoTipHtml(t("tierTipAria"), tierTipText());
     var html = '<div class="l2-tier-panel">' +
+      '<div class="l2-tier-panel__head">' + tipHtml + "</div>" +
       '<table class="l2-tier-table">' +
       "<thead><tr>" +
       "<th></th>" +
@@ -1520,16 +1522,23 @@
     });
     var w = 240;
     var h = 88;
-    var padL = 2;
-    var padR = 4;
-    var padT = 6;
-    var padB = 6;
-    var min = Math.min.apply(null, values);
-    var max = Math.max.apply(null, values);
+    // Keep points/years off the plot edges.
+    var padL = 16;
+    var padR = 16;
+    var padT = 10;
+    var padB = 10;
+    var dataMin = Math.min.apply(null, values);
+    var dataMax = Math.max.apply(null, values);
+    var dataSpan = dataMax - dataMin;
+    var yPad = dataSpan === 0 ? Math.max(Math.abs(dataMax) * 0.15, 1) : dataSpan * 0.18;
+    var min = dataMin - yPad;
+    var max = dataMax + yPad;
     var span = max - min || 1;
+    var plotW = w - padL - padR;
+    var plotH = h - padT - padB;
     var points = values.map(function (v, i) {
-      var x = padL + (rows.length === 1 ? (w - padL - padR) / 2 : (i / (rows.length - 1)) * (w - padL - padR));
-      var y = h - padB - ((v - min) / span) * (h - padT - padB);
+      var x = padL + (rows.length === 1 ? plotW / 2 : (i / (rows.length - 1)) * plotW);
+      var y = h - padB - ((v - min) / span) * plotH;
       return { x: x, y: y, v: v, label: monthYearLabel(rows[i].year, rows[i].month), year: rows[i].year };
     });
     var poly = points.map(function (p) { return p.x.toFixed(1) + "," + p.y.toFixed(1); }).join(" ");
@@ -1555,10 +1564,15 @@
       return "<span>" + esc(String(rows[idx].year)) + "</span>";
     }).join("");
 
+    function axisLabel(n) {
+      var rounded = Math.abs(n) >= 100 ? Math.round(n) : Math.round(n * 10) / 10;
+      return String(rounded);
+    }
+
     return '<div class="l2-chart" role="img" aria-label="' + esc(t("sparkAria")) + '">' +
       '<div class="l2-chart__y" aria-hidden="true">' +
-      "<span>" + esc(String(max)) + "</span>" +
-      "<span>" + esc(String(min)) + "</span>" +
+      "<span>" + esc(axisLabel(max)) + "</span>" +
+      "<span>" + esc(axisLabel(min)) + "</span>" +
       "</div>" +
       '<div class="l2-chart__plot">' +
       '<svg class="l2-spark__svg" viewBox="0 0 ' + w + " " + h +
@@ -1665,7 +1679,6 @@
         '<span class="l2-event-card__last-label">' + esc(t("lastEdition")) + "</span>" +
         '<span class="l2-event-card__last-date">' +
         esc(monthYearLabel(last.year, last.month)) + "</span>" +
-        buildInfoTipHtml(t("tierTipAria"), tierTipText()) +
         "</div>" +
         '<div class="l2-event-card__head-control">' + buildLastMetricsHtml(last) + "</div>";
       tiersBody += buildTierTableHtml(last.tiers || {});

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -964,13 +964,15 @@ h1 {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
-  gap: 6px 12px;
+  gap: 8px 28px;
   height: 100%;
   min-height: 0;
+  padding: 0 2px;
 }
 
 .l2-event-card__grid.is-sparse {
-  grid-template-columns: minmax(0, 1.35fr) minmax(0, 0.65fr);
+  grid-template-columns: minmax(0, 1.25fr) minmax(0, 0.75fr);
+  gap: 8px 24px;
 }
 
 .l2-event-card__series-head,
@@ -983,15 +985,20 @@ h1 {
 
 .l2-event-card__series-head {
   justify-content: space-between;
+  padding-right: 4px;
 }
 
 .l2-event-card__last-head-block {
-  justify-content: space-between;
+  justify-content: flex-start;
+  align-items: center;
+  text-align: center;
+  padding-left: 4px;
 }
 
 .l2-event-card__head-control {
   margin-top: auto;
-  padding-top: 4px;
+  padding-top: 6px;
+  width: 100%;
 }
 
 .l2-event-card__chart-body,
@@ -1002,21 +1009,30 @@ h1 {
   flex-direction: column;
 }
 
+.l2-event-card__chart-body {
+  padding-right: 4px;
+}
+
+.l2-event-card__tiers-body {
+  padding-left: 4px;
+}
+
 .l2-event-card__empty {
   margin-top: 2px;
   font-style: italic;
 }
 
 .l2-event-card__title-row {
-  display: flex;
+  display: inline-flex;
   align-items: baseline;
-  gap: 6px;
+  gap: 5px;
+  max-width: 100%;
   min-width: 0;
 }
 
 .l2-event-card h3 {
   margin: 0;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-width: 0;
   font-size: 13px;
   font-weight: 650;
@@ -1066,9 +1082,12 @@ h1 {
 .l2-event-card__last-head {
   display: flex;
   align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
   gap: 6px;
   min-width: 0;
   min-height: 16px;
+  width: 100%;
 }
 
 .l2-event-card__last-label {
@@ -1087,14 +1106,15 @@ h1 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-width: 0;
 }
 
 .l2-event-card__metrics-row {
   display: flex;
   align-items: flex-start;
-  gap: 4px;
+  justify-content: center;
+  gap: 6px;
   min-width: 0;
 }
 
@@ -1156,8 +1176,8 @@ h1 {
   flex-direction: column;
   justify-content: space-between;
   flex: 0 0 auto;
-  width: 28px;
-  padding: 2px 0 14px;
+  width: 30px;
+  padding: 8px 0 18px;
   font-size: 8px;
   line-height: 1;
   font-variant-numeric: tabular-nums;
@@ -1178,6 +1198,7 @@ h1 {
   display: flex;
   justify-content: space-between;
   flex: 0 0 auto;
+  padding: 0 10px;
   font-size: 8px;
   line-height: 1;
   font-variant-numeric: tabular-nums;
@@ -1191,6 +1212,15 @@ h1 {
   min-height: 0;
   height: 100%;
   flex: 1 1 auto;
+}
+
+.l2-tier-panel__head {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  min-height: 16px;
+  flex: 0 0 auto;
+  margin-bottom: 2px;
 }
 
 .l2-info-tip {


### PR DESCRIPTION
## Summary
- Widen the gap between series and last-edition panels so the card feels less cramped.
- Keep the website arrow with the event title; center Last Edition in the right column.
- Place the tiers tip next to the tiers table and keep the metrics tip beside dancers/points/new.
- Add Y-range and X-edge padding on the trend chart so values/years are not clamped to the plot borders.

## Test plan
- [ ] Open a registry event with history: left/right panels have a clearer valley between them
- [ ] Confirm `↗` sits next to the event name, not visually glued to Last Edition
- [ ] Confirm Last Edition header is centered; metrics `i` and tiers `i` sit next to their blocks
- [ ] Toggle spark series and check Y/X labels leave breathing room around the line

Made with [Cursor](https://cursor.com)