### PR TITLE
Spread mobile calendar stats across full width

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807ag">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807ah">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -2016,12 +2016,13 @@ h1 {
     width: 100%;
     margin: 0 0 8px;
     display: grid;
-    grid-template-columns: auto repeat(3, minmax(3.25rem, auto));
-    justify-content: center;
+    /* Full-width row: tip + 3 status metrics evenly spaced */
+    grid-template-columns: minmax(28px, auto) repeat(3, minmax(0, 1fr));
+    justify-content: stretch;
     justify-items: center;
     align-items: end;
-    column-gap: 12px;
-    row-gap: 10px;
+    column-gap: 8px;
+    row-gap: 12px;
     pointer-events: auto;
   }
   .cal-stats__head {
@@ -2037,15 +2038,14 @@ h1 {
     display: contents;
   }
   .cal-stats__group--types {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: center;
-    align-items: flex-end;
-    gap: 12px 16px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    justify-items: center;
+    align-items: end;
+    column-gap: 8px;
     grid-column: 1 / -1;
     grid-row: 2;
-    width: auto;
+    width: 100%;
     margin: 0;
     padding: 0;
   }
@@ -2066,8 +2066,13 @@ h1 {
     }
   }
   .cal-stats__item {
-    min-width: 3.25rem;
+    width: 100%;
+    min-width: 0;
     align-items: center;
+    text-align: center;
+  }
+  .cal-stats__label {
+    text-align: center;
   }
   .cal-stats__value {
     font-size: 14px;


### PR DESCRIPTION
## Summary
- Mobile stats use full-width equal columns: tip + Confirmed / Expected / Hiatus, then Registry / Trial.
- Metrics stay center-aligned within each column instead of clustering in the middle.

## Test plan
- [ ] Phone: stats span the calendar width with even gaps
- [ ] Tip + 3 statuses on row 1, Registry + Trial on row 2


Made with [Cursor](https://cursor.com)