### PR TITLE
Mobile L2: spacing between chart and Last edition

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807ai">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807aj">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -2247,17 +2247,21 @@ h1 {
     order: 3;
     padding-right: 0;
     padding-top: 0;
+    /* Extra air before Last edition / KPI block. */
+    padding-bottom: 8px;
   }
   .l2-event-card__last-head-block {
     order: 4;
     justify-content: flex-start;
     text-align: left;
     padding-left: 0;
-    padding-top: 4px;
+    padding-top: 8px;
     border-top: 1px solid var(--border-color);
   }
   .l2-event-card__kpi-ctrl {
     order: 5;
+    /* Pull Last edition + KPI 4px closer to the tiers table. */
+    margin-bottom: -4px;
   }
   .l2-event-card__tiers-body {
     order: 6;


### PR DESCRIPTION
## Summary
- Mobile L2: more padding between dynamics chart and Last edition.
- Pull Last edition + KPI 4px closer to the tiers table.

## Test plan
- [ ] Phone: open a day event with history — gap above Last edition larger; KPI sits nearer the table


Made with [Cursor](https://cursor.com)