### PR TITLE
Fix GSC “Page with redirect” from lang-redirect.js

### DIFF
--- a/article_3year_rule.html
+++ b/article_3year_rule.html
@@ -554,7 +554,7 @@
       }
     }
   </style>
-  <script src="static/js/lang-redirect.js"></script>
+  <script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_3year_rule.html
+++ b/article_3year_rule.html
@@ -554,7 +554,7 @@
       }
     }
   </style>
-  <script src="static/js/lang-redirect.js?v=20260808a"></script>
+  <script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_3year_rule_en.html
+++ b/article_3year_rule_en.html
@@ -554,7 +554,7 @@
       }
     }
   </style>
-  <script src="static/js/lang-redirect.js"></script>
+  <script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_3year_rule_en.html
+++ b/article_3year_rule_en.html
@@ -554,7 +554,7 @@
       }
     }
   </style>
-  <script src="static/js/lang-redirect.js?v=20260808a"></script>
+  <script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_3year_rule_es.html
+++ b/article_3year_rule_es.html
@@ -37,7 +37,7 @@
     "@type": "Article",
     "headline": "El regreso de la regla de los 3 años: ¿Necesidad o precipitación?",
     "description": "Разбор публичной инициативы WSDC о возврате правила 3 лет и последствий для All-Stars и Champions",
-    "url": "https://wsdc-analytics.github.io/article_3year_rule.html",
+    "url": "https://wsdc-analytics.github.io/article_3year_rule_es.html",
     "image": "https://wsdc-analytics.github.io/events_background.png",
     "datePublished": "2026-05-01",
     "dateModified": "2026-05-03",
@@ -47,7 +47,7 @@
       "name": "WSDC Analytics",
       "logo": { "@type": "ImageObject", "url": "https://wsdc-analytics.github.io/events_background.png" }
     },
-    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://wsdc-analytics.github.io/article_3year_rule.html" }
+    "mainEntityOfPage": { "@type": "WebPage", "@id": "https://wsdc-analytics.github.io/article_3year_rule_es.html" }
   }
   </script>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-LMLCY5PE8Z"></script>
@@ -554,7 +554,7 @@
       }
     }
   </style>
-  <script src="static/js/lang-redirect.js"></script>
+  <script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_3year_rule_es.html
+++ b/article_3year_rule_es.html
@@ -36,7 +36,7 @@
     "@context": "https://schema.org",
     "@type": "Article",
     "headline": "El regreso de la regla de los 3 años: ¿Necesidad o precipitación?",
-    "description": "Разбор публичной инициативы WSDC о возврате правила 3 лет и последствий для All-Stars и Champions",
+    "description": "El regreso de la regla de los 3 años: un análisis de la iniciativa pública del WSDC, sus posibles objetivos y consecuencias para All-Stars y Champions.",
     "url": "https://wsdc-analytics.github.io/article_3year_rule_es.html",
     "image": "https://wsdc-analytics.github.io/events_background.png",
     "datePublished": "2026-05-01",
@@ -554,7 +554,7 @@
       }
     }
   </style>
-  <script src="static/js/lang-redirect.js?v=20260808a"></script>
+  <script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_division_transition_time.html
+++ b/article_division_transition_time.html
@@ -764,7 +764,7 @@
 
   </style>
 
-  <script src="static/js/lang-redirect.js?v=20260808a"></script>
+  <script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_division_transition_time.html
+++ b/article_division_transition_time.html
@@ -764,7 +764,7 @@
 
   </style>
 
-  <script src="static/js/lang-redirect.js"></script>
+  <script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_division_transition_time_en.html
+++ b/article_division_transition_time_en.html
@@ -764,7 +764,7 @@
 
   </style>
 
-  <script src="static/js/lang-redirect.js?v=20260808a"></script>
+  <script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_division_transition_time_en.html
+++ b/article_division_transition_time_en.html
@@ -764,7 +764,7 @@
 
   </style>
 
-  <script src="static/js/lang-redirect.js"></script>
+  <script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_division_transition_time_es.html
+++ b/article_division_transition_time_es.html
@@ -764,7 +764,7 @@
 
   </style>
 
