### PR TITLE
L2 tips: new copy + mobile bubble fix

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260808c">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260808d">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -294,7 +294,7 @@
       noThisEdition: "No scored stats for this edition",
       trialNoStats: "No scored edition stats yet (trial)",
       metricTipAria: "About metrics",
-      metricTip: "Dancers (~): approximate competitive field from Chart 5 tier ranges (Newcomer + skill divisions × Leader/Follower; midpoint of the summed min–max). Switch dancers may be counted twice. Points: total WSDC points in Skill Level Jack & Jill (Newcomer–Champion, West Coast Swing). New: dancers whose first scored result at this event was this edition.",
+      metricTip: "Dancers: estimated metric from summing the midpoint of each Skill-Level nomination Tier.\nPoints: sum of all points awarded in Skill-Level nominations.\nNew: dancers who earned their first WSDC points at this event.",
       websiteAria: "Event website",
       tierPrefix: "TIER",
       colLeader: "L",
@@ -362,7 +362,7 @@
       noThisEdition: "Нет scored-статистики для этого edition",
       trialNoStats: "Пока нет статистики scored edition (trial)",
       metricTipAria: "О метриках",
-      metricTip: "Танцоры (~): оценка поля по диапазонам тиров Chart 5 (Newcomer + skill × Leader/Follower; середина суммы min–max). Switch может считаться дважды. Очки: сумма очков WSDC в Skill Level Jack & Jill (Newcomer–Champion, West Coast Swing). Новые: танцоры, у которых первый scored-результат на этом ивенте был на этом edition.",
+      metricTip: "Dancers: расчётная метрика — сумма средних значений каждого Tier в Skill-Level номинациях.\nPoints: сумма всех поинтов, начисленных в Skill-Level номинациях.\nNew: количество танцоров, получивших свои первые поинты WSDC на этом ивенте.",
       websiteAria: "Сайт ивента",
       tierPrefix: "ТИР",
       colLeader: "L",
@@ -431,7 +431,7 @@
       noThisEdition: "No hay estadísticas para esta edición",
       trialNoStats: "Aún no hay estadísticas de edición (trial)",
       metricTipAria: "Sobre métricas",
-      metricTip: "Bailarines (~): campo competitivo aproximado por rangos de tier Chart 5 (Newcomer + skill × Leader/Follower; punto medio del min–max sumado). Switch puede contarse dos veces. Puntos: total WSDC en Skill Level Jack & Jill (Newcomer–Champion, West Coast Swing). Nuevos: primera puntuación en este evento en esta edición.",
+      metricTip: "Dancers: métrica estimada sumando el punto medio de cada Tier de nominaciones Skill-Level.\nPoints: suma de todos los puntos otorgados en nominaciones Skill-Level.\nNew: bailarines que obtuvieron sus primeros puntos WSDC en este evento.",
       websiteAria: "Sitio del evento",
       tierPrefix: "TIER",
       colLeader: "L",
