### PR TITLE
Fix L2 tips: mobile tap + desktop z-index

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260808e">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260808f">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -466,7 +466,8 @@
     markers: null,
     markerById: {},
     eventCards: null,
-    l2SparkMetric: "unique_dancers"
+    l2SparkMetric: "unique_dancers",
+    l2TipIgnoreDocCloseUntil: 0
   };
 
   function t(key) {
@@ -2264,22 +2265,89 @@
     refreshDayMapSize(preferReducedMotion() ? 0 : 230);
   }
 
+  function clearL2TipBubblePosition(btn) {
+    var bubble = btn && btn.querySelector(".l2-info-tip__bubble");
+    if (!bubble) return;
+    bubble.style.position = "";
+    bubble.style.left = "";
+    bubble.style.top = "";
+    bubble.style.right = "";
+    bubble.style.width = "";
+    bubble.style.maxWidth = "";
+    bubble.style.transform = "";
+    bubble.style.zIndex = "";
+  }
+
+  function placeL2TipBubble(btn) {
+    var bubble = btn && btn.querySelector(".l2-info-tip__bubble");
+    if (!bubble) return;
+    if (!isMobileL2Layout()) {
+      clearL2TipBubblePosition(btn);
+      return;
+    }
+    var pad = 12;
+    var maxW = Math.min(280, window.innerWidth - pad * 2);
+    bubble.style.position = "fixed";
+    bubble.style.zIndex = "80";
+    bubble.style.right = "auto";
+    bubble.style.transform = "none";
+    bubble.style.width = maxW + "px";
+    bubble.style.maxWidth = maxW + "px";
+    // Measure after opacity rules apply (is-open already set).
+    var r = btn.getBoundingClientRect();
+    var h = bubble.getBoundingClientRect().height || 0;
+    var left = Math.min(Math.max(pad, r.left), window.innerWidth - pad - maxW);
+    var top = r.bottom + 8;
+    if (h && top + h > window.innerHeight - pad && r.top - 8 - h >= pad) {
+      top = r.top - 8 - h;
+    }
+    bubble.style.left = left + "px";
+    bubble.style.top = top + "px";
+  }
+
+  function closeAllL2InfoTips(scope) {
+    var root = scope || document;
+    root.querySelectorAll(".l2-info-tip.is-open").forEach(function (el) {
+      el.classList.remove("is-open");
+      clearL2TipBubblePosition(el);
+    });
+  }
+
   function wireL2InfoTips(root) {
     if (!root) return;
     root.querySelectorAll(".l2-info-tip").forEach(function (btn) {
       if (btn.getAttribute("data-tip-wired") === "1") return;
       btn.setAttribute("data-tip-wired", "1");
       btn.addEventListener("click", function (e) {
-        if (window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
         e.preventDefault();
         e.stopPropagation();
+        // Desktop with real hover: CSS :hover shows the tip.
+        // Mobile / coarse pointer (and mobile L2 layout): tap toggles .is-open.
+        var finePointer = window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+        if (finePointer && !isMobileL2Layout()) return;
+
         var open = btn.classList.contains("is-open");
-        root.querySelectorAll(".l2-info-tip.is-open").forEach(function (el) {
-          el.classList.remove("is-open");
-        });
-        if (!open) btn.classList.add("is-open");
+        closeAllL2InfoTips(root);
+        if (!open) {
+          btn.classList.add("is-open");
+          placeL2TipBubble(btn);
+          // Ignore the document click synthesized for this same tap.
+          state.l2TipIgnoreDocCloseUntil = Date.now() + 400;
+        }
       });
     });
+
+    var body = document.querySelector(".day-island__body");
+    if (body && body.getAttribute("data-l2-tip-scroll") !== "1") {
+      body.setAttribute("data-l2-tip-scroll", "1");
+      body.addEventListener(
+        "scroll",
+        function () {
+          closeAllL2InfoTips(root);
+        },
+        { passive: true }
+      );
+    }
   }
 
   function refreshOpenEventCard() {
@@ -2552,9 +2620,13 @@
       if (tip.classList.contains("is-open") && !(e.target.closest && e.target.closest("#calStatsTip"))) {
         closeTip();
       }
+      if (state.l2TipIgnoreDocCloseUntil && Date.now() < state.l2TipIgnoreDocCloseUntil) {
+        return;
+      }
       document.querySelectorAll(".l2-info-tip.is-open").forEach(function (el) {
         if (!(e.target.closest && e.target.closest(".l2-info-tip") === el)) {
           el.classList.remove("is-open");
+          clearL2TipBubblePosition(el);
         }
       });
     });

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -989,18 +989,6 @@ h1 {
   transform: scale(1);
 }
 
