### PR TITLE
Rebuild calendar after unlinked-trial expected hardening

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="static/css/site-chrome.css">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
-    <link rel="preload" href="static/data/events_year_calendar.json?v=20260807ad" as="fetch" crossorigin>
+    <link rel="preload" href="static/data/events_year_calendar.json?v=20260807ae" as="fetch" crossorigin>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMLCY5PE8Z"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -2559,7 +2559,7 @@
   if (params.get("lang") && I18N[params.get("lang")]) state.lang = params.get("lang");
   applyStaticI18n();
 
-  fetch("static/data/events_year_calendar.json?v=20260807ad")
+  fetch("static/data/events_year_calendar.json?v=20260807ae")
     .then(function (r) {
       if (!r.ok) throw new Error("Failed to load calendar data");
       return r.json();

--- a/static/data/event_l2_cards.json
+++ b/static/data/event_l2_cards.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-07",
-  "generated_at": "2026-08-07T16:36:19Z",
+  "generated_at": "2026-08-07T16:41:24Z",
   "tier_tip": {
     "en": "Tier reflects field size for that role under the WSDC points chart. Larger fields award higher placement points. Current ranges (per role, from 5 competitors): Tier 1: 5–10 · Tier 2: 11–19 · Tier 3: 20–39 · Tier 4: 40–79 · Tier 5: 80–129 · Tier 6: 130+.",
     "ru": "Тир отражает размер поля в роли по чарту очков WSDC. Чем больше поле, тем выше очки за места. Текущие диапазоны (на роль, от 5 участников): Тир 1: 5–10 · Тир 2: 11–19 · Тир 3: 20–39 · Тир 4: 40–79 · Тир 5: 80–129 · Тир 6: 130+.",

--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-07",
-  "generated_at": "2026-08-07T16:36:01Z",
+  "generated_at": "2026-08-07T16:41:06Z",
   "years": [
     2024,
     2025,
@@ -13423,7 +13423,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-08-20"
+      "projected_from_start": "2026-08-20",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:391:2027-08-19",
@@ -13512,7 +13513,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-08-21"
+      "projected_from_start": "2026-08-21",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:t-westie-joy-bucharest-romania:2027-08-20",
@@ -13534,7 +13536,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-08-21"
+      "projected_from_start": "2026-08-21",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:135:2027-08-26",
@@ -14040,7 +14043,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-10-01"
+      "projected_from_start": "2026-10-01",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:t-westie-harbor-gothenburg-sweden:2027-09-30",
@@ -14062,7 +14066,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-10-01"
+      "projected_from_start": "2026-10-01",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:t-autumn-beat-riga-latvia:2027-10-01",
@@ -14084,7 +14089,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-10-02"
+      "projected_from_start": "2026-10-02",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "confirmed:211:2027-10-07",
@@ -14938,7 +14944,8 @@
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-12-18"
+      "projected_from_start": "2026-12-18",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:196:2027-12-29",
@@ -17500,7 +17507,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-08-20"
+      "projected_from_start": "2026-08-20",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:356:2028-08-17",
@@ -17566,7 +17574,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-08-21"
+      "projected_from_start": "2026-08-21",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:t-westie-joy-bucharest-romania:2028-08-18",
@@ -17588,7 +17597,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-08-21"
+      "projected_from_start": "2026-08-21",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:135:2028-08-24",
@@ -18137,7 +18147,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-10-01"
+      "projected_from_start": "2026-10-01",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:t-westie-harbor-gothenburg-sweden:2028-09-28",
@@ -18159,7 +18170,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-10-01"
+      "projected_from_start": "2026-10-01",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:t-autumn-beat-riga-latvia:2028-09-29",
@@ -18181,7 +18193,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-10-02"
+      "projected_from_start": "2026-10-02",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:8:2028-10-05",
@@ -18997,7 +19010,8 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-12-18"
+      "projected_from_start": "2026-12-18",
+      "provisional_unlinked_trial": true
     },
     {
       "id": "expected:75:2028-12-25",


### PR DESCRIPTION
## Summary
- Rebuild JSON after pipeline review follow-up (fingerprint keys + provisional flag).

## Test plan
- [ ] Germany 2027 still shows Swing Creation Hamburg / RiverSwingNights as expected Trial
- [ ] Cache-bust `?v=20260807ae`


Made with [Cursor](https://cursor.com)