### PR TITLE
Unclip L2 info tips from island scrollport

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260808d">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260808e">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -989,6 +989,18 @@ h1 {
   transform: scale(1);
 }
 
+/* L2 info tips are absolutely positioned; keep them out of the island clip. */
+.day-island:has(.l2-info-tip.is-open),
+.day-island:has(.l2-info-tip:focus-visible) {
+  overflow: visible;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .day-island:has(.l2-info-tip:hover) {
+    overflow: visible;
+  }
+}
+
 .day-island__head {
   flex: 0 0 auto;
   display: flex;
@@ -2205,6 +2217,12 @@ h1 {
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     overscroll-behavior: contain;
+  }
+  /* Absolute tip bubbles must not be clipped by the L2 scrollport while open. */
+  .day-island__body:has(.l2-info-tip.is-open),
+  .day-island__body:has(.l2-info-tip:focus-visible),
+  .day-island__body:has(.l2-info-tip:hover) {
+    overflow: visible;
   }
   .day-island__map-col,
   .day-island__list-col {


### PR DESCRIPTION
## Summary
Follow-up to #190: tips could still be clipped by `.day-island { overflow: hidden }` and mobile `.day-island__body` scrollport.
- `:has(.l2-info-tip.is-open|:focus-visible|:hover)` → `overflow: visible` on island + mobile body
- CSS cache `?v=20260808e`

## Test plan
- [ ] Mobile L2: open metrics/tier tips near card edges — full opaque bubble, not cut
- [ ] Desktop hover tips still readable
- [ ] L2 body still scrolls when tips closed


Made with [Cursor](https://cursor.com)