### PR TITLE
Mobile L2: fix tiers Y and metrics tip on Last edition row

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807aj">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807ak">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -2159,9 +2159,12 @@
       "</div>";
   }
 
+  function buildMetricTipHtml() {
+    return buildInfoTipHtml(t("metricTipAria"), t("metricTip"), "l2-info-tip--metrics-between");
+  }
+
   function buildKpiSegHtml() {
     return '<div class="l2-kpi-seg-row">' +
-      buildInfoTipHtml(t("metricTipAria"), t("metricTip"), "l2-info-tip--metrics-between") +
       buildMetricLabelsHtml() +
       "</div>";
   }
@@ -2224,6 +2227,7 @@
     if (hasFocus) {
       var labelKey = right.mode === "edition" ? "thisEdition" : "lastEdition";
       lastHead += '<div class="l2-event-card__last-head">' +
+        buildMetricTipHtml() +
         '<span class="l2-event-card__last-label">' + esc(t(labelKey)) + "</span>" +
         '<span class="l2-event-card__last-date">' +
         esc(monthYearLabel(focusEdition.year, focusEdition.month)) + "</span>" +
@@ -2252,11 +2256,30 @@
       var focusBtn = detail.querySelector('[data-spark="' + restoreSpark + '"]');
       if (focusBtn) focusBtn.focus();
     }
+    wireL2InfoTips(detail);
     if (isMobileL2Layout()) {
       var body = document.querySelector(".day-island__body");
       if (body) body.scrollTop = 0;
     }
     refreshDayMapSize(preferReducedMotion() ? 0 : 230);
+  }
+
+  function wireL2InfoTips(root) {
+    if (!root) return;
+    root.querySelectorAll(".l2-info-tip").forEach(function (btn) {
+      if (btn.getAttribute("data-tip-wired") === "1") return;
+      btn.setAttribute("data-tip-wired", "1");
+      btn.addEventListener("click", function (e) {
+        if (window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
+        e.preventDefault();
+        e.stopPropagation();
+        var open = btn.classList.contains("is-open");
+        root.querySelectorAll(".l2-info-tip.is-open").forEach(function (el) {
+          el.classList.remove("is-open");
+        });
+        if (!open) btn.classList.add("is-open");
+      });
+    });
   }
 
   function refreshOpenEventCard() {
@@ -2529,6 +2552,11 @@
       if (tip.classList.contains("is-open") && !(e.target.closest && e.target.closest("#calStatsTip"))) {
         closeTip();
       }
+      document.querySelectorAll(".l2-info-tip.is-open").forEach(function (el) {
+        if (!(e.target.closest && e.target.closest(".l2-info-tip") === el)) {
+          el.classList.remove("is-open");
+        }
+      });
     });
   })();
 

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -1368,6 +1368,20 @@ h1 {
   min-width: 0;
   width: 100%;
   min-height: 18px;
+  position: relative;
+}
+
+/* Metrics tip lives in the Last edition row; desktop keeps it in the column gap. */
+.l2-event-card__last-head .l2-info-tip--metrics-between {
+  position: absolute;
+  left: -14px;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+}
+
+.l2-event-card__last-head .l2-info-tip--metrics-between:active {
+  transform: translate(-50%, -50%) scale(0.94);
 }
 
 .l2-event-card__last-label {
@@ -1565,7 +1579,8 @@ h1 {
 }
 
 .l2-info-tip:hover .l2-info-tip__bubble,
-.l2-info-tip:focus-visible .l2-info-tip__bubble {
+.l2-info-tip:focus-visible .l2-info-tip__bubble,
+.l2-info-tip.is-open .l2-info-tip__bubble {
   opacity: 1;
   transform: scale(1);
 }
@@ -1591,7 +1606,8 @@ h1 {
 }
 
 .l2-info-tip--metrics-between:hover .l2-info-tip__bubble,
-.l2-info-tip--metrics-between:focus-visible .l2-info-tip__bubble {
+.l2-info-tip--metrics-between:focus-visible .l2-info-tip__bubble,
+.l2-info-tip--metrics-between.is-open .l2-info-tip__bubble {
   transform: translateX(-50%) scale(1);
 }
 
@@ -2247,26 +2263,52 @@ h1 {
     order: 3;
     padding-right: 0;
     padding-top: 0;
-    /* Extra air before Last edition / KPI block. */
-    padding-bottom: 8px;
+    padding-bottom: 0;
   }
   .l2-event-card__last-head-block {
     order: 4;
     justify-content: flex-start;
     text-align: left;
     padding-left: 0;
-    padding-top: 8px;
+    /* More space after dynamics; compensated on tiers so the table does not drop. */
+    padding-top: 12px;
     border-top: 1px solid var(--border-color);
+  }
+  .l2-event-card__last-head {
+    justify-content: flex-start;
+    text-align: left;
+    gap: 8px;
+  }
+  .l2-event-card__last-head .l2-info-tip--metrics-between {
+    position: static;
+    left: auto;
+    top: auto;
+    transform: none;
+    margin: 0;
+    flex: 0 0 auto;
+    order: -1;
+  }
+  .l2-event-card__last-head .l2-info-tip--metrics-between:active {
+    transform: scale(0.94);
+  }
+  .l2-event-card__last-head .l2-info-tip--metrics-between .l2-info-tip__bubble,
+  .l2-event-card__last-head .l2-info-tip--metrics-between.is-open .l2-info-tip__bubble,
+  .l2-event-card__last-head .l2-info-tip--metrics-between:focus-visible .l2-info-tip__bubble {
+    left: 0;
+    right: auto;
+    transform: none;
+    transform-origin: top left;
   }
   .l2-event-card__kpi-ctrl {
     order: 5;
-    /* Pull Last edition + KPI 4px closer to the tiers table. */
-    margin-bottom: -4px;
+    margin-bottom: 0;
   }
   .l2-event-card__tiers-body {
     order: 6;
     padding-left: 0;
     padding-top: 0;
+    /* Keep tiers table Y stable while Last edition/KPI sit closer to it. */
+    margin-top: -8px;
   }
   .l2-event-card__chart-body .l2-chart,
   .l2-event-card__chart-body .l2-chart-panel {


### PR DESCRIPTION
## Summary
- Stop the tiers table from shifting down when spacing Last edition after the chart.
- Move the metrics `i` tip into the Last edition row (top-left on mobile; column-gap bridge on desktop).
- Tap-to-toggle for L2 info tips on touch devices.

## Test plan
- [ ] Phone: chart → Last edition gap looks open; tiers table not lower than before
- [ ] Metrics `i` is on the same line as Last edition, left side
- [ ] Desktop tip still sits in the column gap


Made with [Cursor](https://cursor.com)