### PR TITLE
Calendar: compact filter row + relevant options only

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807u">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807v">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -103,16 +103,17 @@
                             <ul class="cal-dd__menu" id="kindFilterMenu" role="listbox" aria-labelledby="kindFilterLabel" aria-hidden="true"></ul>
                         </div>
                     </div>
+                    <div class="filter-field cal-reset-field">
+                        <span class="filter-label" aria-hidden="true">&nbsp;</span>
+                        <button type="button" class="cal-reset-btn" id="clearFiltersBtn" data-i18n="clearFilters">Clear</button>
+                    </div>
                     <div class="filter-field cal-search-field">
-                        <span class="filter-label" id="eventSearchLabel" data-i18n="search">Search</span>
+                        <span class="filter-label cal-search-field__label-spacer" aria-hidden="true">&nbsp;</span>
+                        <span class="visually-hidden" id="eventSearchLabel" data-i18n="search">Search</span>
                         <div class="cal-search" id="eventSearch">
                             <input type="search" class="cal-search__input" id="eventSearchInput" autocomplete="off" spellcheck="false" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-controls="eventSearchSuggestions" aria-labelledby="eventSearchLabel" data-i18n-placeholder="searchPlaceholder" placeholder="Event name…">
                             <div class="cal-search__suggestions" id="eventSearchSuggestions" role="listbox" aria-label="Matching events" hidden></div>
                         </div>
-                    </div>
-                    <div class="filter-field cal-reset-field">
-                        <span class="filter-label" aria-hidden="true">&nbsp;</span>
-                        <button type="button" class="cal-reset-btn" id="clearFiltersBtn" data-i18n="clearFilters">Clear filters</button>
                     </div>
                 </div>
             </div>
@@ -234,13 +235,13 @@
       year: "Year",
       continent: "Continent",
       country: "Country",
-      confirmStatus: "Confirm status",
-      eventType: "Event type",
+      confirmStatus: "Status",
+      eventType: "Type",
       search: "Search",
       searchPlaceholder: "Event name…",
       searchAria: "Search events by name in the selected year",
       searchNoMatches: "No matching events",
-      clearFilters: "Clear filters",
+      clearFilters: "Clear",
       allContinents: "All continents",
       allCountries: "All countries",
       allConfirmStatuses: "All confirm statuses",
@@ -300,13 +301,13 @@
       year: "Год",
       continent: "Континент",
       country: "Страна",
-      confirmStatus: "Подтверждение",
-      eventType: "Тип ивента",
+      confirmStatus: "Статус",
+      eventType: "Тип",
       search: "Поиск",
       searchPlaceholder: "Название ивента…",
       searchAria: "Поиск ивентов по названию в выбранном году",
       searchNoMatches: "Нет совпадений",
-      clearFilters: "Сбросить фильтры",
+      clearFilters: "Сброс",
       allContinents: "Все континенты",
       allCountries: "Все страны",
       allConfirmStatuses: "Все статусы подтверждения",
@@ -365,13 +366,13 @@
       year: "Año",
       continent: "Continente",
       country: "País",
-      confirmStatus: "Confirmación",
-      eventType: "Tipo de evento",
+      confirmStatus: "Estado",
+      eventType: "Tipo",
       search: "Buscar",
       searchPlaceholder: "Nombre del evento…",
       searchAria: "Buscar eventos por nombre en el año seleccionado",
       searchNoMatches: "Sin coincidencias",
-      clearFilters: "Borrar filtros",
+      clearFilters: "Limpiar",
       allContinents: "Todos los continentes",
       allCountries: "Todos los países",
       allConfirmStatuses: "Todas las confirmaciones",
