### PR TITLE
Mobile L2: tighten values–tiers gap, not labels–values

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807al">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260807am">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -2308,8 +2308,9 @@ h1 {
     order: 6;
     padding-left: 0;
     padding-top: 0;
-    /* Tighten KPI → tiers gap by another 5px (was -8). */
-    margin-top: -13px;
+    margin-top: 0;
+    /* Tighten metric values → tiers table (not labels → values). */
+    gap: 8px;
   }
   .l2-event-card__chart-body .l2-chart,
   .l2-event-card__chart-body .l2-chart-panel {


### PR DESCRIPTION
## Summary
- Undo `margin-top: -13px` on tiers body (it pulled values into the metric labels).
- Reduce `.l2-event-card__tiers-body` gap 13→8px so metric values sit closer to the tiers table.

## Test plan
- [ ] Phone: label pills and values have normal spacing again
- [ ] Values are ~5px closer to the tiers table


Made with [Cursor](https://cursor.com)