### PR TITLE
Shorten calendar subtitle

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -52,7 +52,7 @@
                 <h1 data-i18n="title">WSDC Events Calendar</h1>
                 <time class="data-as-of" id="dataAsOf" hidden></time>
             </div>
-            <p class="subtitle" data-i18n="subtitle">A calendar of expected, confirmed, and paused (hiatus) events for the selected year. Filter the list or use search. Click a date for the map and location, plus a short analytics view: event history, estimated dancers, points earned, and new participants.</p>
+            <p class="subtitle" data-i18n="subtitle">A calendar of expected, confirmed, and paused (hiatus) events for the selected year. Filter the list or use search. Click a date for the map with location and a short analytics view of the event.</p>
             <p class="disclaimer" id="disclaimer"></p>
             <div class="toolbar">
                 <div class="filters" role="toolbar" aria-label="Filters">
@@ -235,7 +235,7 @@
     en: {
       title: "WSDC Events Calendar",
       asOf: "As of {date}",
-      subtitle: "A calendar of expected, confirmed, and paused (hiatus) events for the selected year. Filter the list or use search. Click a date for the map and location, plus a short analytics view: event history, estimated dancers, points earned, and new participants.",
+      subtitle: "A calendar of expected, confirmed, and paused (hiatus) events for the selected year. Filter the list or use search. Click a date for the map with location and a short analytics view of the event.",
       disclaimer: "Important: Expected events are those whose dates were not yet confirmed in the {link} as of the latest update, but that ran around these dates the year before with no cancellation or hiatus reported. Expected dates in the calendar are approximate and may change once the event becomes confirmed.",
       wsdcEventsList: "WSDC Events List",
       year: "Year",
@@ -304,7 +304,7 @@
     ru: {
       title: "WSDC Events Calendar",
       asOf: "По состоянию на {date}",
-      subtitle: "Календарь ожидаемых, подтверждённых и приостановленных (hiatus) ивентов за выбранный год. Можно отфильтровать список или воспользоваться поиском. Клик по дате открывает карту с локацией и краткую аналитику: историю проведения, расчётное число участников, набранные поинты и новых танцоров.",
+      subtitle: "Календарь ожидаемых, подтверждённых и приостановленных (hiatus) ивентов за выбранный год. Можно отфильтровать список или воспользоваться поиском. Клик по дате открывает карту с локацией и краткую аналитику по ивенту.",
       disclaimer: "Важно: ожидаемые ивенты — те, чьи даты на момент последнего обновления ещё не подтверждены в {link}, но годом раньше ивент шёл примерно в эти дни и нет сведений об отмене или hiatus. Даты ожидаемых ивентов ориентировочные и могут измениться после подтверждения.",
       wsdcEventsList: "списке ивентов WSDC",
       year: "Год",
@@ -372,7 +372,7 @@
     es: {
       title: "WSDC Events Calendar",
       asOf: "Actualizado al {date}",
-      subtitle: "Calendario de eventos esperados, confirmados y en pausa (hiatus) para el año seleccionado. Puedes filtrar la lista o usar la búsqueda. Al hacer clic en una fecha verás el mapa con la ubicación y una breve analítica: historial del evento, número estimado de participantes, puntos obtenidos y nuevos bailarines.",
+      subtitle: "Calendario de eventos esperados, confirmados y en pausa (hiatus) para el año seleccionado. Puedes filtrar la lista o usar la búsqueda. Al hacer clic en una fecha verás el mapa con la ubicación y una breve analítica del evento.",
       disclaimer: "Importante: los eventos esperados son aquellos cuyas fechas, a la última actualización, aún no están confirmadas en {link}, pero el año anterior se celebraron aproximadamente en esos días y no hay información de cancelación o hiatus. Las fechas esperadas son orientativas y pueden cambiar cuando el evento pase a confirmado.",
       wsdcEventsList: "la lista de eventos WSDC",
       year: "Año",


### PR DESCRIPTION
## Summary
- RU/EN/ES subtitle ends at «краткую аналитику по ивенту» / equivalent — no metric list in the intro.

## Test plan
- [ ] Header subtitle matches the shorter copy in RU/EN/ES


Made with [Cursor](https://cursor.com)