### PR TITLE
Calendar: center filters, keep search on the right

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807w">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807x">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -107,13 +107,13 @@
                         <span class="filter-label" aria-hidden="true">&nbsp;</span>
                         <button type="button" class="cal-reset-btn" id="clearFiltersBtn" data-i18n="clearFilters">Clear</button>
                     </div>
-                    <div class="filter-field cal-search-field">
-                        <span class="filter-label cal-search-field__label-spacer" aria-hidden="true">&nbsp;</span>
-                        <span class="visually-hidden" id="eventSearchLabel" data-i18n="search">Search</span>
-                        <div class="cal-search" id="eventSearch">
-                            <input type="search" class="cal-search__input" id="eventSearchInput" autocomplete="off" spellcheck="false" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-controls="eventSearchSuggestions" aria-labelledby="eventSearchLabel" data-i18n-placeholder="searchPlaceholder" placeholder="Event name…">
-                            <div class="cal-search__suggestions" id="eventSearchSuggestions" role="listbox" aria-label="Matching events" hidden></div>
-                        </div>
+                </div>
+                <div class="filter-field cal-search-field">
+                    <span class="filter-label cal-search-field__label-spacer" aria-hidden="true">&nbsp;</span>
+                    <span class="visually-hidden" id="eventSearchLabel" data-i18n="search">Search</span>
+                    <div class="cal-search" id="eventSearch">
+                        <input type="search" class="cal-search__input" id="eventSearchInput" autocomplete="off" spellcheck="false" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-controls="eventSearchSuggestions" aria-labelledby="eventSearchLabel" data-i18n-placeholder="searchPlaceholder" placeholder="Event name…">
+                        <div class="cal-search__suggestions" id="eventSearchSuggestions" role="listbox" aria-label="Matching events" hidden></div>
                     </div>
                 </div>
             </div>
@@ -1353,16 +1353,18 @@
 
   function islandFinalRect() {
     var grid = gridEl();
+    var toolbar = document.querySelector(".toolbar");
     var filters = document.querySelector(".filters");
     var target = grid && grid.getBoundingClientRect().width
       ? grid.getBoundingClientRect()
       : stageEl().getBoundingClientRect();
     var pad = 10;
-    var filterTop = filters ? filters.getBoundingClientRect().top : NaN;
+    var bar = toolbar || filters;
+    var barTop = bar ? bar.getBoundingClientRect().top : NaN;
     // Same size as the month-grid inset; only the top edge moves up to the filters row.
     return {
       left: target.left + pad,
-      top: Number.isFinite(filterTop) ? filterTop : target.top + pad,
+      top: Number.isFinite(barTop) ? barTop : target.top + pad,
       width: Math.max(280, target.width - pad * 2),
       height: Math.max(220, target.height - pad * 2)
     };

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -110,11 +110,10 @@ h1 {
 }
 
 .toolbar {
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: flex-end;
-  justify-content: stretch;
-  gap: 6px 8px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: end;
+  column-gap: 12px;
   padding-top: 2px;
   width: 100%;
   min-width: 0;
@@ -123,12 +122,12 @@ h1 {
 }
 
 .filters {
+  grid-column: 2;
   display: flex;
   flex-wrap: nowrap;
   align-items: flex-end;
-  justify-content: flex-start;
+  justify-content: center;
   gap: 4px 6px;
-  width: 100%;
   min-width: 0;
   overflow: visible;
 }
@@ -155,11 +154,13 @@ h1 {
 }
 
 .cal-search-field {
+  grid-column: 3;
+  justify-self: end;
   flex: 0 1 220px;
   width: 220px;
-  max-width: min(240px, 28vw);
+  max-width: min(240px, 100%);
   min-width: 140px;
-  margin-left: auto;
+  margin-left: 0;
   align-items: stretch;
 }
 
@@ -1900,10 +1901,21 @@ h1 {
   h1 { font-size: 1.25rem; }
   .subtitle { font-size: 13px; }
   .filter-field { flex: 1 1 42%; }
-  .filters {
+  .toolbar {
+    display: flex;
     flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+  }
+  .filters {
+    grid-column: auto;
+    flex-wrap: wrap;
+    width: 100%;
+    justify-content: center;
   }
   .cal-search-field {
+    grid-column: auto;
+    justify-self: auto;
     flex: 1 1 100%;
     width: auto;
     max-width: none;


### PR DESCRIPTION
## Summary
- Filter pills (Year → Clear) are **centered** again
- Search stays on the **right** of the header container with a gap from the filters
- Fixes the left-packed look from the previous polish

## Test plan
- [ ] Filters look centered in the page-head width
- [ ] Search is on the right, visually separate from Clear
- [ ] Dropdowns still open

Made with [Cursor](https://cursor.com)