### PR TITLE
Fix L2 tip clip/position + narrower tier tip

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260808f">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260808g">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>
@@ -2265,9 +2265,18 @@
     refreshDayMapSize(preferReducedMotion() ? 0 : 230);
   }
 
+  function getL2TipBubble(btn) {
+    if (!btn) return null;
+    if (btn._l2Bubble && btn._l2Bubble.isConnected) return btn._l2Bubble;
+    var bubble = btn.querySelector(".l2-info-tip__bubble");
+    if (bubble) btn._l2Bubble = bubble;
+    return bubble || null;
+  }
+
   function clearL2TipBubblePosition(btn) {
-    var bubble = btn && btn.querySelector(".l2-info-tip__bubble");
+    var bubble = getL2TipBubble(btn);
     if (!bubble) return;
+    bubble.classList.remove("is-ported", "is-visible");
     bubble.style.position = "";
     bubble.style.left = "";
     bubble.style.top = "";
@@ -2276,33 +2285,61 @@
     bubble.style.maxWidth = "";
     bubble.style.transform = "";
     bubble.style.zIndex = "";
+    if (btn._l2BubbleHome && bubble.parentNode !== btn._l2BubbleHome) {
+      btn._l2BubbleHome.appendChild(bubble);
+    }
   }
 
   function placeL2TipBubble(btn) {
-    var bubble = btn && btn.querySelector(".l2-info-tip__bubble");
+    var bubble = getL2TipBubble(btn);
     if (!bubble) return;
     if (!isMobileL2Layout()) {
       clearL2TipBubblePosition(btn);
       return;
     }
-    var pad = 12;
-    var maxW = Math.min(280, window.innerWidth - pad * 2);
-    bubble.style.position = "fixed";
-    bubble.style.zIndex = "80";
-    bubble.style.right = "auto";
-    bubble.style.transform = "none";
-    bubble.style.width = maxW + "px";
-    bubble.style.maxWidth = maxW + "px";
-    // Measure after opacity rules apply (is-open already set).
-    var r = btn.getBoundingClientRect();
-    var h = bubble.getBoundingClientRect().height || 0;
-    var left = Math.min(Math.max(pad, r.left), window.innerWidth - pad - maxW);
-    var top = r.bottom + 8;
-    if (h && top + h > window.innerHeight - pad && r.top - 8 - h >= pad) {
-      top = r.top - 8 - h;
+    if (!btn._l2BubbleHome) btn._l2BubbleHome = bubble.parentNode;
+    // Port to body so fixed coords are viewport-relative (island must not be a fixed CB).
+    if (bubble.parentNode !== document.body) {
+      document.body.appendChild(bubble);
     }
-    bubble.style.left = left + "px";
-    bubble.style.top = top + "px";
+    bubble.classList.add("is-ported", "is-visible");
+
+    var isTier = btn.classList.contains("l2-info-tip--tier-between");
+    var pad = 12;
+    var maxW = isTier
+      ? Math.min(140, Math.max(96, Math.floor((window.innerWidth - pad * 2) * 0.42)))
+      : Math.min(280, window.innerWidth - pad * 2);
+
+    function applyPos() {
+      if (!btn.classList.contains("is-open")) return;
+      var r = btn.getBoundingClientRect();
+      var vv = window.visualViewport;
+      var vx = vv && typeof vv.offsetLeft === "number" ? vv.offsetLeft : 0;
+      var vy = vv && typeof vv.offsetTop === "number" ? vv.offsetTop : 0;
+      var vw = vv && vv.width ? vv.width : window.innerWidth;
+      var vh = vv && vv.height ? vv.height : window.innerHeight;
+
+      bubble.style.position = "fixed";
+      bubble.style.zIndex = "200";
+      bubble.style.right = "auto";
+      bubble.style.transform = "none";
+      bubble.style.width = maxW + "px";
+      bubble.style.maxWidth = maxW + "px";
+
+      var h = bubble.getBoundingClientRect().height || 0;
+      var left = Math.min(Math.max(pad + vx, r.left), vx + vw - pad - maxW);
+      var top = r.bottom + 8;
+      if (h && top + h > vy + vh - pad && r.top - 8 - h >= vy + pad) {
+        top = r.top - 8 - h;
+      }
+      bubble.style.left = Math.round(left) + "px";
+      bubble.style.top = Math.round(top) + "px";
+    }
+
+    applyPos();
+    requestAnimationFrame(function () {
+      requestAnimationFrame(applyPos);
+    });
   }
 
   function closeAllL2InfoTips(scope) {

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -979,14 +979,12 @@ h1 {
   box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18);
   overflow: hidden;
   opacity: 0;
-  transform: scale(0.985);
-  transform-origin: center center;
-  transition: opacity 180ms var(--ease-out), transform 180ms var(--ease-out);
+  /* No transform here: it makes position:fixed tips use the island as containing block. */
+  transition: opacity 180ms var(--ease-out);
 }
 
 .day-island.is-settled {
   opacity: 1;
-  transform: scale(1);
 }
 
 .day-island__head {
@@ -1011,7 +1009,20 @@ h1 {
 .day-island.is-dragging {
   transition: none;
   opacity: 1;
-  transform: none;
+}
+
+/* Keep open L2 analytics above the Leaflet map so tip bubbles are not covered. */
+.day-island__map-col.has-event .l2-event-card.is-open {
+  position: relative;
+  z-index: 6;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .day-island:has(.l2-info-tip:hover),
+  .day-island:has(.l2-info-tip:focus-visible),
+  .day-island:has(.l2-info-tip.is-open) {
+    overflow: visible;
+  }
 }
 
 .day-island__head h2 {
@@ -1087,6 +1098,8 @@ h1 {
 
 .day-island__map-col.has-event #dayMap {
   grid-area: secondary;
+  position: relative;
+  z-index: 1;
 }
 
 .no-geo {
@@ -1584,9 +1597,20 @@ h1 {
 
 /* Touch/coarse: only .is-open / keyboard focus — never sticky :hover flash. */
 .l2-info-tip:focus-visible .l2-info-tip__bubble,
-.l2-info-tip.is-open .l2-info-tip__bubble {
+.l2-info-tip.is-open .l2-info-tip__bubble,
+.l2-info-tip__bubble.is-visible {
   opacity: 1;
   transform: scale(1);
+}
+
+/* Ported to document.body on mobile — viewport-fixed, above island/map. */
+.l2-info-tip__bubble.is-ported {
+  position: fixed;
+  z-index: 200;
+  right: auto;
+  transform: none;
+  transform-origin: top left;
+  pointer-events: none;
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -1657,6 +1681,8 @@ h1 {
 .l2-info-tip--tier-between .l2-info-tip__bubble {
   right: auto;
   left: 50%;
+  /* Compact range list — about half the metrics tip width. */
+  width: min(140px, 40vw);
   transform: translateX(-50%) scale(0.97);
   transform-origin: top center;
 }
@@ -2341,15 +2367,21 @@ h1 {
   .l2-event-card__last-head .l2-info-tip--metrics-between:active {
     transform: translateY(-50%) scale(0.94);
   }
-  .l2-event-card__last-head .l2-info-tip--metrics-between .l2-info-tip__bubble,
-  .l2-event-card__last-head .l2-info-tip--metrics-between.is-open .l2-info-tip__bubble,
-  .l2-event-card__last-head .l2-info-tip--metrics-between:focus-visible .l2-info-tip__bubble,
   .l2-info-tip--tier-between .l2-info-tip__bubble,
   .l2-info-tip--tier-between.is-open .l2-info-tip__bubble,
   .l2-info-tip--tier-between:focus-visible .l2-info-tip__bubble {
     left: 0;
     right: auto;
-    /* 100% here is the 16px tip button — use viewport, not parent %. */
+    width: min(140px, calc(100vw - 32px));
+    max-width: min(140px, calc(100vw - 32px));
+    transform: none;
+    transform-origin: top left;
+  }
+  .l2-event-card__last-head .l2-info-tip--metrics-between .l2-info-tip__bubble,
+  .l2-event-card__last-head .l2-info-tip--metrics-between.is-open .l2-info-tip__bubble,
+  .l2-event-card__last-head .l2-info-tip--metrics-between:focus-visible .l2-info-tip__bubble {
+    left: 0;
+    right: auto;
     width: min(280px, calc(100vw - 32px));
     max-width: min(280px, calc(100vw - 32px));
     transform: none;


### PR DESCRIPTION
## Summary
- **Desktop:** open L2 card stacks above the Leaflet map; island `overflow: visible` while tip hovered so bubbles are not clipped
- **Mobile:** tip was placed with viewport coords while `position:fixed` was relative to transformed `.day-island` → bubble jumped to the bottom. Now: no island transform; bubbles ported to `document.body` and positioned from the `i` button
- **Tier tip:** ~half width (`140px`)

## Test plan
- [ ] Desktop: hover metrics tip — full bubble, not under/cut by map; covers tier `i`
- [ ] Mobile: tap metrics `i` — tip appears next to the button, not at screen bottom
- [ ] Mobile/desktop: tier tip is clearly narrower than metrics tip


Made with [Cursor](https://cursor.com)