### PR TITLE
Mobile polish: no sideways scroll, L2 snap, centered stats

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807af">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807ag">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -1422,22 +1422,43 @@
     return window.matchMedia(MOBILE_L2_MQ).matches;
   }
 
-  function islandFinalRect() {
+  function mobileIslandRect() {
     var pad = 10;
-    var vw = window.innerWidth || document.documentElement.clientWidth;
-    var vh = window.innerHeight || document.documentElement.clientHeight;
-    // Mobile: nearly full-viewport vertical card (scroll inside the body).
-    // Never exceed the visible viewport (landscape / narrow phones).
-    if (isMobileL2Layout()) {
-      var safeTop = 8;
-      var safeBottom = 8;
-      return {
-        left: pad,
-        top: safeTop,
-        width: Math.max(0, vw - pad * 2),
-        height: Math.max(0, vh - safeTop - safeBottom)
-      };
+    var vv = window.visualViewport;
+    var vw = vv && vv.width ? vv.width : (window.innerWidth || document.documentElement.clientWidth);
+    var vh = vv && vv.height ? vv.height : (window.innerHeight || document.documentElement.clientHeight);
+    var offsetTop = vv && typeof vv.offsetTop === "number" ? vv.offsetTop : 0;
+    var offsetLeft = vv && typeof vv.offsetLeft === "number" ? vv.offsetLeft : 0;
+    var safeBottom = 8;
+    var top = offsetTop + 8;
+
+    var chrome = document.querySelector("[data-site-chrome]");
+    if (chrome) {
+      var chromeBottom = chrome.getBoundingClientRect().bottom;
+      if (Number.isFinite(chromeBottom)) top = Math.max(top, chromeBottom + 6);
     }
+
+    // If filters are still on-screen, sit the card just under them.
+    var filters = document.querySelector(".toolbar") || document.querySelector(".filters");
+    if (filters) {
+      var fr = filters.getBoundingClientRect();
+      if (fr.bottom > top && fr.top < vh * 0.45) {
+        top = Math.max(top, fr.bottom + 6);
+      }
+    }
+
+    var maxBottom = offsetTop + vh - safeBottom;
+    return {
+      left: offsetLeft + pad,
+      top: top,
+      width: Math.max(0, vw - pad * 2),
+      height: Math.max(0, maxBottom - top)
+    };
+  }
+
+  function islandFinalRect() {
+    if (isMobileL2Layout()) return mobileIslandRect();
+    var pad = 10;
     var grid = gridEl();
     var toolbar = document.querySelector(".toolbar");
     var filters = document.querySelector(".filters");
@@ -1736,7 +1757,7 @@
       renderCalendar();
       populateDayIsland(iso);
       var island = document.getElementById("dayIsland");
-      if (state.l2Moved) placeIslandKeepingOffset(island);
+      if (state.l2Moved && !isMobileL2Layout()) placeIslandKeepingOffset(island);
       else placeIslandDefault(island);
       island.classList.add("is-settled");
       setTimeout(function () {
@@ -2543,21 +2564,25 @@
     head.addEventListener("pointercancel", endDrag);
   })();
 
-  window.addEventListener("resize", function () {
+  function relocateOpenIsland() {
     if (!state.l2Open) return;
     var island = document.getElementById("dayIsland");
-    if (state.l2Moved) placeIslandKeepingOffset(island);
-    else placeIslandDefault(island);
+    if (!island) return;
+    // Mobile: always snap to the visible viewport under chrome/filters.
+    if (isMobileL2Layout() || !state.l2Moved) placeIslandDefault(island);
+    else placeIslandKeepingOffset(island);
     island.classList.add("is-settled");
     if (state.map) {
       state.map.invalidateSize();
-      var bounds = Object.keys(state.markerById).map(function (id) {
-        var e = state.markerById[id].event;
-        return [e.lat, e.lon];
-      });
-      fitDayMap(bounds);
+      fitDayMap(dayMapBounds());
     }
-  });
+  }
+
+  window.addEventListener("resize", relocateOpenIsland);
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener("resize", relocateOpenIsland);
+    window.visualViewport.addEventListener("scroll", relocateOpenIsland);
+  }
   window.WsdcChrome = window.WsdcChrome || {};
   window.WsdcChrome.onLangChange = function (lang) {
     state.lang = lang;

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -1926,11 +1926,29 @@ h1 {
 }
 
 @media (max-width: 700px) {
+  html {
+    overflow-x: hidden;
+    max-width: 100%;
+  }
   body {
-    overflow: auto;
+    overflow-x: hidden;
+    overflow-y: auto;
     height: auto;
     min-height: 100dvh;
     display: block;
+    max-width: 100%;
+    overscroll-behavior-x: none;
+  }
+  body.day-layer-open {
+    overflow: hidden;
+  }
+  .page-shell,
+  .container,
+  .calendar-stage,
+  #calendarRoot,
+  .year-grid {
+    max-width: 100%;
+    overflow-x: hidden;
   }
   .page-shell { min-height: calc(100dvh - 72px); }
   .container { min-height: 0; padding: 12px 14px 16px; }
@@ -1987,7 +2005,8 @@ h1 {
   }
   .cal-dd__btn { width: 100%; }
   .calendar-stage {
-    overflow: visible;
+    overflow-x: hidden;
+    overflow-y: visible;
   }
   .cal-stats {
     position: static;
@@ -1995,45 +2014,60 @@ h1 {
     left: auto;
     top: auto;
     width: 100%;
-    margin: 0 0 4px;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: flex-end;
-    gap: 8px 14px;
+    margin: 0 0 8px;
+    display: grid;
+    grid-template-columns: auto repeat(3, minmax(3.25rem, auto));
+    justify-content: center;
+    justify-items: center;
+    align-items: end;
+    column-gap: 12px;
+    row-gap: 10px;
     pointer-events: auto;
   }
   .cal-stats__head {
-    width: 100%;
+    grid-column: 1;
+    grid-row: 1;
+    width: auto;
     min-height: 0;
     margin-bottom: 0;
+    align-self: end;
+    justify-content: center;
   }
   .cal-stats__group {
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: flex-end;
-    gap: 8px 14px;
+    display: contents;
   }
   .cal-stats__group--types {
-    margin-top: 0;
-    width: 100%;
-    padding-top: 12px;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: center;
+    align-items: flex-end;
+    gap: 12px 16px;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    width: auto;
+    margin: 0;
+    padding: 0;
   }
   .cal-stats__tip-bubble {
-    left: 0;
+    left: 50%;
+    right: auto;
     top: calc(100% + 8px);
-    transform: translateY(-4px) scale(0.96);
-    transform-origin: top left;
+    transform: translate(-50%, -4px) scale(0.96);
+    transform-origin: top center;
+    max-width: min(260px, calc(100% - 24px));
   }
   .cal-stats__tip:focus-visible .cal-stats__tip-bubble {
-    transform: translateY(0) scale(1);
+    transform: translate(-50%, 0) scale(1);
   }
   @media (hover: hover) and (pointer: fine) {
     .cal-stats__tip:hover .cal-stats__tip-bubble {
-      transform: translateY(0) scale(1);
+      transform: translate(-50%, 0) scale(1);
     }
   }
   .cal-stats__item {
-    min-width: 4.5rem;
+    min-width: 3.25rem;
+    align-items: center;
   }
   .cal-stats__value {
     font-size: 14px;
@@ -2047,15 +2081,18 @@ h1 {
     flex-direction: row;
     flex-wrap: wrap;
     align-items: center;
+    justify-content: center;
     gap: 8px 12px;
   }
   .cal-legend__title {
     width: 100%;
     margin-bottom: 0;
+    text-align: center;
   }
   .cal-legend__group {
     flex-direction: row;
     flex-wrap: wrap;
+    justify-content: center;
     gap: 8px 12px;
   }
   .cal-legend__gap {
@@ -2082,8 +2119,8 @@ h1 {
      Default: map → event buttons
      Selected: left analytics → right analytics → map → buttons */
   .day-island {
-    max-width: calc(100vw - 16px);
-    max-height: calc(100dvh - 16px);
+    max-width: none;
+    max-height: none;
   }
   /* Override ≤960px map-col floor — contents layout + flex order need no min height. */
   .day-island__map-col {
@@ -2196,7 +2233,7 @@ h1 {
     min-height: 120px;
   }
   .l2-info-tip__bubble {
-    max-width: min(240px, calc(100vw - 48px));
+    max-width: min(240px, calc(100% - 48px));
   }
 }
 


### PR DESCRIPTION
## Summary
- Stop horizontal rubber-band scroll into empty space (`overflow-x: hidden`, drop `100vw` island max).
- Mobile L2 uses `visualViewport` and sits under site chrome / visible filters so the card opens fully on-screen after scrolling the year grid.
- Center stats: `[i] Confirmed Expected Hiatus` then `Registry Trial`.

## Test plan
- [ ] Phone: swipe calendar horizontally — page should not shift into a blank strip
- [ ] Scroll down the year grid, tap a day — L2 fills from top (under chrome/filters)
- [ ] Stats row is centered: info + 3, then 2 below
- [ ] Desktop layout unchanged


Made with [Cursor](https://cursor.com)