-  <script src="static/js/lang-redirect.js?v=20260808a"></script>
+  <script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_division_transition_time_es.html
+++ b/article_division_transition_time_es.html
@@ -764,7 +764,7 @@
 
   </style>
 
-  <script src="static/js/lang-redirect.js"></script>
+  <script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_secondary_role.html
+++ b/article_secondary_role.html
@@ -711,7 +711,7 @@
     }
     .article-footer .data-note a:hover { opacity: 0.85; }
   </style>
-  <script src="static/js/lang-redirect.js"></script>
+  <script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_secondary_role.html
+++ b/article_secondary_role.html
@@ -711,7 +711,7 @@
     }
     .article-footer .data-note a:hover { opacity: 0.85; }
   </style>
-  <script src="static/js/lang-redirect.js?v=20260808a"></script>
+  <script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_secondary_role_en.html
+++ b/article_secondary_role_en.html
@@ -595,7 +595,7 @@
     }
     .article-footer .data-note a:hover { opacity: 0.85; }
   </style>
-  <script src="static/js/lang-redirect.js?v=20260808a"></script>
+  <script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_secondary_role_en.html
+++ b/article_secondary_role_en.html
@@ -595,7 +595,7 @@
     }
     .article-footer .data-note a:hover { opacity: 0.85; }
   </style>
-  <script src="static/js/lang-redirect.js"></script>
+  <script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_secondary_role_es.html
+++ b/article_secondary_role_es.html
@@ -567,7 +567,7 @@
     }
     .article-footer .data-note a:hover { opacity: 0.85; }
   </style>
-  <script src="static/js/lang-redirect.js"></script>
+  <script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/article_secondary_role_es.html
+++ b/article_secondary_role_es.html
@@ -567,7 +567,7 @@
     }
     .article-footer .data-note a:hover { opacity: 0.85; }
   </style>
-  <script src="static/js/lang-redirect.js?v=20260808a"></script>
+  <script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/dancers_2025.html
+++ b/dancers_2025.html
@@ -877,7 +877,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 

--- a/dancers_2025.html
+++ b/dancers_2025.html
@@ -877,7 +877,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 

--- a/dancers_2025_en.html
+++ b/dancers_2025_en.html
@@ -874,7 +874,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 

--- a/dancers_2025_en.html
+++ b/dancers_2025_en.html
@@ -874,7 +874,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 

--- a/dancers_2025_es.html
+++ b/dancers_2025_es.html
@@ -877,7 +877,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 

--- a/dancers_2025_es.html
+++ b/dancers_2025_es.html
@@ -877,7 +877,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 

--- a/events_2025.html
+++ b/events_2025.html
@@ -778,7 +778,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/events_2025.html
+++ b/events_2025.html
@@ -778,7 +778,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/events_2025_en.html
+++ b/events_2025_en.html
@@ -778,7 +778,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/events_2025_en.html
+++ b/events_2025_en.html
@@ -778,7 +778,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/events_2025_es.html
+++ b/events_2025_es.html
@@ -778,7 +778,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/events_2025_es.html
+++ b/events_2025_es.html
@@ -778,7 +778,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/geo_2025.html
+++ b/geo_2025.html
@@ -676,7 +676,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/geo_2025.html
+++ b/geo_2025.html
@@ -676,7 +676,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/geo_2025_en.html
+++ b/geo_2025_en.html
@@ -676,7 +676,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/geo_2025_en.html
+++ b/geo_2025_en.html
@@ -676,7 +676,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/geo_2025_es.html
+++ b/geo_2025_es.html
@@ -676,7 +676,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/geo_2025_es.html
+++ b/geo_2025_es.html
@@ -676,7 +676,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/overview_2025.html
+++ b/overview_2025.html
@@ -1177,7 +1177,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/overview_2025.html
+++ b/overview_2025.html
@@ -1177,7 +1177,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/overview_2025_en.html
+++ b/overview_2025_en.html
@@ -1116,7 +1116,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/overview_2025_en.html
+++ b/overview_2025_en.html
@@ -1116,7 +1116,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/overview_2025_es.html
+++ b/overview_2025_es.html
@@ -1113,7 +1113,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 

