### PR TITLE
Pin calendar search back to the header right edge

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807y">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807z">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -110,17 +110,15 @@ h1 {
 }
 
 .toolbar {
-  /* Same 820px centered track as #calendarRoot / .year-grid so filters
-     share the calendar's left edge; search stays on the right. */
+  /* Full page-head width: filters align to the 820px calendar left edge;
+     search stays on the far right of the header. */
   display: flex;
   flex-wrap: nowrap;
   align-items: end;
-  justify-content: space-between;
+  justify-content: flex-start;
   column-gap: 12px;
   padding-top: 2px;
-  width: min(100%, 820px);
-  max-width: 820px;
-  margin-inline: auto;
+  width: 100%;
   min-width: 0;
   /* Must stay visible — overflow clips absolute dropdown menus. */
   overflow: visible;
@@ -133,7 +131,9 @@ h1 {
   justify-content: flex-start;
   gap: 4px 6px;
   min-width: 0;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
+  /* Match #calendarRoot / .year-grid left edge inside page-head. */
+  margin-left: max(0px, calc((100% - 820px) / 2));
   overflow: visible;
 }
 
@@ -163,7 +163,7 @@ h1 {
   width: 220px;
   max-width: min(240px, 100%);
   min-width: 140px;
-  margin-left: 12px;
+  margin-left: auto;
   align-items: stretch;
 }
 
@@ -1915,6 +1915,7 @@ h1 {
     flex-wrap: wrap;
     width: 100%;
     justify-content: center;
+    margin-left: 0;
   }
   .cal-search-field {
     grid-column: auto;


### PR DESCRIPTION
## Summary
- Filters still align to the year-grid left edge via `margin-left: calc((100% - 820px) / 2)`.
- Toolbar is full page-head width again so search sits on the far right (`margin-left: auto`), not the right edge of the 820px track.

## Test plan
- [ ] Desktop: filters left = January grid left
- [ ] Desktop: search at the right edge of the header (not above August)
- [ ] Mobile: stacked layout unchanged


Made with [Cursor](https://cursor.com)