@@ -687,16 +688,29 @@
   }
 
   function refreshFilterOptions() {
-    var continents = (state.data && state.data.continents) || CONTINENTS;
+    var yearAll = eventsInYearRaw(state.year);
+    var continentPresent = {};
+    yearAll.forEach(function (e) {
+      if (e.continent) continentPresent[e.continent] = true;
+    });
+    var catalogContinents = (state.data && state.data.continents) || CONTINENTS;
+    var continentOpts = catalogContinents.filter(function (c) {
+      return continentPresent[c];
+    }).map(function (c) {
+      return { value: c, label: continentLabel(c) };
+    });
+    if (state.continent && continentPresent[state.continent] !== true) {
+      state.continent = "";
+    }
     fillDropdown(
       document.getElementById("continentFilterMenu"),
       document.getElementById("continentFilterValue"),
-      continents.map(function (c) { return { value: c, label: continentLabel(c) }; }),
+      continentOpts,
       state.continent,
       t("allContinents")
     );
 
-    var yearEvents = eventsInYearRaw(state.year).filter(function (e) {
+    var yearEvents = yearAll.filter(function (e) {
       if (state.continent && e.continent !== state.continent) return false;
       return true;
     });
@@ -707,10 +721,8 @@
     var countryList = Object.keys(countries).sort(function (a, b) {
       return a.localeCompare(b);
     });
-    // Keep a selected country across years even if it has no events this year.
     if (state.country && countries[state.country] !== true) {
-      countryList.push(state.country);
-      countryList.sort(function (a, b) { return a.localeCompare(b); });
+      state.country = "";
     }
     fillDropdown(
       document.getElementById("countryFilterMenu"),
@@ -720,9 +732,22 @@
       t("allCountries")
     );
 
-    var statusOpts = STATUSES.map(function (s) {
+    var statusPool = yearEvents.filter(function (e) {
+      if (state.country && e.country !== state.country) return false;
+      return true;
+    });
+    var statusPresent = {};
+    statusPool.forEach(function (e) {
+      statusPresent[normalizeStatus(e.status)] = true;
+    });
+    var statusOpts = STATUSES.filter(function (s) {
+      return statusPresent[s];
+    }).map(function (s) {
       return { value: s, label: statusLabel(s) };
     });
+    if (state.status && statusPresent[state.status] !== true) {
+      state.status = "";
+    }
     fillDropdown(
       document.getElementById("statusFilterMenu"),
       document.getElementById("statusFilterValue"),
@@ -731,8 +756,7 @@
       t("allConfirmStatuses")
     );
 
-    var kindPool = yearEvents.filter(function (e) {
-      if (state.country && e.country !== state.country) return false;
+    var kindPool = statusPool.filter(function (e) {
       if (state.status && normalizeStatus(e.status) !== state.status) return false;
       return true;
     });
@@ -743,9 +767,8 @@
     var kindOpts = KINDS.filter(function (k) { return kindPresent[k]; }).map(function (k) {
       return { value: k, label: kindLabel(k) };
     });
-    // Persist kind selection across years; surface it even if absent this year.
     if (state.kind && kindPresent[state.kind] !== true) {
-      kindOpts.push({ value: state.kind, label: kindLabel(state.kind) });
+      state.kind = "";
     }
     fillDropdown(
       document.getElementById("kindFilterMenu"),

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -109,20 +109,21 @@ h1 {
 
 .toolbar {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: flex-end;
   justify-content: center;
-  gap: 10px 16px;
-  padding-top: 4px;
+  gap: 6px 8px;
+  padding-top: 2px;
   min-width: 0;
+  overflow-x: auto;
 }
 
 .filters {
   display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
+  flex-wrap: nowrap;
+  align-items: flex-end;
   justify-content: center;
-  gap: 8px 10px;
+  gap: 4px 6px;
   min-width: 0;
 }
 
@@ -130,20 +131,38 @@ h1 {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   min-width: 0;
+  flex: 0 0 auto;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .cal-search-field {
-  flex: 1 1 180px;
-  max-width: 280px;
+  flex: 1 1 140px;
+  max-width: 200px;
+  min-width: 120px;
   align-items: stretch;
+}
+
+.cal-search-field__label-spacer {
+  visibility: hidden;
 }
 
 .cal-search {
   position: relative;
   width: 100%;
-  --cal-search-height: 34px;
+  --cal-search-height: 28px;
 }
 
 .cal-search__input {
@@ -151,13 +170,13 @@ h1 {
   height: var(--cal-search-height);
   box-sizing: border-box;
   margin: 0;
-  padding: 0 12px 0 34px;
+  padding: 0 8px 0 28px;
   border: 1px solid var(--border-color, #d0d7e2);
-  border-radius: 8px;
-  background: var(--bg-primary, #fff) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%238b95a5' stroke-width='2'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.35-4.35'/%3E%3C/svg%3E") no-repeat 10px center;
+  border-radius: 999px;
+  background: var(--bg-primary, #fff) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%238b95a5' stroke-width='2'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.35-4.35'/%3E%3C/svg%3E") no-repeat 9px center;
   color: var(--text-primary, #0f172a);
   font: inherit;
-  font-size: 13px;
+  font-size: 12px;
   line-height: 1.2;
 }
 
@@ -236,16 +255,17 @@ h1 {
 }
 
 .cal-reset-btn {
-  height: 34px;
+  height: 28px;
   margin: 0;
-  padding: 0 12px;
-  border: 1px solid var(--border-color, #d0d7e2);
-  border-radius: 8px;
-  background: var(--bg-primary, #fff);
-  color: var(--text-secondary, #64748b);
+  padding: 0 8px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-tertiary, #94a3b8);
   font: inherit;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
+  letter-spacing: 0.02em;
   white-space: nowrap;
   cursor: pointer;
 }
@@ -253,52 +273,52 @@ h1 {
 .cal-reset-btn:hover,
 .cal-reset-btn:focus-visible {
   outline: none;
-  border-color: var(--color-accent, #2563eb);
   color: var(--color-primary-dark, #1e3a8a);
+  background: rgba(37, 99, 235, 0.06);
 }
 
 .filter-label {
   display: block;
   width: 100%;
   text-align: center;
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.03em;
   text-transform: uppercase;
   color: var(--text-tertiary);
-  line-height: 1.2;
+  line-height: 1.15;
 }
 
 /* Chrome-matched pill dropdowns (Dashboards pattern) */
 .cal-dd {
   position: relative;
   display: inline-flex;
-  width: var(--cal-dd-width, 9rem);
+  width: var(--cal-dd-width, 7.5rem);
   flex-shrink: 0;
 }
 
-#yearSelectDd { --cal-dd-width: 5.25rem; }
-#continentFilterDd { --cal-dd-width: 9.5rem; }
-#countryFilterDd { --cal-dd-width: 10.5rem; }
-#statusFilterDd { --cal-dd-width: 13.5rem; }
-#kindFilterDd { --cal-dd-width: 8.75rem; }
+#yearSelectDd { --cal-dd-width: 4.25rem; }
+#continentFilterDd { --cal-dd-width: 7.25rem; }
+#countryFilterDd { --cal-dd-width: 8rem; }
+#statusFilterDd { --cal-dd-width: 6.5rem; }
+#kindFilterDd { --cal-dd-width: 5.5rem; }
 
 .cal-dd__btn {
   appearance: none;
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
-  gap: 4px;
+  gap: 2px;
   box-sizing: border-box;
   width: 100%;
   height: 28px;
-  padding: 0 10px;
+  padding: 0 8px;
   border-radius: 999px;
   border: 1px solid transparent;
   background: transparent;
   color: var(--text-secondary);
   font: inherit;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 500;
   line-height: 1;
   cursor: pointer;
@@ -1866,14 +1886,18 @@ h1 {
   h1 { font-size: 1.25rem; }
   .subtitle { font-size: 13px; }
   .filter-field { flex: 1 1 42%; }
+  .filters {
+    flex-wrap: wrap;
+  }
   .cal-search-field {
     flex: 1 1 100%;
     max-width: none;
+    min-width: 0;
   }
   .cal-reset-field {
-    flex: 1 1 100%;
+    flex: 0 0 auto;
   }
-  .cal-reset-btn { width: 100%; }
+  .cal-reset-btn { width: auto; }
   .cal-dd {
     width: 100%;
     --cal-dd-width: 100%;


### PR DESCRIPTION
## Summary
- One toolbar row: Year → Continent → Country → Status → Type → **Clear** → **Search**
- Removed visible Search label; Clear is a small text control (not a large button)
- Compact filter labels/fonts/widths so the row fits
- Dropdown options are **only relevant** for the selected year (and upstream filters); invalid selections clear instead of orphan entries

## Test plan
- [ ] Desktop: filters + Clear + Search stay on one line
- [ ] Status/kind lists only values that exist for the year/filters
- [ ] Change year with Europe selected → keeps if present, clears country if absent
- [ ] Clear resets filters; search highlight unchanged until cleared separately

Made with [Cursor](https://cursor.com)