--- a/overview_2025_es.html
+++ b/overview_2025_es.html
@@ -1113,7 +1113,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 

--- a/rules_catalog.html
+++ b/rules_catalog.html
@@ -144,7 +144,7 @@
             }
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/rules_catalog.html
+++ b/rules_catalog.html
@@ -144,7 +144,7 @@
             }
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/rules_catalog_en.html
+++ b/rules_catalog_en.html
@@ -144,7 +144,7 @@
             }
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/rules_catalog_en.html
+++ b/rules_catalog_en.html
@@ -144,7 +144,7 @@
             }
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/rules_catalog_es.html
+++ b/rules_catalog_es.html
@@ -144,7 +144,7 @@
             }
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/rules_catalog_es.html
+++ b/rules_catalog_es.html
@@ -144,7 +144,7 @@
             }
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/rules_evolution_2025.html
+++ b/rules_evolution_2025.html
@@ -952,7 +952,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/rules_evolution_2025.html
+++ b/rules_evolution_2025.html
@@ -952,7 +952,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/rules_evolution_2025_en.html
+++ b/rules_evolution_2025_en.html
@@ -949,7 +949,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/rules_evolution_2025_en.html
+++ b/rules_evolution_2025_en.html
@@ -949,7 +949,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/rules_evolution_2025_es.html
+++ b/rules_evolution_2025_es.html
@@ -935,7 +935,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js?v=20260808a"></script>
+<script src="static/js/lang-redirect.js?v=20260808b"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/rules_evolution_2025_es.html
+++ b/rules_evolution_2025_es.html
@@ -935,7 +935,7 @@
             color: var(--text-secondary);
         }
     </style>
-<script src="static/js/lang-redirect.js"></script>
+<script src="static/js/lang-redirect.js?v=20260808a"></script>
   <link rel="stylesheet" href="static/css/article-shell.css">
 </head>
 <body>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -98,7 +98,7 @@
   </url>
 <url>
     <loc>https://wsdc-analytics.github.io/dancers_2025.html</loc>
-    <lastmod>2026-01-13</lastmod>
+    <lastmod>2026-08-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -182,7 +182,7 @@
   </url>
 <url>
     <loc>https://wsdc-analytics.github.io/article_3year_rule_es.html</loc>
-    <lastmod>2026-05-03</lastmod>
+    <lastmod>2026-08-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/static/js/lang-redirect.js
+++ b/static/js/lang-redirect.js
@@ -11,25 +11,6 @@
     article_division_transition_time: ["ru", "en", "es"]
   };
 
-  function pickPreferredLanguage() {
-    var stored = localStorage.getItem("wsdc-lang");
-    if (stored && ["ru", "en", "es"].indexOf(stored) !== -1) {
-      return stored;
-    }
-
-    var browserLangs = Array.isArray(navigator.languages) && navigator.languages.length
-      ? navigator.languages
-      : [navigator.language || "en"];
-
-    for (var i = 0; i < browserLangs.length; i += 1) {
-      var l = (browserLangs[i] || "").toLowerCase();
-      if (l.indexOf("ru") === 0) return "ru";
-      if (l.indexOf("es") === 0) return "es";
-      if (l.indexOf("en") === 0) return "en";
-    }
-    return "en";
-  }
-
   function parseCurrent() {
     var file = (window.location.pathname.split("/").pop() || "").toLowerCase();
     var match = file.match(/^(.*?)(?:_(en|es|ru))?\.html$/);
@@ -52,34 +33,51 @@
     return base + "_" + lang + ".html";
   }
 
