### PR TITLE
Rebuild calendar: unlinked lookback + provisional_unlinked

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="static/css/site-chrome.css">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
-    <link rel="preload" href="static/data/events_year_calendar.json?v=20260807ag" as="fetch" crossorigin>
+    <link rel="preload" href="static/data/events_year_calendar.json?v=20260807ah" as="fetch" crossorigin>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMLCY5PE8Z"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -2559,7 +2559,7 @@
   if (params.get("lang") && I18N[params.get("lang")]) state.lang = params.get("lang");
   applyStaticI18n();
 
-  fetch("static/data/events_year_calendar.json?v=20260807ag")
+  fetch("static/data/events_year_calendar.json?v=20260807ah")
     .then(function (r) {
       if (!r.ok) throw new Error("Failed to load calendar data");
       return r.json();

--- a/static/data/event_l2_cards.json
+++ b/static/data/event_l2_cards.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-07",
-  "generated_at": "2026-08-07T16:56:53Z",
+  "generated_at": "2026-08-07T17:10:59Z",
   "tier_tip": {
     "en": "Tier reflects field size for that role under the WSDC points chart. Larger fields award higher placement points. Current ranges (per role, from 5 competitors): Tier 1: 5–10 · Tier 2: 11–19 · Tier 3: 20–39 · Tier 4: 40–79 · Tier 5: 80–129 · Tier 6: 130+.",
     "ru": "Тир отражает размер поля в роли по чарту очков WSDC. Чем больше поле, тем выше очки за места. Текущие диапазоны (на роль, от 5 участников): Тир 1: 5–10 · Тир 2: 11–19 · Тир 3: 20–39 · Тир 4: 40–79 · Тир 5: 80–129 · Тир 6: 130+.",

--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
   "as_of": "2026-08-07",
-  "generated_at": "2026-08-07T16:56:35Z",
+  "generated_at": "2026-08-07T17:10:40Z",
   "years": [
     2024,
     2025,
@@ -13424,7 +13424,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-08-20",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:391:2027-08-19",
@@ -13514,7 +13514,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-08-21",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:t-westie-joy-bucharest-romania:2027-08-20",
@@ -13537,7 +13537,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-08-21",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:135:2027-08-26",
@@ -13934,7 +13934,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-09-24",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:131:2027-09-23",
@@ -14067,7 +14067,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-10-01",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:t-westie-harbor-gothenburg-sweden:2027-09-30",
@@ -14090,7 +14090,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-10-01",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:t-autumn-beat-riga-latvia:2027-10-01",
@@ -14113,7 +14113,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-10-02",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "confirmed:211:2027-10-07",
@@ -14968,7 +14968,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-12-18",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:196:2027-12-29",
@@ -15036,7 +15036,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2027,
       "projected_from_start": "2027-01-07",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:200:2028-01-13",
@@ -15081,7 +15081,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2027,
       "projected_from_start": "2027-01-14",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:309:2028-01-14",
@@ -15236,7 +15236,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2027,
       "projected_from_start": "2027-01-22",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:273:2028-02-03",
@@ -15764,7 +15764,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2027,
       "projected_from_start": "2027-03-11",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:314:2028-03-09",
@@ -16031,7 +16031,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2027,
       "projected_from_start": "2027-04-08",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:210:2028-04-06",
@@ -16970,7 +16970,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2027,
       "projected_from_start": "2027-06-24",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:369:2028-06-23",
@@ -17105,7 +17105,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2027,
       "projected_from_start": "2027-07-01",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:225:2028-06-29",
@@ -17692,7 +17692,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-08-20",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:356:2028-08-17",
@@ -17759,7 +17759,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-08-21",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:t-westie-joy-bucharest-romania:2028-08-18",
@@ -17782,7 +17782,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-08-21",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:135:2028-08-24",
@@ -18202,7 +18202,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-09-24",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:131:2028-09-21",
@@ -18355,7 +18355,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-10-01",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:t-westie-harbor-gothenburg-sweden:2028-09-28",
@@ -18378,7 +18378,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-10-01",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:t-autumn-beat-riga-latvia:2028-09-29",
@@ -18401,7 +18401,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-10-02",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:8:2028-10-05",
@@ -19218,7 +19218,7 @@
       "source": "expected_yoy",
       "projected_from_year": 2026,
       "projected_from_start": "2026-12-18",
-      "provisional_unlinked_trial": true
+      "provisional_unlinked": true
     },
     {
       "id": "expected:75:2028-12-25",


### PR DESCRIPTION
## Summary
- Rebuild `events_year_calendar.json` after pipeline unlinked lookback + `provisional_unlinked` rename.
- Bump calendar JSON cache bust (`?v=20260807ah`).

Depends on pipeline PR for the lookback rule (site data already rebuilt from that code).

## Test plan
- [ ] Hard-refresh events calendar; as-of and year counts look sane
- [ ] 2027 ≈ 199 / 2028 ≈ 198 events
- [ ] No obvious zombie expected from old one-off list rows


Made with [Cursor](https://cursor.com)