### PR TITLE
Calendar: continuous amber search-period highlight

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807s">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807t">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -880,7 +880,7 @@
   }
 
   function scrollHighlightIntoView() {
-    var hit = document.querySelector(".day.is-search-hit");
+    var hit = document.querySelector(".day.is-search-range");
     if (!hit) return;
     var month = hit.closest(".month");
     var target = month || hit;
@@ -1017,6 +1017,17 @@
         cells.push({ empty: true });
       }
       for (i = 0; i < cells.length; i++) {
+        var cell = cells[i];
+        if (!cell.searchHit) continue;
+        var row = Math.floor(i / 7);
+        var prev = i > 0 ? cells[i - 1] : null;
+        var next = i < cells.length - 1 ? cells[i + 1] : null;
+        var prevSameWeek = prev && Math.floor((i - 1) / 7) === row && prev.searchHit;
+        var nextSameWeek = next && Math.floor((i + 1) / 7) === row && next.searchHit;
+        cell.searchRangeStart = !prevSameWeek;
+        cell.searchRangeEnd = !nextSameWeek;
+      }
+      for (i = 0; i < cells.length; i++) {
         var c = cells[i];
         if (c.empty) {
           html += '<div class="day is-empty" aria-hidden="true"></div>';
@@ -1025,14 +1036,18 @@
         var cls = "day";
         if (c.occupied) cls += " has-events is-occupied dens-" + c.dens;
         if (c.selected) cls += " is-selected";
-        if (c.searchHit) cls += " is-search-hit";
+        if (c.searchHit) {
+          cls += " is-search-range";
+          if (c.searchRangeStart) cls += " is-search-range-start";
+          if (c.searchRangeEnd) cls += " is-search-range-end";
+        }
         if (c.today) cls += " is-today";
         if (c.past) cls += " is-past";
         html += '<button type="button" class="' + cls + '" data-date="' + c.iso + '"' +
           (c.occupied ? "" : " disabled") +
           ' aria-label="' + c.iso + (c.occupied ? ", " + c.count + " events" : "") +
           (c.today ? ", today" : "") +
-          (c.searchHit ? ", search match" : "") + '">';
+          (c.searchHit ? ", search period" : "") + '">';
         html += "<span>" + c.day + "</span>";
         html += "</button>";
       }

--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807t">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807u">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -109,6 +109,10 @@
                             <input type="search" class="cal-search__input" id="eventSearchInput" autocomplete="off" spellcheck="false" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-controls="eventSearchSuggestions" aria-labelledby="eventSearchLabel" data-i18n-placeholder="searchPlaceholder" placeholder="Event name…">
                             <div class="cal-search__suggestions" id="eventSearchSuggestions" role="listbox" aria-label="Matching events" hidden></div>
                         </div>
+                    </div>
+                    <div class="filter-field cal-reset-field">
+                        <span class="filter-label" aria-hidden="true">&nbsp;</span>
+                        <button type="button" class="cal-reset-btn" id="clearFiltersBtn" data-i18n="clearFilters">Clear filters</button>
                     </div>
                 </div>
             </div>
@@ -236,6 +240,7 @@
       searchPlaceholder: "Event name…",
       searchAria: "Search events by name in the selected year",
       searchNoMatches: "No matching events",
+      clearFilters: "Clear filters",
       allContinents: "All continents",
       allCountries: "All countries",
       allConfirmStatuses: "All confirm statuses",
@@ -301,6 +306,7 @@
       searchPlaceholder: "Название ивента…",
       searchAria: "Поиск ивентов по названию в выбранном году",
       searchNoMatches: "Нет совпадений",
+      clearFilters: "Сбросить фильтры",
       allContinents: "Все континенты",
       allCountries: "Все страны",
       allConfirmStatuses: "Все статусы подтверждения",
@@ -365,6 +371,7 @@
       searchPlaceholder: "Nombre del evento…",
       searchAria: "Buscar eventos por nombre en el año seleccionado",
       searchNoMatches: "Sin coincidencias",
+      clearFilters: "Borrar filtros",
       allContinents: "Todos los continentes",
       allCountries: "Todos los países",
       allConfirmStatuses: "Todas las confirmaciones",
@@ -700,8 +707,10 @@
     var countryList = Object.keys(countries).sort(function (a, b) {
       return a.localeCompare(b);
     });
+    // Keep a selected country across years even if it has no events this year.
     if (state.country && countries[state.country] !== true) {
-      state.country = "";
+      countryList.push(state.country);
+      countryList.sort(function (a, b) { return a.localeCompare(b); });
     }
     fillDropdown(
       document.getElementById("countryFilterMenu"),
@@ -734,8 +743,9 @@
     var kindOpts = KINDS.filter(function (k) { return kindPresent[k]; }).map(function (k) {
       return { value: k, label: kindLabel(k) };
     });
+    // Persist kind selection across years; surface it even if absent this year.
     if (state.kind && kindPresent[state.kind] !== true) {
-      state.kind = "";
+      kindOpts.push({ value: state.kind, label: kindLabel(state.kind) });
     }
     fillDropdown(
       document.getElementById("kindFilterMenu"),
@@ -889,35 +899,89 @@
     }
   }
 
+  function applyHighlightForEvent(e, opts) {
+    opts = opts || {};
+    if (!e) {
+      state.highlight = null;
+      return false;
+    }
+    var span = eventDateSpanInYear(e, state.year);
+    if (!span) {
+      state.highlight = null;
+      return false;
+    }
+    state.highlight = {
+      key: e.id,
+      eventId: e.event_id != null ? e.event_id : null,
+      nameNorm: normalizeSearchText(e.name),
+      start: span.start,
+      end: span.end
+    };
+    if (opts.syncInput) {
+      var input = document.getElementById("eventSearchInput");
+      if (input) input.value = e.name || "";
+    }
+    return true;
+  }
+
+  function rematchHighlightForYear() {
+    var h = state.highlight;
+    var input = document.getElementById("eventSearchInput");
+    var nameNorm = (h && h.nameNorm) || (input ? normalizeSearchText(input.value) : "");
+    if ((!h || h.eventId == null) && !nameNorm) {
+      state.highlight = null;
+      return;
+    }
+    var pool = eventsInYearRaw(state.year).filter(function (e) {
+      return !e.stats_only && e.start_date;
+    });
+    var match = null;
+    if (h && h.eventId != null) {
+      for (var i = 0; i < pool.length; i++) {
+        if (String(pool[i].event_id) === String(h.eventId)) {
+          match = pool[i];
+          break;
+        }
+      }
+    }
+    if (!match && nameNorm) {
+      for (var j = 0; j < pool.length; j++) {
+        if (normalizeSearchText(pool[j].name) === nameNorm) {
+          match = pool[j];
+          break;
+        }
+      }
+    }
+    if (!match && nameNorm) {
+      for (var k = 0; k < pool.length; k++) {
+        if (eventSearchHaystack(pool[k]).indexOf(nameNorm) !== -1) {
+          match = pool[k];
+          break;
+        }
+      }
+    }
+    if (match) applyHighlightForEvent(match);
+    else state.highlight = null;
+  }
+
+  function clearAllFilters() {
+    state.continent = "";
+    state.country = "";
+    state.status = "";
+    state.kind = "";
+    forceCloseDayIsland();
+    refreshFilterOptions();
+    renderCalendar();
+  }
+
   function selectEventFromSearch(eventKey) {
     var e = findEventByKey(eventKey);
     hideEventSearchSuggestions();
     if (!e) return;
-    var span = eventDateSpanInYear(e, state.year);
-    if (!span) return;
-    var input = document.getElementById("eventSearchInput");
-    if (input) input.value = e.name || "";
-    state.highlight = {
-      key: e.id,
-      start: span.start,
-      end: span.end
-    };
+    if (!applyHighlightForEvent(e, { syncInput: true })) return;
     renderCalendar();
     requestAnimationFrame(function () {
       scrollHighlightIntoView();
-      var openIso = span.start;
-      if (!(state.byDay[openIso] && state.byDay[openIso].length)) {
-        openIso = null;
-        eachIsoDay(span.start, span.end, function (iso) {
-          if (openIso) return;
-          if (state.byDay[iso] && state.byDay[iso].length) openIso = iso;
-        });
-      }
-      if (!openIso) return;
-      openDay(openIso);
-      // Avoid selectEvent toggle-off if the same id was already selected.
-      state.selectedEventId = null;
-      if (e.id != null) selectEvent(String(e.id));
     });
   }
 
@@ -2103,13 +2167,13 @@
   function setYear(y) {
     state.year = y;
     forceCloseDayIsland();
-    state.country = "";
-    state.status = "";
-    state.kind = "";
-    clearEventHighlight(true);
     renderYearSelect();
     refreshFilterOptions();
+    rematchHighlightForYear();
     renderCalendar();
+    requestAnimationFrame(function () {
+      if (state.highlight) scrollHighlightIntoView();
+    });
   }
 
   function applyFiltersAndRender() {
@@ -2246,6 +2310,12 @@
       e.stopPropagation();
     });
   })();