+  /**
+   * Strip setlang/lang from the URL without a navigation.
+   * location.replace() here is reported by Google as "Page with redirect".
+   */
+  function stripLangQueryInPlace(params) {
+    params.delete("setlang");
+    params.delete("lang");
+    var cleanQuery = params.toString();
+    var next =
+      window.location.pathname +
+      (cleanQuery ? "?" + cleanQuery : "") +
+      window.location.hash;
+    var current =
+      window.location.pathname + window.location.search + window.location.hash;
+    if (next === current) return;
+    if (window.history && typeof window.history.replaceState === "function") {
+      window.history.replaceState(null, "", next);
+    }
+  }
+
   function redirectIfNeeded() {
     var current = parseCurrent();
     if (!current) return;
 
     var params = new URLSearchParams(window.location.search);
-    // Treat both setlang and lang as explicit user choice.
-    // If present, do not run auto language detection redirect.
+    // Explicit user/language choice only (?lang= / ?setlang=).
+    // Do not auto-redirect from Accept-Language or localStorage — that makes
+    // sitemap language URLs (e.g. *_es.html) look like redirects to Googlebot.
     var forced = params.get("setlang") || params.get("lang");
-    if (forced && ["ru", "en", "es"].indexOf(forced) !== -1) {
-      localStorage.setItem("wsdc-lang", forced);
-      params.delete("setlang");
-      params.delete("lang");
-      var cleanQuery = params.toString();
-      var forcedTarget = buildTarget(current.base, forced);
-      var forcedUrl = forcedTarget + (cleanQuery ? "?" + cleanQuery : "") + window.location.hash;
-      if (forcedTarget === current.file && !cleanQuery) return;
-      window.location.replace(forcedUrl);
+    if (!(forced && ["ru", "en", "es"].indexOf(forced) !== -1)) return;
+
+    localStorage.setItem("wsdc-lang", forced);
+    var forcedTarget = buildTarget(current.base, forced);
+
+    if (forcedTarget === current.file) {
+      stripLangQueryInPlace(params);
       return;
     }
 
-    var preferred = pickPreferredLanguage();
-    if (SUPPORTED[current.base].indexOf(preferred) === -1) return;
-    if (preferred === current.currentLang) return;
-
-    var targetFile = buildTarget(current.base, preferred);
-    var query = params.toString();
-    var targetUrl = targetFile + (query ? "?" + query : "") + window.location.hash;
-    window.location.replace(targetUrl);
+    params.delete("setlang");
+    params.delete("lang");
+    var cleanQuery = params.toString();
+    var forcedUrl =
+      forcedTarget + (cleanQuery ? "?" + cleanQuery : "") + window.location.hash;
+    window.location.replace(forcedUrl);
   }
 
   try {

--- a/static/js/lang-redirect.js
+++ b/static/js/lang-redirect.js
@@ -17,15 +17,9 @@
     if (!match) return null;
 
     var base = match[1];
-    var suffix = match[2] || null;
     if (!SUPPORTED[base]) return null;
 
-    var currentLang = suffix || "ru";
-    if (base === "dancers_2025" && file === "dancers_2025_ru.html") {
-      currentLang = "ru";
-    }
-
-    return { base: base, file: file, currentLang: currentLang };
+    return { base: base, file: file };
   }
 
   function buildTarget(base, lang) {


### PR DESCRIPTION
## Summary
Google Search Console Coverage drilldown (2026-08-08) flagged **Страница с переадресацией** for:
- `article_3year_rule_es.html`
- `dancers_2025.html?lang=ru`

Root cause: `static/js/lang-redirect.js` used `location.replace` to (1) auto-switch language from browser/`localStorage` (so Googlebot on EN bounced off `*_es.html`) and (2) strip `?lang=` via a real navigation.

## Changes
- Drop auto language redirects; only honor explicit `?lang=` / `?setlang=`
- Same-page `?lang=` → `history.replaceState` (no navigation)
- Cache-bust `lang-redirect.js?v=20260808a` on article/report pages
- Point ES 3-year-rule JSON-LD `url` / `@id` at the ES page
- Bump sitemap `lastmod` for the two flagged URLs

## Test plan
- [ ] Open `article_3year_rule_es.html` with EN browser locale: stays on ES (no bounce)
- [ ] Open `dancers_2025.html?lang=ru`: stays on RU; URL may clean without reload
- [ ] Language pills still navigate RU/EN/ES files
- [ ] After deploy: GSC → Validate fix / request indexing for both URLs


Made with [Cursor](https://cursor.com)