### PR TITLE
Pull calendar filters closer to the header divider

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807ab">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807ac">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -71,7 +71,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding-bottom: 10px;
+  /* Keep filters near the divider so they read with the calendar, not the copy. */
+  padding-bottom: 4px;
   border-bottom: 1px solid var(--border-color);
   min-width: 0;
   /* 100px inset each side vs container content width */
@@ -147,7 +148,9 @@ h1 {
   align-items: end;
   justify-content: flex-start;
   column-gap: 12px;
-  padding-top: 2px;
+  /* Extra air under subtitle/disclaimer so filters sit with the calendar. */
+  margin-top: 8px;
+  padding-top: 0;
   width: 100%;
   min-width: 0;
   /* Must stay visible — overflow clips absolute dropdown menus. */


### PR DESCRIPTION
## Summary
- `padding-bottom` under filters: 10px → 4px (closer to the divider)
- Extra `margin-top` on the toolbar so filters sit farther from subtitle/disclaimer
- Filter control sizes unchanged; search layout unchanged

## Test plan
- [ ] Filters visually closer to the divider than to the copy
- [ ] Search still right-aligned
- [ ] Dropdowns still open without clipping


Made with [Cursor](https://cursor.com)