@@ -2672,7 +2672,7 @@
       return r.json();
     })
     .then(function (calendar) {
-      return fetch("static/data/event_l2_cards.json?v=20260806c")
+      return fetch("static/data/event_l2_cards.json?v=20260808d")
         .then(function (r) {
           if (!r.ok) return null;
           return r.json();

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -1200,7 +1200,8 @@ h1 {
 
 .l2-event-card.is-open {
   opacity: 1;
-  overflow: hidden;
+  /* Tips are absolutely positioned and must not be clipped by the card. */
+  overflow: visible;
   padding: 8px 10px;
   border-color: var(--border-color);
   pointer-events: auto;
@@ -1282,6 +1283,7 @@ h1 {
   min-height: 0;
   display: flex;
   flex-direction: column;
+  overflow: visible;
 }
 
 .l2-event-card__chart-body {
@@ -1526,6 +1528,7 @@ h1 {
   height: 100%;
   flex: 1 1 auto;
   position: relative;
+  overflow: visible;
 }
 
 .l2-tier-panel__head {
@@ -1558,10 +1561,10 @@ h1 {
 
 .l2-info-tip__bubble {
   position: absolute;
-  z-index: 5;
+  z-index: 40;
   right: 0;
   top: calc(100% + 6px);
-  width: min(260px, 70vw);
+  width: min(280px, 72vw);
   padding: 8px 9px;
   border-radius: var(--radius-sm);
   border: 1px solid rgba(15, 23, 42, 0.1);
@@ -1571,6 +1574,7 @@ h1 {
   font-size: 10px;
   line-height: 1.35;
   text-align: left;
+  white-space: pre-line;
   opacity: 0;
   transform: scale(0.97);
   transform-origin: top right;
@@ -1632,7 +1636,8 @@ h1 {
 }
 
 .l2-info-tip--tier-between:hover .l2-info-tip__bubble,
-.l2-info-tip--tier-between:focus-visible .l2-info-tip__bubble {
+.l2-info-tip--tier-between:focus-visible .l2-info-tip__bubble,
+.l2-info-tip--tier-between.is-open .l2-info-tip__bubble {
   transform: translateX(-50%) scale(1);
 }
 
@@ -2304,11 +2309,35 @@ h1 {
   }
   .l2-event-card__last-head .l2-info-tip--metrics-between .l2-info-tip__bubble,
   .l2-event-card__last-head .l2-info-tip--metrics-between.is-open .l2-info-tip__bubble,
-  .l2-event-card__last-head .l2-info-tip--metrics-between:focus-visible .l2-info-tip__bubble {
+  .l2-event-card__last-head .l2-info-tip--metrics-between:focus-visible .l2-info-tip__bubble,
+  .l2-info-tip--tier-between .l2-info-tip__bubble,
+  .l2-info-tip--tier-between.is-open .l2-info-tip__bubble,
+  .l2-info-tip--tier-between:focus-visible .l2-info-tip__bubble {
     left: 0;
     right: auto;
+    /* 100% here is the 16px tip button — use viewport, not parent %. */
+    width: min(280px, calc(100vw - 32px));
+    max-width: min(280px, calc(100vw - 32px));
     transform: none;
     transform-origin: top left;
+  }
+  .l2-event-card__last-head .l2-info-tip--metrics-between.is-open .l2-info-tip__bubble,
+  .l2-event-card__last-head .l2-info-tip--metrics-between:focus-visible .l2-info-tip__bubble,
+  .l2-info-tip--tier-between.is-open .l2-info-tip__bubble,
+  .l2-info-tip--tier-between:focus-visible .l2-info-tip__bubble {
+    opacity: 1;
+  }
+  .l2-info-tip__bubble {
+    width: min(280px, calc(100vw - 32px));
+    max-width: min(280px, calc(100vw - 32px));
+  }
+  .l2-event-card.is-open,
+  .l2-event-card__grid,
+  .l2-event-card__last-head-block,
+  .l2-event-card__last-head,
+  .l2-event-card__tiers-body,
+  .l2-tier-panel {
+    overflow: visible;
   }
   .l2-event-card__kpi-ctrl {
     order: 5;
@@ -2325,9 +2354,6 @@ h1 {
   .l2-event-card__chart-body .l2-chart,
   .l2-event-card__chart-body .l2-chart-panel {
     min-height: 120px;
-  }
-  .l2-info-tip__bubble {
-    max-width: min(240px, calc(100% - 48px));
   }
 }
 

--- a/static/data/event_l2_cards.json
+++ b/static/data/event_l2_cards.json
@@ -2,9 +2,9 @@
   "as_of": "2026-08-07",
   "generated_at": "2026-08-07T21:06:39Z",
   "tier_tip": {
-    "en": "Tier reflects field size for that role under the WSDC points chart. Larger fields award higher placement points. Current ranges (per role, from 5 competitors): Tier 1: 5–10 · Tier 2: 11–19 · Tier 3: 20–39 · Tier 4: 40–79 · Tier 5: 80–129 · Tier 6: 130+.",
-    "ru": "Тир отражает размер поля в роли по чарту очков WSDC. Чем больше поле, тем выше очки за места. Текущие диапазоны (на роль, от 5 участников): Тир 1: 5–10 · Тир 2: 11–19 · Тир 3: 20–39 · Тир 4: 40–79 · Тир 5: 80–129 · Тир 6: 130+.",
-    "es": "El tier refleja el tamaño del campo por rol según la tabla de puntos WSDC. Campos más grandes dan más puntos por plaza. Rangos actuales (por rol, desde 5 competidores): Tier 1: 5–10 · Tier 2: 11–19 · Tier 3: 20–39 · Tier 4: 40–79 · Tier 5: 80–129 · Tier 6: 130+."
+    "en": "Tier depends on the number of unique competitors in each role.\n\nTier 1: 5–10\nTier 2: 11–19\nTier 3: 20–39\nTier 4: 40–79\nTier 5: 80–129\nTier 6: 130+",
+    "ru": "Тир зависит от количества уникальных конкурентов в каждой роли.\n\nТир 1: 5–10\nТир 2: 11–19\nТир 3: 20–39\nТир 4: 40–79\nТир 5: 80–129\nТир 6: 130+",
+    "es": "El tier depende del número de competidores únicos en cada rol.\n\nTier 1: 5–10\nTier 2: 11–19\nTier 3: 20–39\nTier 4: 40–79\nTier 5: 80–129\nTier 6: 130+"
   },
   "cards": {
     "1": {


### PR DESCRIPTION
## Summary
- New metrics tip copy (Dancers / Points / New) in EN/RU/ES
- New tier tip: depends on unique competitors per role + Tier 1–6 ranges
- `white-space: pre-line` for multiline tips
- Stop clipping: `overflow: visible` on open L2 card / tip parents
- Mobile fix: tip `max-width` used `calc(100% - 48px)` where `100%` was the 16px button → near-zero / “transparent” bubbles; now uses viewport width
- Tier tip CSS now includes `.is-open`
- Cache bust CSS + `event_l2_cards.json`

## Test plan
- [ ] Desktop L2: hover metrics + tier tips — full opaque text, not clipped
- [ ] Mobile L2: tap tips — readable white bubble, not transparent/tiny
- [ ] RU/EN/ES strings match the new wording


Made with [Cursor](https://cursor.com)