### PR TITLE
Tighten calendar header subtitle and expected-events copy

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -52,7 +52,7 @@
                 <h1 data-i18n="title">WSDC Events Calendar</h1>
                 <time class="data-as-of" id="dataAsOf" hidden></time>
             </div>
-            <p class="subtitle" data-i18n="subtitle">A calendar of expected, confirmed, and paused events for the selected year. Filter the list or use search. Click a date for location details and a short analytics view of the event’s history, estimated dancers, points earned, and new participants.</p>
+            <p class="subtitle" data-i18n="subtitle">A calendar of expected, confirmed, and paused (hiatus) events for the selected year. Filter the list or use search. Click a date for the map and location, plus a short analytics view: event history, estimated dancers, points earned, and new participants.</p>
             <p class="disclaimer" id="disclaimer"></p>
             <div class="toolbar">
                 <div class="filters" role="toolbar" aria-label="Filters">
@@ -235,8 +235,8 @@
     en: {
       title: "WSDC Events Calendar",
       asOf: "As of {date}",
-      subtitle: "A calendar of expected, confirmed, and paused events for the selected year. Filter the list or use search. Click a date for location details and a short analytics view of the event’s history, estimated dancers, points earned, and new participants.",
-      disclaimer: "Important: Expected events are events whose dates were not yet confirmed on the WSDC site ({link}) as of the latest update, but that ran around these dates the year before with no cancellation or hiatus reported. Expected dates in the calendar are approximate and may change once the event becomes confirmed.",
+      subtitle: "A calendar of expected, confirmed, and paused (hiatus) events for the selected year. Filter the list or use search. Click a date for the map and location, plus a short analytics view: event history, estimated dancers, points earned, and new participants.",
+      disclaimer: "Important: Expected events are those whose dates were not yet confirmed in the {link} as of the latest update, but that ran around these dates the year before with no cancellation or hiatus reported. Expected dates in the calendar are approximate and may change once the event becomes confirmed.",
       wsdcEventsList: "WSDC Events List",
       year: "Year",
       continent: "Continent",
@@ -304,9 +304,9 @@
     ru: {
       title: "WSDC Events Calendar",
       asOf: "По состоянию на {date}",
-      subtitle: "Календарь ивентов, который включает в себя информацию об ожидаемых, подтверждённых и приостановленных ивентах в рамках выбранного года. Ивенты можно отфильтровать или воспользоваться поиском. При клике на дату можно посмотреть более детальную информацию о расположении ивента, а также небольшую аналитическую информацию об истории проведения и расчётном количестве участников, набранных поинтов и новых участниках.",
-      disclaimer: "Важно: ожидаемые ивенты — это ивенты, информация о проведении которых на момент последнего апдейта не подтверждена на сайте WSDC ({link}), но годом ранее ивент проводился примерно в эти даты и информация об отмене или приостановке ивента отсутствует. Даты проведения ожидаемых ивентов в календаре ориентировочные и могут измениться после перехода ивента в статус подтверждённых.",
-      wsdcEventsList: "Лист ивентов WSDC",
+      subtitle: "Календарь ожидаемых, подтверждённых и приостановленных (hiatus) ивентов за выбранный год. Можно отфильтровать список или воспользоваться поиском. Клик по дате открывает карту с локацией и краткую аналитику: историю проведения, расчётное число участников, набранные поинты и новых танцоров.",
+      disclaimer: "Важно: ожидаемые ивенты — те, чьи даты на момент последнего обновления ещё не подтверждены в {link}, но годом раньше ивент шёл примерно в эти дни и нет сведений об отмене или hiatus. Даты ожидаемых ивентов ориентировочные и могут измениться после подтверждения.",
+      wsdcEventsList: "списке ивентов WSDC",
       year: "Год",
       continent: "Континент",
       country: "Страна",
@@ -372,9 +372,9 @@
     es: {
       title: "WSDC Events Calendar",
       asOf: "Actualizado al {date}",
-      subtitle: "Calendario de eventos esperados, confirmados y en pausa para el año seleccionado. Puedes filtrar la lista o usar la búsqueda. Al hacer clic en una fecha verás la ubicación del evento y una breve analítica de su historial, el número estimado de participantes, los puntos obtenidos y los nuevos bailarines.",
-      disclaimer: "Importante: los eventos esperados son aquellos cuya celebración, a la fecha de la última actualización, aún no está confirmada en el sitio de WSDC ({link}), pero el año anterior se celebraron aproximadamente en estas fechas y no hay información de cancelación o pausa. Las fechas de los eventos esperados en el calendario son orientativas y pueden cambiar cuando el evento pase a confirmado.",
-      wsdcEventsList: "lista de eventos WSDC",
+      subtitle: "Calendario de eventos esperados, confirmados y en pausa (hiatus) para el año seleccionado. Puedes filtrar la lista o usar la búsqueda. Al hacer clic en una fecha verás el mapa con la ubicación y una breve analítica: historial del evento, número estimado de participantes, puntos obtenidos y nuevos bailarines.",
+      disclaimer: "Importante: los eventos esperados son aquellos cuyas fechas, a la última actualización, aún no están confirmadas en {link}, pero el año anterior se celebraron aproximadamente en esos días y no hay información de cancelación o hiatus. Las fechas esperadas son orientativas y pueden cambiar cuando el evento pase a confirmado.",
+      wsdcEventsList: "la lista de eventos WSDC",
       year: "Año",
       continent: "Continente",
       country: "País",


### PR DESCRIPTION
## Summary
- Shorter RU/EN/ES subtitle (less bureaucracy, same meaning)
- Expected-events note tightened; hiatus named explicitly
- Link label fits the sentence case (RU «в списке…», EN «in the WSDC Events List»)

## Test plan
- [ ] RU/EN/ES header reads cleanly
- [ ] WSDC Events List link still works


Made with [Cursor](https://cursor.com)