### PR TITLE
Mobile L2: center Last edition, tighten KPI–tiers gap

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807ak">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807al">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -2267,29 +2267,30 @@ h1 {
   }
   .l2-event-card__last-head-block {
     order: 4;
-    justify-content: flex-start;
-    text-align: left;
+    justify-content: center;
+    text-align: center;
     padding-left: 0;
     /* More space after dynamics; compensated on tiers so the table does not drop. */
     padding-top: 12px;
     border-top: 1px solid var(--border-color);
   }
   .l2-event-card__last-head {
-    justify-content: flex-start;
-    text-align: left;
-    gap: 8px;
+    justify-content: center;
+    text-align: center;
+    gap: 6px;
+    position: relative;
   }
   .l2-event-card__last-head .l2-info-tip--metrics-between {
-    position: static;
-    left: auto;
-    top: auto;
-    transform: none;
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
     margin: 0;
     flex: 0 0 auto;
-    order: -1;
+    z-index: 2;
   }
   .l2-event-card__last-head .l2-info-tip--metrics-between:active {
-    transform: scale(0.94);
+    transform: translateY(-50%) scale(0.94);
   }
   .l2-event-card__last-head .l2-info-tip--metrics-between .l2-info-tip__bubble,
   .l2-event-card__last-head .l2-info-tip--metrics-between.is-open .l2-info-tip__bubble,
@@ -2307,8 +2308,8 @@ h1 {
     order: 6;
     padding-left: 0;
     padding-top: 0;
-    /* Keep tiers table Y stable while Last edition/KPI sit closer to it. */
-    margin-top: -8px;
+    /* Tighten KPI → tiers gap by another 5px (was -8). */
+    margin-top: -13px;
   }
   .l2-event-card__chart-body .l2-chart,
   .l2-event-card__chart-body .l2-chart-panel {


### PR DESCRIPTION
## Summary
- Mobile: Last edition label/date stay centered; metrics `i` remains absolute top-left.
- Reduce KPI → tiers table spacing by 5px.

## Test plan
- [ ] Phone L2: Last edition centered, tip left
- [ ] KPI labels sit 5px closer to the tiers table


Made with [Cursor](https://cursor.com)