-/* L2 info tips are absolutely positioned; keep them out of the island clip. */
-.day-island:has(.l2-info-tip.is-open),
-.day-island:has(.l2-info-tip:focus-visible) {
-  overflow: visible;
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .day-island:has(.l2-info-tip:hover) {
-    overflow: visible;
-  }
-}
-
 .day-island__head {
   flex: 0 0 auto;
   display: flex;
@@ -1594,11 +1582,18 @@ h1 {
   transition: opacity 125ms var(--ease-out), transform 125ms var(--ease-out);
 }
 
-.l2-info-tip:hover .l2-info-tip__bubble,
+/* Touch/coarse: only .is-open / keyboard focus — never sticky :hover flash. */
 .l2-info-tip:focus-visible .l2-info-tip__bubble,
 .l2-info-tip.is-open .l2-info-tip__bubble {
   opacity: 1;
   transform: scale(1);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .l2-info-tip:hover .l2-info-tip__bubble {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 /* Column-gap bridge: centered between spark tabs and KPI pills. */
@@ -1614,6 +1609,12 @@ h1 {
   transform: translate(-50%, -50%) scale(0.94);
 }
 
+/* Open tip must stack above the sibling tier info button. */
+.l2-info-tip--metrics-between:focus-visible,
+.l2-info-tip--metrics-between.is-open {
+  z-index: 50;
+}
+
 .l2-info-tip--metrics-between .l2-info-tip__bubble {
   right: auto;
   left: 50%;
@@ -1621,10 +1622,18 @@ h1 {
   transform-origin: top center;
 }
 
-.l2-info-tip--metrics-between:hover .l2-info-tip__bubble,
 .l2-info-tip--metrics-between:focus-visible .l2-info-tip__bubble,
 .l2-info-tip--metrics-between.is-open .l2-info-tip__bubble {
   transform: translateX(-50%) scale(1);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .l2-info-tip--metrics-between:hover {
+    z-index: 50;
+  }
+  .l2-info-tip--metrics-between:hover .l2-info-tip__bubble {
+    transform: translateX(-50%) scale(1);
+  }
 }
 
 /* Column-gap bridge: same X as metrics tip, directly underneath. */
@@ -1640,6 +1649,11 @@ h1 {
   transform: translateX(-50%) scale(0.94);
 }
 
+.l2-info-tip--tier-between:focus-visible,
+.l2-info-tip--tier-between.is-open {
+  z-index: 50;
+}
+
 .l2-info-tip--tier-between .l2-info-tip__bubble {
   right: auto;
   left: 50%;
@@ -1647,10 +1661,18 @@ h1 {
   transform-origin: top center;
 }
 
-.l2-info-tip--tier-between:hover .l2-info-tip__bubble,
 .l2-info-tip--tier-between:focus-visible .l2-info-tip__bubble,
 .l2-info-tip--tier-between.is-open .l2-info-tip__bubble {
   transform: translateX(-50%) scale(1);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .l2-info-tip--tier-between:hover {
+    z-index: 50;
+  }
+  .l2-info-tip--tier-between:hover .l2-info-tip__bubble {
+    transform: translateX(-50%) scale(1);
+  }
 }
 
 .l2-event-card__metrics {
@@ -2217,12 +2239,6 @@ h1 {
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     overscroll-behavior: contain;
-  }
-  /* Absolute tip bubbles must not be clipped by the L2 scrollport while open. */
-  .day-island__body:has(.l2-info-tip.is-open),
-  .day-island__body:has(.l2-info-tip:focus-visible),
-  .day-island__body:has(.l2-info-tip:hover) {
-    overflow: visible;
   }
   .day-island__map-col,
   .day-island__list-col {


### PR DESCRIPTION
## Summary
- **Mobile:** tip `:hover` caused flash-then-hide and `overflow: visible` toggles jerked the L2 card. Tips now open only via tap (`.is-open`), bubbles use `position: fixed`, no overflow flip; ignore same-tap document close; close on L2 body scroll.
- **Desktop:** open/hover metrics tip raises stacking context (`z-index: 50`) so the bubble covers the tier info button underneath.
- CSS cache `?v=20260808f`

## Test plan
- [ ] Mobile: tap metrics `i` — tip stays open until outside tap / scroll / other tip
- [ ] Mobile: no screen jerk when opening tip
- [ ] Desktop: hover metrics tip — bubble covers the lower tier `i` button
- [ ] Desktop: hover still works without needing click


Made with [Cursor](https://cursor.com)