### PR TITLE
L2 card: last-edition fallback for unscored past slots

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -1518,6 +1518,10 @@
     }
     var found = findEditionForCalendarEvent(card, e);
     if (found) return { edition: found, mode: "edition" };
+    // Past calendar slot with no scored row (hiatus / unscored): fall back to last edition.
+    if (card.last_edition) {
+      return { edition: card.last_edition, mode: "last" };
+    }
     return { edition: null, mode: "missing" };
   }
 


### PR DESCRIPTION
## Summary
- Past calendar events without a scored edition (e.g. hiatus) now show **Last edition** KPIs when `last_edition` exists
- Keeps **Edition** when scored stats match the calendar year; empty state only when there is no last edition either

## Test plan
- [ ] Open Dance Mardi Gras (Jul 2026, hiatus) → right panel shows Last edition (Jul 2025), not “No scored stats…”
- [ ] Open a past confirmed event with scored stats for that year → still labeled Edition with that year’s metrics
- [ ] Open an upcoming event → still Last edition as before

Made with [Cursor](https://cursor.com)