+
+  document.getElementById("clearFiltersBtn").addEventListener("click", function (e) {
+    e.stopPropagation();
+    closeAllFilterDropdowns();
+    clearAllFilters();
+  });
 
   document.getElementById("eventDetail").addEventListener("click", function (e) {
     var sparkBtn = e.target.closest("[data-spark]");

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -784,24 +784,52 @@ h1 {
   box-shadow: inset 0 0 0 1.5px var(--color-accent), inset 0 0 0 3px rgba(37, 99, 235, 0.2);
 }
 
-.day.is-search-hit {
-  box-shadow: inset 0 0 0 2px var(--color-accent);
-  color: var(--color-primary-dark);
-  font-weight: 700;
+/* Search period = continuous amber band (not Today’s blue day outline). */
+.day.is-search-range {
   z-index: 2;
 }
-.day.is-search-hit.is-occupied {
-  background: #dbeafe;
-  filter: none;
+.day.is-search-range > span {
+  position: relative;
+  z-index: 1;
 }
-.day.is-search-hit.is-past {
-  opacity: 0.92;
+.day.is-search-range::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 14%;
+  bottom: 14%;
+  background: rgba(245, 158, 11, 0.38);
+  pointer-events: none;
+  z-index: 0;
 }
-.day.is-search-hit.is-today {
-  box-shadow: inset 0 0 0 2px var(--color-accent), inset 0 0 0 4px rgba(37, 99, 235, 0.22);
+.day.is-search-range-start::before {
+  left: 10%;
+  border-radius: 999px 0 0 999px;
 }
-.day.is-search-hit.is-selected {
-  box-shadow: inset 0 0 0 2px var(--color-accent), inset 0 0 0 4px rgba(37, 99, 235, 0.28);
+.day.is-search-range-end::before {
+  right: 10%;
+  border-radius: 0 999px 999px 0;
+}
+.day.is-search-range-start.is-search-range-end::before {
+  left: 12%;
+  right: 12%;
+  border-radius: 999px;
+}
+.day.is-search-range.is-occupied {
+  color: #78350f;
+  font-weight: 700;
+}
+.day.is-search-range.is-past {
+  opacity: 0.95;
+}
+/* Today outline stays blue and sits above the amber period band. */
+.day.is-search-range.is-today {
+  box-shadow: inset 0 0 0 1.5px var(--color-accent);
+  color: var(--color-primary-dark);
+}
+.day.is-search-range.is-selected:not(.is-today) {
+  box-shadow: inset 0 0 0 1px #b45309;
 }
 
 .day.has-events:active {

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -230,6 +230,33 @@ h1 {
   color: var(--text-secondary, #64748b);
 }
 
+.cal-reset-field {
+  flex: 0 0 auto;
+  align-items: stretch;
+}
+
+.cal-reset-btn {
+  height: 34px;
+  margin: 0;
+  padding: 0 12px;
+  border: 1px solid var(--border-color, #d0d7e2);
+  border-radius: 8px;
+  background: var(--bg-primary, #fff);
+  color: var(--text-secondary, #64748b);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.cal-reset-btn:hover,
+.cal-reset-btn:focus-visible {
+  outline: none;
+  border-color: var(--color-accent, #2563eb);
+  color: var(--color-primary-dark, #1e3a8a);
+}
+
 .filter-label {
   display: block;
   width: 100%;
@@ -1843,6 +1870,10 @@ h1 {
     flex: 1 1 100%;
     max-width: none;
   }
+  .cal-reset-field {
+    flex: 1 1 100%;
+  }
+  .cal-reset-btn { width: 100%; }
   .cal-dd {
     width: 100%;
     --cal-dd-width: 100%;


### PR DESCRIPTION
## Summary
- Search match is a **continuous amber band** across the event’s date span (distinct from Today’s blue outline)
- Selecting a search result **only highlights** the period (does not open L2 — user clicks the weekend if they want)
- Year changes **keep** filters and rematch the search highlight by `event_id` / name
- **Clear filters** button resets continent/country/status/kind (search clears separately)

## Test plan
- [ ] Search an event → amber period only, no day island
- [ ] Click a highlighted day → L2 opens as usual
- [ ] Set continent/country/status → change year → filters stay; highlight rematches if series exists
- [ ] Clear filters → dropdowns back to All; search highlight unchanged until cleared