### PR TITLE
Rebuild calendar: SwingVester Wels (not Brno)

### DIFF
--- a/static/data/champion_news.json
+++ b/static/data/champion_news.json
@@ -425,7 +425,7 @@
               {
                 "event_name": "SwingVester",
                 "points": 15,
-                "location": "Brno, Czech Republic",
+                "location": "Wels, Austria",
                 "year": 2026,
                 "month": 1
               },
@@ -766,7 +766,7 @@
               {
                 "event_name": "Swingsation",
                 "points": 29,
-                "location": "St. Petersburg, Russia",
+                "location": "Gold Coast, Australia",
                 "year": 2026,
                 "month": 5
               },
@@ -807,24 +807,24 @@
                 "points": 39
               },
               {
-                "location": "Singapore, Singapore",
+                "location": "Gold Coast, Australia",
                 "points": 37
               },
               {
-                "location": "St. Petersburg, Russia",
-                "points": 29
+                "location": "Singapore, Singapore",
+                "points": 37
               }
             ],
             "continents_total": {
-              "Australia": 85,
-              "Europe": 82,
+              "Australia": 114,
               "America": 72,
+              "Europe": 53,
               "Asia": 37
             },
             "continents_all_stars": {
+              "Australia": 47,
               "America": 42,
-              "Australia": 42,
-              "Europe": 38,
+              "Europe": 33,
               "Asia": 28
             }
           },
@@ -1129,7 +1129,7 @@
               {
                 "event_name": "SwingVester",
                 "points": 30,
-                "location": "Brno, Czech Republic",
+                "location": "Wels, Austria",
                 "year": 2026,
                 "month": 1
               },
@@ -1174,8 +1174,8 @@
                 "points": 35
               },
               {
-                "location": "Brno, Czech Republic",
-                "points": 33
+                "location": "Wels, Austria",
+                "points": 30
               }
             ],
             "continents_total": {
@@ -1415,8 +1415,9 @@
             ],
             "continents_total": {
               "America": 279,
-              "Europe": 5,
-              "Asia": 4
+              "Asia": 4,
+              "Australia": 4,
+              "Europe": 1
             },
             "continents_all_stars": {
               "America": 150
@@ -1760,8 +1761,7 @@
             ],
             "continents_total": {
               "Europe": 186,
-              "America": 144,
-              "Asia": 5,
+              "America": 149,
               "Australia": 1
             },
             "continents_all_stars": {
@@ -2918,7 +2918,7 @@
             "top_cities": [
               {
                 "location": "Herndon, VA",
-                "points": 49
+                "points": 53
               },
               {
                 "location": "Atlanta, GA, United States",
@@ -2926,7 +2926,7 @@
               },
               {
                 "location": "Washington, DC",
-                "points": 43
+                "points": 39
               }
             ],
             "continents_total": {
@@ -3155,16 +3155,16 @@
             ],
             "top_cities": [
               {
-                "location": "Washington, DC",
-                "points": 28
-              },
-              {
                 "location": "Sacramento, CA",
                 "points": 26
               },
               {
                 "location": "San Francisco, CA",
                 "points": 21
+              },
+              {
+                "location": "San Diego, CA",
+                "points": 19
               }
             ],
             "continents_total": {
@@ -3271,11 +3271,11 @@
             "top_cities": [
               {
                 "location": "Herndon, VA",
-                "points": 67
+                "points": 69
               },
               {
                 "location": "Washington, DC",
-                "points": 49
+                "points": 47
               },
               {
                 "location": "Atlanta, GA, United States",
@@ -3382,14 +3382,14 @@
             "top_cities": [
               {
                 "location": "Herndon, VA",
-                "points": 28
+                "points": 29
+              },
+              {
+                "location": "Boston, MA",
+                "points": 23
               },
               {
                 "location": "Detroit, MI",
-                "points": 22
-              },
-              {
-                "location": "Dallas, TX",
                 "points": 22
               }
             ],
@@ -4437,7 +4437,7 @@
             "top_cities": [
               {
                 "location": "Boston, MA",
-                "points": 45
+                "points": 47
               },
               {
                 "location": "Herndon, VA",
@@ -4848,7 +4848,7 @@
             "first_points": {
               "event_name": "Swingsation",
               "date": "2011-05-01",
-              "location": "St. Petersburg, Russia",
+              "location": "Gold Coast, Australia",
               "year": 2011,
               "month": 5
             },
@@ -4868,7 +4868,7 @@
               {
                 "event_name": "Swingsation",
                 "points": 50,
-                "location": "St. Petersburg, Russia",
+                "location": "Gold Coast, Australia",
                 "year": 2024,
                 "month": 5
               },
@@ -4912,12 +4912,12 @@
             ],
             "top_cities": [
               {
-                "location": "Sydney, Australia",
-                "points": 52
+                "location": "Gold Coast, Australia",
+                "points": 75
               },
               {
-                "location": "St. Petersburg, Russia",
-                "points": 50
+                "location": "Sydney, Australia",
+                "points": 52
               },
               {
                 "location": "Singapore, Singapore",
@@ -4925,15 +4925,15 @@
               }
             ],
             "continents_total": {
-              "Australia": 137,
-              "Europe": 87,
+              "Australia": 187,
               "America": 67,
-              "Asia": 45
+              "Asia": 45,
+              "Europe": 37
             },
             "continents_all_stars": {
               "America": 46,
-              "Europe": 42,
-              "Australia": 36,
+              "Australia": 41,
+              "Europe": 37,
               "Asia": 30
             }
           },
@@ -5377,7 +5377,7 @@
               {
                 "event_name": "DC Swing eXperience (DCSX)",
                 "points": 16,
-                "location": "Washington, DC",
+                "location": "Herndon, VA",
                 "year": 2023,
                 "month": 11
               }
@@ -5385,7 +5385,7 @@
             "top_cities": [
               {
                 "location": "Herndon, VA",
-                "points": 61
+                "points": 62
               },
               {
                 "location": "Atlanta, GA, United States",

--- a/static/data/events_year_calendar.json
+++ b/static/data/events_year_calendar.json
@@ -1,6 +1,6 @@
 {
-  "as_of": "2026-08-07",
-  "generated_at": "2026-08-07T21:06:21Z",
+  "as_of": "2026-08-08",
+  "generated_at": "2026-08-08T11:52:19Z",
   "years": [
     2024,
     2025,
@@ -25,8 +25,8 @@
     "2024": 139,
     "2025": 177,
     "2026": 191,
-    "2027": 198,
-    "2028": 197
+    "2027": 195,
+    "2028": 192
   },
   "disclaimer": {
     "en": "Expected events are projected from the latest confirmed edition (±1 week per WSDC Registry Rules) for the current year and near-future years in the selector. They stay unconfirmed until published on the WSDC calendar; hiatus stops the projection.",
@@ -50,7 +50,7 @@
       "continent": "America",
       "lat": 30.267153,
       "lon": -97.7430608,
-      "url": "http://www.austinswing.com/",
+      "url": "https://austinswingdance.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -72,7 +72,7 @@
       "continent": "Europe",
       "lat": 43.8338727,
       "lon": 4.359999699999999,
-      "url": "http://Www.avignoncityswing.com",
+      "url": "https://www.avignoncityswing.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -116,7 +116,7 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://www.countdownswingboston.com",
+      "url": "http://countdownswingboston.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -160,7 +160,7 @@
       "continent": "America",
       "lat": 28.5383832,
       "lon": -81.3789269,
-      "url": "http://www.floorplayswingvacation.com",
+      "url": "http://www.floorplayswingvacation.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -204,7 +204,7 @@
       "continent": "America",
       "lat": 36.5972925,
       "lon": -121.8977688,
-      "url": "http://www.montereyswing.com",
+      "url": "http://www.montereyswing.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -226,7 +226,7 @@
       "continent": "America",
       "lat": 36.1626638,
       "lon": -86.7816016,
-      "url": "http://www.spotlightnewyears.com",
+      "url": "http://www.spotlightnewyears.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -248,7 +248,7 @@
       "continent": "Europe",
       "lat": 55.953252,
       "lon": -3.188267,
-      "url": "http://www.swingresolution.com",
+      "url": "http://www.swingresolution.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -287,11 +287,11 @@
       "weekend_key": "2023-12-28",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Brno",
-      "country": "Czech Republic",
+      "city": "Wels",
+      "country": "Austria",
       "continent": "Europe",
-      "lat": 49.1950602,
-      "lon": 16.6068371,
+      "lat": 48.1664268,
+      "lon": 14.0388714,
       "url": "https://www.swingvester.com/",
       "year": 2024,
       "source": "event_editions_month_only",
@@ -314,7 +314,7 @@
       "continent": "America",
       "lat": 32.7831,
       "lon": -96.8067,
-      "url": "https://ucwdc.org/worlds-home/",
+      "url": "http://www.ucwdcworlds.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -358,7 +358,7 @@
       "continent": "America",
       "lat": 38.5781342,
       "lon": -121.4944209,
-      "url": "http://www.capitalswingconvention.com",
+      "url": "http://www.capitalswingconvention.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -402,7 +402,7 @@
       "continent": "Europe",
       "lat": 48.8575475,
       "lon": 2.3513765,
-      "url": "http://pariswestiefest.com/?lang=en",
+      "url": "http://https//parisswingclassic.com",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -424,7 +424,7 @@
       "continent": "America",
       "lat": 45.515232,
       "lon": -122.6783853,
-      "url": "https://rosecityswing.com",
+      "url": "https://rosecityswing.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -446,7 +446,7 @@
       "continent": "Europe",
       "lat": 59.9310584,
       "lon": 30.3609097,
-      "url": "http://swingandsnow.ru",
+      "url": "http://swingandsnow.ru/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -534,7 +534,7 @@
       "continent": "America",
       "lat": 39.7392358,
       "lon": -104.990251,
-      "url": "https://www.5280westival.com",
+      "url": "http://www.5280westival.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -600,7 +600,7 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://teapartyswings.com",
+      "url": "http://teapartyswings.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -622,7 +622,7 @@
       "continent": "America",
       "lat": 34.703947,
       "lon": -118.1481016,
-      "url": "http://www.highdesertdanceclassic.com",
+      "url": "http://www.highdesertdanceclassic.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -688,7 +688,7 @@
       "continent": "America",
       "lat": 29.7600771,
       "lon": -95.3701108,
-      "url": "http://www.htownthrowdownwcs.com",
+      "url": "http://www.htownthrowdownwcs.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -732,7 +732,7 @@
       "continent": "Australia",
       "lat": -41.2923814,
       "lon": 174.7787463,
-      "url": "https://swingcentral.nz/swingvasion",
+      "url": "https://swingvasion.nz/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -754,7 +754,7 @@
       "continent": "America",
       "lat": 41.88325,
       "lon": -87.6323879,
-      "url": "www.TheChicagoClassic.com",
+      "url": "https://thechicagoclassic.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -776,7 +776,7 @@
       "continent": "America",
       "lat": 36.1551375,
       "lon": -95.989501,
-      "url": "http://www.TulsaSpringSwing.com",
+      "url": "http://www.tulsaspringswing.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -798,7 +798,7 @@
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
-      "url": "http://www.west-in-lyon.fr",
+      "url": "http://www.west-in-lyon.fr/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -820,7 +820,7 @@
       "continent": "Europe",
       "lat": 47.497912,
       "lon": 19.040235,
-      "url": "http://www.westiespringthing.com",
+      "url": "https://westiespringthing.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -842,7 +842,7 @@
       "continent": "Asia",
       "lat": 1.352083,
       "lon": 103.819836,
-      "url": "https://www.asiawcsopen.com/",
+      "url": "https://asiawcsopen.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -864,7 +864,7 @@
       "continent": "America",
       "lat": 51.04473309999999,
       "lon": -114.0718831,
-      "url": "http://www.calgarydancestampede.com",
+      "url": "http://www.calgarydancestampede.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -886,7 +886,7 @@
       "continent": "America",
       "lat": 34.1820605,
       "lon": -118.3074827,
-      "url": "http://cityofangelswcs.com",
+      "url": "https://cityofangelswcs.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -908,7 +908,7 @@
       "continent": "Europe",
       "lat": 53.4807593,
       "lon": -2.2426305,
-      "url": "http://www.DetonationDance.com",
+      "url": "http://www.detonationdance.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -974,7 +974,7 @@
       "continent": "Europe",
       "lat": 54.73479099999999,
       "lon": 55.9578555,
-      "url": "https://honeyfest-ufa.ru/",
+      "url": "https://t.me/honeyfest",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1040,7 +1040,7 @@
       "continent": "America",
       "lat": 28.5383832,
       "lon": -81.3789269,
-      "url": "http://www.swingoverevent.com",
+      "url": "http://swingoverevent.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1128,7 +1128,7 @@
       "continent": "America",
       "lat": 42.1967113,
       "lon": -122.7139216,
-      "url": "http://soswingdance.com",
+      "url": "http://wwww.soswingdance.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1194,7 +1194,7 @@
       "continent": "America",
       "lat": 41.7658043,
       "lon": -72.6733723,
-      "url": "http://www.sis.djkenm.com",
+      "url": "http://www.sis.djkenm.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1260,7 +1260,7 @@
       "continent": "America",
       "lat": 33.7501275,
       "lon": -84.3885209,
-      "url": "http://www.usagrandnationals.com",
+      "url": "http://www.usagrandnationals.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1414,7 +1414,7 @@
       "continent": "America",
       "lat": 40.4966567,
       "lon": -74.4442802,
-      "url": "http://www.libertyswing.com",
+      "url": "http://www.libertyswing.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1436,7 +1436,7 @@
       "continent": "America",
       "lat": 42.32971819999999,
       "lon": -83.0424533,
-      "url": "http://www.michiganclassicswing.com/",
+      "url": "http://michiganclassicswing.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1502,7 +1502,7 @@
       "continent": "America",
       "lat": 30.4514677,
       "lon": -91.1871466,
-      "url": "http://www.swingapaloozaevent.com",
+      "url": "http://www.swingapaloozaevent.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1634,7 +1634,7 @@
       "continent": "America",
       "lat": 38.9822282,
       "lon": -94.6707917,
-      "url": "http://Www.midwestwestiefest.com",
+      "url": "http://www.midwestwestiefest.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1656,7 +1656,7 @@
       "continent": "Europe",
       "lat": 52.3675734,
       "lon": 4.9041389,
-      "url": "http://www.neverlandswing.com",
+      "url": "http://www.neverlandswing.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1854,7 +1854,7 @@
       "continent": "America",
       "lat": 41.88325,
       "lon": -87.6323879,
-      "url": "http://www.chicagolanddancefestival.com",
+      "url": "http://www.chicagolanddancefestival.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1876,7 +1876,7 @@
       "continent": "Europe",
       "lat": 47.9990077,
       "lon": 7.842104299999999,
-      "url": "http://www.go-wcs.com",
+      "url": "http://www.go-wcs.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1920,7 +1920,7 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "http://www.nedancefestival.com",
+      "url": "http://www.nedancefestival.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -1986,7 +1986,7 @@
       "continent": "America",
       "lat": 42.3555076,
       "lon": -71.0565364,
-      "url": "https://summerhummerboston.com/",
+      "url": "http://summerhummerboston.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2030,7 +2030,7 @@
       "continent": "America",
       "lat": 37.7749295,
       "lon": -122.4194155,
-      "url": "http://dancegeekproductions.art",
+      "url": "http://www.dancegeekproductions.art/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2096,7 +2096,7 @@
       "continent": "America",
       "lat": 30.267153,
       "lon": -97.7430608,
-      "url": "http://www.atxrox.com",
+      "url": "https://atxrox.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2162,7 +2162,7 @@
       "continent": "America",
       "lat": 33.4482948,
       "lon": -112.0725488,
-      "url": "http://www.desertcityswing.com",
+      "url": "http://www.desertcityswing.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2184,7 +2184,7 @@
       "continent": "Europe",
       "lat": 60.16985569999999,
       "lon": 24.938379,
-      "url": "http://www.finnfest.fi",
+      "url": "http://www.finnfest.fi/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2206,7 +2206,7 @@
       "continent": "Asia",
       "lat": 33.5042779,
       "lon": 126.519838,
-      "url": "http://koreawestival.com",
+      "url": "http://koreawestival.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2228,7 +2228,7 @@
       "continent": "America",
       "lat": 38.62742799999999,
       "lon": -90.1982439,
-      "url": "http://Www.mmisl.com",
+      "url": "http://www.mmisl.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2250,7 +2250,7 @@
       "continent": "Europe",
       "lat": 51.5072178,
       "lon": -0.1275862,
-      "url": "http://www.MidlandSwingOpen.com",
+      "url": "http://www.midlandswingopen.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2294,7 +2294,7 @@
       "continent": "America",
       "lat": 30.3297566,
       "lon": -81.6591529,
-      "url": "http://www.floridadanceevents.com",
+      "url": "http://www.jaxwestiefest.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2360,7 +2360,7 @@
       "continent": "America",
       "lat": 37.33874,
       "lon": -121.8852525,
-      "url": "http://www.SBDF.dance",
+      "url": "https://sbdf.dance/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2382,7 +2382,7 @@
       "continent": "America",
       "lat": 35.7795897,
       "lon": -78.6381787,
-      "url": "http://www.trilogywcs.com",
+      "url": "https://trilogywcs.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2404,7 +2404,7 @@
       "continent": "America",
       "lat": 33.7501275,
       "lon": -84.3885209,
-      "url": "https://www.atlantaswingclassic.com",
+      "url": "https://www.atlantaswingclassic.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2426,7 +2426,7 @@
       "continent": "Europe",
       "lat": 48.3705449,
       "lon": 10.89779,
-      "url": "https://www.augsburgwestiestation.com/home",
+      "url": "https://www.augsburgwestiestation.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2448,7 +2448,7 @@
       "continent": "America",
       "lat": 37.7749295,
       "lon": -122.4194155,
-      "url": "https://boogiebythebay.com",
+      "url": "https://boogiebythebay.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2492,7 +2492,7 @@
       "continent": "America",
       "lat": 33.6638439,
       "lon": -117.9047429,
-      "url": "http://Hstswing.com",
+      "url": "http://hstswing.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2558,7 +2558,7 @@
       "continent": "America",
       "lat": 33.6845673,
       "lon": -117.8265049,
-      "url": "http://www.ParadiseCountryDanceFestival.com",
+      "url": "https://paradisecountrydancefestival.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2580,7 +2580,7 @@
       "continent": "America",
       "lat": 41.88325,
       "lon": -87.6323879,
-      "url": "https://swingcitychicago.com",
+      "url": "https://swingcitychicago.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2602,7 +2602,7 @@
       "continent": "Europe",
       "lat": 50.6402286,
       "lon": 5.5689372,
-      "url": "http://www.swingside-invitational.com",
+      "url": "http://www.swingside-invitational.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2624,7 +2624,7 @@
       "continent": "America",
       "lat": 39.9525839,
       "lon": -75.1652215,
-      "url": "http://www.sparklage.com",
+      "url": "http://www.swustlicious.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2668,7 +2668,7 @@
       "continent": "Europe",
       "lat": 52.2296756,
       "lon": 21.0122287,
-      "url": "http://www.warsawhalloweenswing.com",
+      "url": "http://www.warsawhalloweenswing.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2690,7 +2690,7 @@
       "continent": "Europe",
       "lat": 47.497912,
       "lon": 19.040235,
-      "url": "http://www.asc-budapest.com",
+      "url": "http://www.asc-budapest.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2734,7 +2734,7 @@
       "continent": "America",
       "lat": 32.7831,
       "lon": -96.8067,
-      "url": "http://www.MidnightMadnessWCS.com",
+      "url": "http://www.midnightmadnesswcs.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2844,7 +2844,7 @@
       "continent": "Australia",
       "lat": -34.9284989,
       "lon": 138.6007456,
-      "url": "http://www.simplyadelaidewcs.com.au",
+      "url": "http://www.simplyadelaidewcs.com.au/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2910,7 +2910,7 @@
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
-      "url": "http://www.frenchywesty.com",
+      "url": "http://www.frenchywesty.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2954,7 +2954,7 @@
       "continent": "Europe",
       "lat": 52.52000659999999,
       "lon": 13.404954,
-      "url": "https://berlinswingrevolution.com",
+      "url": "https://berlinswingrevolution.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2976,7 +2976,7 @@
       "continent": "America",
       "lat": 41.49932,
       "lon": -81.6943605,
-      "url": "http://Cashdanceclub.org",
+      "url": "https://cashdanceclub.org/cash-bash/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -2998,7 +2998,7 @@
       "continent": "Europe",
       "lat": 43.6048462,
       "lon": 1.442848,
-      "url": "http://www.globalgrandprixwcs.com",
+      "url": "https://www.globalgrandprixwcs.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -3042,7 +3042,7 @@
       "continent": "America",
       "lat": 33.7174708,
       "lon": -117.8311428,
-      "url": "http://www.tapwcs.com",
+      "url": "http://www.tapwcs.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -3064,7 +3064,7 @@
       "continent": "America",
       "lat": 34.0549076,
       "lon": -118.242643,
-      "url": "http://www.theopenswing.com",
+      "url": "http://www.theopenswing.com/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -3086,7 +3086,7 @@
       "continent": "Europe",
       "lat": 59.9121746,
       "lon": 10.7312704,
-      "url": "http://www.winterwhite.no",
+      "url": "http://www.winterwhite.no/",
       "year": 2024,
       "source": "event_editions_month_only",
       "stats_only": true,
@@ -3145,11 +3145,11 @@
       "weekend_key": "2024-12-26",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Brno",
-      "country": "Czech Republic",
+      "city": "Wels",
+      "country": "Austria",
       "continent": "Europe",
-      "lat": 49.1950602,
-      "lon": 16.6068371,
+      "lat": 48.1664268,
+      "lon": 14.0388714,
       "url": "http://www.swingvester.com",
       "year": 2025,
       "source": "edition_calendar_dates",
@@ -4870,7 +4870,7 @@
       "continent": "Europe",
       "lat": 52.3675734,
       "lon": 4.9041389,
-      "url": "http://www.neverlandswing.com",
+      "url": "http://www.neverlandswing.com/",
       "year": 2025,
       "source": "event_editions",
       "has_results": true
@@ -6653,7 +6653,7 @@
       "continent": "America",
       "lat": 34.0549076,
       "lon": -118.242643,
-      "url": "http://www.theopenswing.com",
+      "url": "http://www.theopenswing.com/",
       "year": 2025,
       "source": "event_editions",
       "has_results": true
@@ -6921,11 +6921,11 @@
       "weekend_key": "2025-12-25",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Brno",
-      "country": "Czech Republic",
+      "city": "Wels",
+      "country": "Austria",
       "continent": "Europe",
-      "lat": 49.1950602,
-      "lon": 16.6068371,
+      "lat": 48.1664268,
+      "lon": 14.0388714,
       "url": "http://www.swingvester.com",
       "year": 2026,
       "source": "edition_calendar_dates",
@@ -9148,7 +9148,7 @@
       "lon": 7.842104299999999,
       "url": "http://www.go-wcs.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:120:2026-08-06",
@@ -9191,7 +9191,7 @@
       "lon": -71.0565364,
       "url": "http://www.nedancefestival.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:59:2026-08-06",
@@ -9204,14 +9204,14 @@
       "weekend_key": "2026-08-06",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Washington",
+      "city": "Herndon",
       "country": "United States",
       "continent": "America",
       "lat": 38.9695545,
       "lon": -77.3860976,
       "url": "http://www.swingfling.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:227:2026-08-06",
@@ -9231,7 +9231,7 @@
       "lon": -122.4194155,
       "url": "http://www.dancegeekproductions.art/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:384:2026-08-14",
@@ -9251,7 +9251,7 @@
       "lon": 23.3218675,
       "url": "https://wcs-gps.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:264:2026-08-14",
@@ -9271,7 +9271,7 @@
       "lon": 18.0710935,
       "url": "http://www.uptownswing.se/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:298:2026-08-20",
@@ -9284,14 +9284,14 @@
       "weekend_key": "2026-08-20",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Christchurch",
-      "country": "New Zealand",
+      "city": "Perth",
+      "country": "Australia",
       "continent": "Australia",
       "lat": -31.9513993,
       "lon": 115.8616783,
       "url": "http://www.code03swing.com/shakedown",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:53:2026-08-20",
@@ -9311,7 +9311,7 @@
       "lon": -71.0565364,
       "url": "http://summerhummerboston.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:t-swing-creation-hamburg-hamburg-germany:2026-08-20",
@@ -9331,7 +9331,7 @@
       "lon": 9.9871703,
       "url": "http://hamburgswing.dance/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:391:2026-08-20",
@@ -9374,7 +9374,7 @@
       "lon": -121.3153096,
       "url": "http://thebendconnection.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:119:2026-08-21",
@@ -9394,7 +9394,7 @@
       "lon": -87.6323879,
       "url": "http://www.chicagolanddancefestival.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:t-manneken-swing-bruxelles-belgium:2026-08-21",
@@ -9414,7 +9414,7 @@
       "lon": 4.357200100000001,
       "url": "https://www.mannekenswing.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:t-westie-joy-bucharest-romania:2026-08-21",
@@ -9434,7 +9434,7 @@
       "lon": null,
       "url": "https://www.westiejoy.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:135:2026-08-27",
@@ -9454,7 +9454,7 @@
       "lon": -112.0725488,
       "url": "http://www.desertcityswing.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:313:2026-08-27",
@@ -9467,14 +9467,14 @@
       "weekend_key": "2026-08-27",
       "status": "confirmed",
       "kind": "registry",
-      "city": "LYON",
+      "city": "Lyon",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
       "url": "http://www.frenchywesty.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:339:2026-08-28",
@@ -9494,7 +9494,7 @@
       "lon": -2.58791,
       "url": "https://www.bristolcityswing.com/bsf",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:268:2026-09-03",
@@ -9514,7 +9514,7 @@
       "lon": 126.519838,
       "url": "http://koreawestival.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:48:2026-09-03",
@@ -9534,7 +9534,7 @@
       "lon": -121.8852525,
       "url": "https://sbdf.dance/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:177:2026-09-04",
@@ -9554,7 +9554,7 @@
       "lon": -81.6591529,
       "url": "http://www.jaxwestiefest.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:233:2026-09-10",
@@ -9574,12 +9574,12 @@
       "lon": 11.5819806,
       "url": "https://bavarianopen.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:47:2026-09-10",
       "event_id": 47,
-      "name": "Swingtime in the Rockies",
+      "name": "SwingTime Denver",
       "start_date": "2026-09-10",
       "end_date": "2026-09-13",
       "weekend_start": "2026-09-10",
@@ -9594,7 +9594,7 @@
       "lon": -104.990251,
       "url": "http://www.swingtimewcs.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:231:2026-09-10",
@@ -9614,7 +9614,7 @@
       "lon": -78.6381787,
       "url": "https://trilogywcs.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:338:2026-09-11",
@@ -9634,7 +9634,7 @@
       "lon": 37.6150527,
       "url": "https://vk.com/seadancefest",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:359:2026-09-17",
@@ -9654,7 +9654,7 @@
       "lon": -122.3328481,
       "url": "https://www.retaliationswing.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:357:2026-09-17",
@@ -9674,7 +9674,7 @@
       "lon": 16.3713095,
       "url": "https://www.wcsparty.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:300:2026-09-18",
@@ -9694,7 +9694,7 @@
       "lon": -97.7430608,
       "url": "https://atxrox.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:254:2026-09-18",
@@ -9714,12 +9714,12 @@
       "lon": 24.938379,
       "url": "http://www.finnfest.fi/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:342:2026-09-18",
       "event_id": 342,
-      "name": "Global Grand Prix - West Coast Swing Reunion",
+      "name": "Global Grand Prix -- West Coast Swing Championships",
       "start_date": "2026-09-18",
       "end_date": "2026-09-21",
       "weekend_start": "2026-09-17",
@@ -9734,7 +9734,7 @@
       "lon": 2.3513765,
       "url": "https://www.globalgrandprixwcs.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:355:2026-09-23",
@@ -9754,7 +9754,7 @@
       "lon": -156.4391668,
       "url": "http://www.alohaopenwcs.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:324:2026-09-24",
@@ -9774,7 +9774,7 @@
       "lon": -114.0718831,
       "url": "https://ctodance.ca/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:167:2026-09-24",
@@ -9794,7 +9794,7 @@
       "lon": 151.2057136,
       "url": "https://www.bestofthebestwcs.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:131:2026-09-24",
@@ -9814,7 +9814,7 @@
       "lon": -90.1982439,
       "url": "http://www.mmisl.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:165:2026-09-24",
@@ -9834,12 +9834,12 @@
       "lon": -0.1275862,
       "url": "http://www.midlandswingopen.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:361:2026-09-24",
       "event_id": 361,
-      "name": "Mooseland Swing",
+      "name": "Mooseland Swing 2026",
       "start_date": "2026-09-24",
       "end_date": "2026-09-28",
       "weekend_start": "2026-09-24",
@@ -9854,7 +9854,7 @@
       "lon": 14.6360681,
       "url": "https://mooselandswing.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:234:2026-09-25",
@@ -9867,14 +9867,14 @@
       "weekend_key": "2026-09-24",
       "status": "confirmed",
       "kind": "registry",
-      "city": "WILMINGTON",
+      "city": "Wilmington",
       "country": "United States",
       "continent": "America",
       "lat": 39.744655,
       "lon": -75.5483909,
       "url": "https://phillyswing.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:211:2026-10-01",
@@ -9894,7 +9894,7 @@
       "lon": -84.3885209,
       "url": "https://www.atlantaswingclassic.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:388:2026-10-01",
@@ -9914,7 +9914,7 @@
       "lon": 11.0679977,
       "url": "https://norwegianopen.no/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:t-riverswingnights-dresden-germany:2026-10-01",
@@ -9934,7 +9934,7 @@
       "lon": 13.7372621,
       "url": "http://www.riverswingnights.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:t-westie-harbor-gothenburg-sweden:2026-10-01",
@@ -9954,7 +9954,7 @@
       "lon": 11.97456,
       "url": "http://www.westieharbor.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:t-autumn-beat-riga-latvia:2026-10-02",
@@ -9974,7 +9974,7 @@
       "lon": 24.1056221,
       "url": "https://autumnbeat.lv/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:8:2026-10-08",
@@ -9994,7 +9994,7 @@
       "lon": -122.4194155,
       "url": "https://boogiebythebay.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:367:2026-10-09",
@@ -10037,7 +10037,7 @@
       "lon": -73.56739189999999,
       "url": "http://montrealwestiefest.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:322:2026-10-15",
@@ -10057,7 +10057,7 @@
       "lon": 9.1824027,
       "url": "https://www.westcoastswingmilan.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:179:2026-10-15",
@@ -10077,7 +10077,7 @@
       "lon": 174.7644881,
       "url": "https://www.streetswing.co.nz/the-new-zealand-open",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:43:2026-10-15",
@@ -10097,7 +10097,27 @@
       "lon": -117.8265049,
       "url": "https://paradisecountrydancefestival.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
+    },
+    {
+      "id": "confirmed:286:2026-10-15",
+      "event_id": 286,
+      "name": "WCS Festival",
+      "start_date": "2026-10-15",
+      "end_date": "2026-10-17",
+      "weekend_start": "2026-10-15",
+      "weekend_end": "2026-10-18",
+      "weekend_key": "2026-10-15",
+      "status": "confirmed",
+      "kind": "registry",
+      "city": "Düsseldorf",
+      "country": "Germany",
+      "continent": "Europe",
+      "lat": 51.2230411,
+      "lon": 6.7824545,
+      "url": "http://www.wcsfestival.com/",
+      "year": 2026,
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:267:2026-10-16",
@@ -10117,27 +10137,7 @@
       "lon": -75.1652215,
       "url": "http://www.swustlicious.com/",
       "year": 2026,
-      "source": "events_list_current"
-    },
-    {
-      "id": "confirmed:286:2026-10-16",
-      "event_id": 286,
-      "name": "WCS Festival",
-      "start_date": "2026-10-16",
-      "end_date": "2026-10-18",
-      "weekend_start": "2026-10-15",
-      "weekend_end": "2026-10-18",
-      "weekend_key": "2026-10-15",
-      "status": "confirmed",
-      "kind": "registry",
-      "city": "Duesseldorf",
-      "country": "Germany",
-      "continent": "Europe",
-      "lat": 51.2230411,
-      "lon": 6.7824545,
-      "url": "http://www.wcsfestival.com/",
-      "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:350:2026-10-22",
@@ -10157,7 +10157,7 @@
       "lon": 10.89779,
       "url": "https://www.augsburgwestiestation.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:65:2026-10-22",
@@ -10177,7 +10177,7 @@
       "lon": -117.9047429,
       "url": "http://hstswing.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:380:2026-10-22",
@@ -10197,7 +10197,7 @@
       "lon": -73.75447070000001,
       "url": "http://www.spookyalbanyswing.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:125:2026-10-22",
@@ -10210,21 +10210,21 @@
       "weekend_key": "2026-10-22",
       "status": "confirmed",
       "kind": "registry",
-      "city": "CHICAGO",
+      "city": "Chicago",
       "country": "United States",
       "continent": "America",
       "lat": 41.88325,
       "lon": -87.6323879,
       "url": "https://swingcitychicago.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
-      "id": "confirmed:346:2026-10-23",
+      "id": "confirmed:346:2026-10-22",
       "event_id": 346,
       "name": "Swingside Invitational",
-      "start_date": "2026-10-23",
-      "end_date": "2026-10-25",
+      "start_date": "2026-10-22",
+      "end_date": "2026-10-24",
       "weekend_start": "2026-10-22",
       "weekend_end": "2026-10-25",
       "weekend_key": "2026-10-22",
@@ -10235,9 +10235,9 @@
       "continent": "Europe",
       "lat": 50.6402286,
       "lon": 5.5689372,
-      "url": "https://www.swingside-invitational.com/",
+      "url": "http://www.swingside-invitational.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:229:2026-10-28",
@@ -10257,7 +10257,7 @@
       "lon": 18.0710935,
       "url": "http://www.snowcs.se/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:340:2026-10-29",
@@ -10277,7 +10277,7 @@
       "lon": 103.819836,
       "url": "https://spookywestieweekend.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:236:2026-10-29",
@@ -10297,7 +10297,7 @@
       "lon": 21.0122287,
       "url": "http://www.warsawhalloweenswing.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:31:2026-11-05",
@@ -10317,12 +10317,12 @@
       "lon": -119.7788687,
       "url": "http://mountainmagic.dance/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:79:2026-11-05",
       "event_id": 79,
-      "name": "Sea to Sky",
+      "name": "Sea to Sky Seattle",
       "start_date": "2026-11-05",
       "end_date": "2026-11-09",
       "weekend_start": "2026-11-05",
@@ -10337,7 +10337,7 @@
       "lon": -122.3328481,
       "url": "http://seatoskywcs.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:330:2026-11-05",
@@ -10357,7 +10357,7 @@
       "lon": 138.6007456,
       "url": "http://www.simplyadelaidewcs.com.au/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:137:2026-11-05",
@@ -10370,14 +10370,14 @@
       "weekend_key": "2026-11-05",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Tampa Bay",
+      "city": "Tampa",
       "country": "United States",
       "continent": "America",
       "lat": 27.9516896,
       "lon": -82.45875269999999,
       "url": "http://www.tbcwcs.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:194:2026-11-06",
@@ -10397,7 +10397,7 @@
       "lon": 37.6150527,
       "url": "http://westiefest.org/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:312:2026-11-06",
@@ -10410,19 +10410,19 @@
       "weekend_key": "2026-11-05",
       "status": "confirmed",
       "kind": "registry",
-      "city": "TOULOUSE",
+      "city": "Toulouse",
       "country": "France",
       "continent": "Europe",
       "lat": 43.6048462,
       "lon": 1.442848,
       "url": "http://www.westiepinkcity.fr/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:288:2026-11-12",
       "event_id": 288,
-      "name": "Midnight Madness",
+      "name": "Midnight Madness WCS 2026",
       "start_date": "2026-11-12",
       "end_date": "2026-11-15",
       "weekend_start": "2026-11-12",
@@ -10430,14 +10430,14 @@
       "weekend_key": "2026-11-12",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Dallas Ft. Worth",
+      "city": "Dallas",
       "country": "United States",
       "continent": "America",
       "lat": 32.7831,
       "lon": -96.8067,
       "url": "http://www.midnightmadnesswcs.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:376:2026-11-12",
@@ -10450,14 +10450,14 @@
       "weekend_key": "2026-11-12",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Providence RI",
+      "city": "Providence",
       "country": "United States",
       "continent": "America",
       "lat": 41.8245558,
       "lon": -71.414199,
       "url": "http://www.northeastswingclassic.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:270:2026-11-12",
@@ -10470,14 +10470,14 @@
       "weekend_key": "2026-11-12",
       "status": "confirmed",
       "kind": "registry",
-      "city": "LYON",
+      "city": "Lyon",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
       "url": "http://www.frenchywesty.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:269:2026-11-13",
@@ -10497,7 +10497,7 @@
       "lon": 19.040235,
       "url": "http://www.asc-budapest.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:365:2026-11-13",
@@ -10517,7 +10517,7 @@
       "lon": -0.1275862,
       "url": "http://www.flowstatefest.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:181:2026-11-19",
@@ -10530,14 +10530,14 @@
       "weekend_key": "2026-11-19",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Washington",
+      "city": "Herndon",
       "country": "United States",
       "continent": "America",
       "lat": 38.9695545,
       "lon": -77.3860976,
       "url": "http://www.dcswingexperience.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:323:2026-11-19",
@@ -10557,7 +10557,7 @@
       "lon": -86.5853155,
       "url": "http://rocketcityswing.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:68:2026-11-25",
@@ -10577,7 +10577,7 @@
       "lon": -118.242643,
       "url": "http://www.theopenswing.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:87:2026-11-26",
@@ -10597,12 +10597,12 @@
       "lon": -81.6943605,
       "url": "https://cashdanceclub.org/cash-bash/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:212:2026-12-03",
       "event_id": 212,
-      "name": "The After Party (TAP)",
+      "name": "The After Party aka TAP",
       "start_date": "2026-12-03",
       "end_date": "2026-12-07",
       "weekend_start": "2026-12-03",
@@ -10617,7 +10617,7 @@
       "lon": -117.8311428,
       "url": "http://www.tapwcs.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:238:2026-12-03",
@@ -10637,7 +10637,7 @@
       "lon": 10.7312704,
       "url": "http://www.winterwhite.no/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:290:2026-12-04",
@@ -10680,7 +10680,7 @@
       "lon": 13.404954,
       "url": "https://berlinswingrevolution.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:377:2026-12-10",
@@ -10700,7 +10700,7 @@
       "lon": 19.9449799,
       "url": "https://www.santaswing.pl/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "hiatus:990001:2026-12-11",
@@ -10713,14 +10713,14 @@
       "weekend_key": "2026-12-10",
       "status": "hiatus",
       "kind": "registry",
-      "city": "Toulouse-Blagnac",
+      "city": "Toulouse",
       "country": "France",
       "continent": "Europe",
-      "lat": null,
-      "lon": null,
+      "lat": 43.6048462,
+      "lon": 1.442848,
       "url": "https://www.globalgrandprixwcs.com/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "operator_override"
     },
     {
       "id": "confirmed:t-swiss-open-wcs-geneva-switzerland:2026-12-18",
@@ -10740,7 +10740,7 @@
       "lon": 6.1431577,
       "url": "http://www.swissopenwcs.ch/",
       "year": 2026,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:75:2026-12-28",
@@ -10760,7 +10760,7 @@
       "lon": -96.8067,
       "url": "http://www.ucwdcworlds.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:42:2026-12-30",
@@ -10780,12 +10780,12 @@
       "lon": -81.3789269,
       "url": "http://www.floorplayswingvacation.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:214:2026-12-30",
       "event_id": 214,
-      "name": "New Year's Swing Fling",
+      "name": "New Years Swing Fling",
       "start_date": "2026-12-30",
       "end_date": "2027-01-03",
       "weekend_start": "2026-12-24",
@@ -10800,7 +10800,7 @@
       "lon": -0.1275862,
       "url": "http://nysf.uk/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:141:2026-12-30",
@@ -10820,7 +10820,7 @@
       "lon": -86.7816016,
       "url": "http://www.spotlightnewyears.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:289:2026-12-30",
@@ -10836,11 +10836,11 @@
       "city": "Wels",
       "country": "Austria",
       "continent": "Europe",
-      "lat": 49.1950602,
-      "lon": 16.6068371,
+      "lat": 48.1664268,
+      "lon": 14.0388714,
       "url": "https://www.swingvester.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:334:2026-12-31",
@@ -10860,7 +10860,7 @@
       "lon": -71.0565364,
       "url": "http://countdownswingboston.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:240:2026-12-31",
@@ -10880,7 +10880,7 @@
       "lon": 18.0710935,
       "url": "http://www.westiegala.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:184:2027-01-05",
@@ -10900,11 +10900,11 @@
       "lon": 19.040235,
       "url": "http://wcs-budafest.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
-      "id": "confirmed:t-swingco-portland-united-states:2027-01-07",
-      "event_id": null,
+      "id": "confirmed:196:2027-01-07",
+      "event_id": 196,
       "name": "SwingCo",
       "start_date": "2027-01-07",
       "end_date": "2027-01-11",
@@ -10920,7 +10920,7 @@
       "lon": -122.6783853,
       "url": "https://swingco.dance/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:200:2027-01-14",
@@ -10940,7 +10940,7 @@
       "lon": -97.7430608,
       "url": "https://austinswingdance.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:t-cologne-calling-wcs-koln-germany:2027-01-14",
@@ -10960,7 +10960,7 @@
       "lon": null,
       "url": "https://colognecallingwcs.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:309:2027-01-15",
@@ -10980,7 +10980,7 @@
       "lon": 4.359999699999999,
       "url": "https://www.avignoncityswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:62:2027-01-15",
@@ -11000,7 +11000,7 @@
       "lon": -121.8977688,
       "url": "http://www.montereyswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:381:2027-01-15",
@@ -11042,7 +11042,7 @@
       "lon": -85.7663724,
       "url": "https://derbycityswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:301:2027-01-21",
@@ -11062,7 +11062,7 @@
       "lon": -3.188267,
       "url": "http://www.swingresolution.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:183:2027-01-22",
@@ -11075,14 +11075,14 @@
       "weekend_key": "2027-01-21",
       "status": "confirmed",
       "kind": "registry",
-      "city": "WILMINGTON DEL",
+      "city": "Wilmington",
       "country": "United States",
       "continent": "America",
       "lat": 39.744655,
       "lon": -75.5483909,
       "url": "https://freedomswingdance.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:t-swing-in-paris-paris-france:2027-01-22",
@@ -11095,19 +11095,19 @@
       "weekend_key": "2027-01-21",
       "status": "confirmed",
       "kind": "trial",
-      "city": "PARIS",
+      "city": "Paris",
       "country": "France",
       "continent": "Europe",
       "lat": 48.8575475,
       "lon": 2.3513765,
       "url": "http://swing-in-paris.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:273:2027-02-04",
       "event_id": 273,
-      "name": "Charlotte Westie Fest",
+      "name": "Charlotte WestieFest",
       "start_date": "2027-02-04",
       "end_date": "2027-02-07",
       "weekend_start": "2027-02-04",
@@ -11122,7 +11122,7 @@
       "lon": -80.84089329999999,
       "url": "https://charlottewestiefest.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:215:2027-02-04",
@@ -11142,7 +11142,7 @@
       "lon": 30.3609097,
       "url": "http://swingandsnow.ru/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:258:2027-02-04",
@@ -11162,7 +11162,7 @@
       "lon": 8.541694,
       "url": "https://swingtzerland.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:387:2027-02-04",
@@ -11176,13 +11176,13 @@
       "status": "confirmed",
       "kind": "registry",
       "city": "Waterloo",
-      "country": "United States",
+      "country": "Canada",
       "continent": "America",
       "lat": 43.4819752,
       "lon": -80.5261203,
       "url": "http://www.waterlooopenwcs.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:363:2027-02-05",
@@ -11202,7 +11202,7 @@
       "lon": -6.388300099999999,
       "url": "http://www.trinityswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:302:2027-02-05",
@@ -11244,7 +11244,7 @@
       "lon": 7.725619099999999,
       "url": "https://www.euro-dance-festival.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:12:2027-02-11",
@@ -11264,7 +11264,7 @@
       "lon": -121.4944209,
       "url": "http://www.capitalswingconvention.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:344:2027-02-18",
@@ -11284,7 +11284,7 @@
       "lon": -8.8252502,
       "url": "https://www.arousawestiefest.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:343:2027-02-18",
@@ -11304,7 +11304,7 @@
       "lon": -98.4945922,
       "url": "https://swingcrush.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:386:2027-02-19",
@@ -11324,7 +11324,7 @@
       "lon": 14.4378005,
       "url": "https://praguealchemyswing.cz/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:310:2027-02-19",
@@ -11344,7 +11344,7 @@
       "lon": 18.0710935,
       "url": "http://www.valentineswing.dance/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:272:2027-02-25",
@@ -11364,7 +11364,7 @@
       "lon": 2.3513765,
       "url": "http://https//parisswingclassic.com",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:244:2027-02-25",
@@ -11384,7 +11384,7 @@
       "lon": -122.6783853,
       "url": "https://rosecityswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:394:2027-02-25",
@@ -11404,7 +11404,7 @@
       "lon": 147.3257196,
       "url": "http://www.southernlightsswing.com.au/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:297:2027-02-25",
@@ -11424,7 +11424,7 @@
       "lon": 27.7880116,
       "url": "https://www.wintercoastswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:378:2027-02-26",
@@ -11437,14 +11437,14 @@
       "weekend_key": "2027-02-25",
       "status": "confirmed",
       "kind": "registry",
-      "city": "New York City",
+      "city": "New York",
       "country": "United States",
       "continent": "America",
       "lat": 40.7127753,
       "lon": -74.0059728,
       "url": "https://www.flowfest.nyc/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:92:2027-03-04",
@@ -11464,7 +11464,7 @@
       "lon": -77.0369274,
       "url": "http://www.atlanticdancejam.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:232:2027-03-05",
@@ -11484,7 +11484,7 @@
       "lon": 10.3950528,
       "url": "https://www.norwaywestiefest.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:333:2027-03-05",
@@ -11504,7 +11504,7 @@
       "lon": 174.7787463,
       "url": "https://swingvasion.nz/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:197:2027-03-11",
@@ -11524,7 +11524,7 @@
       "lon": -104.990251,
       "url": "http://www.5280westival.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:318:2027-03-11",
@@ -11567,11 +11567,11 @@
       "lon": 5.9736992,
       "url": "http://www.dutchopenwcs.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
-      "id": "confirmed:t-h-town-throw-down-2027-houston-united-states:2027-03-11",
-      "event_id": null,
+      "id": "confirmed:153:2027-03-11",
+      "event_id": 153,
       "name": "H-Town Throw Down 2027",
       "start_date": "2027-03-11",
       "end_date": "2027-03-14",
@@ -11587,7 +11587,7 @@
       "lon": -95.3701108,
       "url": "http://www.htownthrowdownwcs.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:314:2027-03-11",
@@ -11607,7 +11607,7 @@
       "lon": 19.040235,
       "url": "https://westiespringthing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:143:2027-03-12",
@@ -11627,7 +11627,7 @@
       "lon": -118.1481016,
       "url": "http://www.highdesertdanceclassic.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:292:2027-03-18",
@@ -11647,7 +11647,7 @@
       "lon": 19.9449799,
       "url": "https://kingswing.pl/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:142:2027-03-18",
@@ -11667,7 +11667,7 @@
       "lon": -87.6323879,
       "url": "https://thechicagoclassic.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:186:2027-03-18",
@@ -11680,14 +11680,14 @@
       "weekend_key": "2027-03-18",
       "status": "confirmed",
       "kind": "registry",
-      "city": "LYON",
+      "city": "Lyon",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
       "lon": 4.835659,
       "url": "http://www.west-in-lyon.fr/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:9:2027-03-19",
@@ -11707,7 +11707,7 @@
       "lon": -71.0565364,
       "url": "http://teapartyswings.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:18:2027-03-25",
@@ -11727,30 +11727,7 @@
       "lon": -122.3328481,
       "url": "https://easterswing.org/",
       "year": 2027,
-      "source": "events_list_current"
-    },
-    {
-      "id": "expected:153:2027-03-25",
-      "event_id": 153,
-      "name": "Novice Invitational",
-      "start_date": "2027-03-25",
-      "end_date": "2027-03-28",
-      "weekend_start": "2027-03-25",
-      "weekend_end": "2027-03-28",
-      "weekend_key": "2027-03-25",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Houston",
-      "country": "United States",
-      "continent": "America",
-      "lat": 29.7600771,
-      "lon": -95.3701108,
-      "url": "http://htownthrowdownwcs.com",
-      "year": 2027,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-03-26",
-      "has_results": true
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:132:2027-03-25",
@@ -11770,7 +11747,7 @@
       "lon": -95.989501,
       "url": "http://www.tulsaspringswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:154:2027-03-25",
@@ -11790,7 +11767,7 @@
       "lon": -0.1275862,
       "url": "http://www.ukwcschamps.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:t-franconian-swing-project-nurnberg-germany:2027-04-08",
@@ -11810,7 +11787,7 @@
       "lon": 11.0745641,
       "url": "https://franconian-swing-project.de/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:210:2027-04-08",
@@ -11830,7 +11807,7 @@
       "lon": 126.6312666,
       "url": "https://www.kopenwcs.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:304:2027-04-08",
@@ -11873,12 +11850,12 @@
       "lon": 14.5057515,
       "url": "https://slovenianopen.dance/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:218:2027-04-15",
       "event_id": 218,
-      "name": "Asia West Coast Swing Open",
+      "name": "Asia WCS Open 2027",
       "start_date": "2027-04-15",
       "end_date": "2027-04-18",
       "weekend_start": "2027-04-15",
@@ -11893,7 +11870,7 @@
       "lon": 103.819836,
       "url": "https://asiawcsopen.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:293:2027-04-16",
@@ -11913,7 +11890,7 @@
       "lon": -1.553621,
       "url": "https://www.westynantes.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:203:2027-04-22",
@@ -11933,7 +11910,7 @@
       "lon": -2.2426305,
       "url": "http://www.detonationdance.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:345:2027-04-22",
@@ -11953,7 +11930,7 @@
       "lon": 55.9578555,
       "url": "https://t.me/honeyfest",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:393:2027-04-22",
@@ -11973,7 +11950,7 @@
       "lon": -75.7003397,
       "url": "http://www.swinginbloom.ca/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:370:2027-04-22",
@@ -11993,12 +11970,12 @@
       "lon": 7.0982068,
       "url": "http://www.swinginfestival.de/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:259:2027-04-22",
       "event_id": 259,
-      "name": "Swingover",
+      "name": "Swingover 2027",
       "start_date": "2027-04-22",
       "end_date": "2027-04-25",
       "weekend_start": "2027-04-22",
@@ -12013,7 +11990,7 @@
       "lon": -81.3789269,
       "url": "http://swingoverevent.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:347:2027-04-29",
@@ -12033,7 +12010,7 @@
       "lon": -3.7032905,
       "url": "https://beemadwcs.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:116:2027-04-29",
@@ -12053,7 +12030,7 @@
       "lon": -114.0718831,
       "url": "http://www.calgarydancestampede.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:187:2027-04-29",
@@ -12073,7 +12050,7 @@
       "lon": -118.3074827,
       "url": "https://cityofangelswcs.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:253:2027-04-29",
@@ -12139,7 +12116,7 @@
       "lon": -72.6733723,
       "url": "http://www.sis.djkenm.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:336:2027-05-06",
@@ -12175,14 +12152,14 @@
       "weekend_key": "2027-05-06",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Washington DC",
+      "city": "Silver Spring",
       "country": "United States",
       "continent": "America",
       "lat": 38.9906654,
       "lon": -77.026088,
       "url": "https://dancejamproductions.com/westieweekend/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:175:2027-05-12",
@@ -12225,7 +12202,7 @@
       "lon": -122.7139216,
       "url": "http://wwww.soswingdance.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:174:2027-05-13",
@@ -12245,7 +12222,7 @@
       "lon": 153.380936,
       "url": "https://rawconnection.com.au/swingsation/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:105:2027-05-14",
@@ -12331,7 +12308,7 @@
       "lon": -90.1982439,
       "url": "http://gatewayswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:206:2027-05-21",
@@ -12374,7 +12351,7 @@
       "lon": -123.9400647,
       "url": "http://www.nanaimodancefusion.ca/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:22:2027-05-27",
@@ -12394,7 +12371,7 @@
       "lon": -84.3885209,
       "url": "http://www.usagrandnationals.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:368:2027-05-28",
@@ -12437,7 +12414,7 @@
       "lon": -1.61778,
       "url": "https://www.fcswing.co.uk/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:25:2027-06-03",
@@ -12480,7 +12457,7 @@
       "lon": -83.0424533,
       "url": "http://michiganclassicswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:117:2027-06-03",
@@ -12516,19 +12493,19 @@
       "weekend_key": "2027-06-10",
       "status": "confirmed",
       "kind": "registry",
-      "city": "Gdansk",
+      "city": "Gdańsk",
       "country": "Poland",
       "continent": "Europe",
       "lat": 54.35202520000001,
       "lon": 18.6466384,
       "url": "http://www.balticswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:220:2027-06-10",
       "event_id": 220,
-      "name": "D-Town Swing",
+      "name": "D-TOWNSWING 2027",
       "start_date": "2027-06-10",
       "end_date": "2027-06-13",
       "weekend_start": "2027-06-10",
@@ -12543,7 +12520,7 @@
       "lon": 6.7824545,
       "url": "http://www.d-townswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:405:2027-06-17",
@@ -12586,7 +12563,7 @@
       "lon": -91.1871466,
       "url": "http://www.swingapaloozaevent.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:374:2027-06-24",
@@ -12606,7 +12583,7 @@
       "lon": 9.1942834,
       "url": "https://baroqueswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:109:2027-06-24",
@@ -12649,34 +12626,11 @@
       "lon": -74.4442802,
       "url": "http://www.libertyswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
-      "id": "expected:261:2027-06-24",
+      "id": "confirmed:261:2027-06-24",
       "event_id": 261,
-      "name": "Neverland Swing",
-      "start_date": "2027-06-24",
-      "end_date": "2027-06-28",
-      "weekend_start": "2027-06-24",
-      "weekend_end": "2027-06-27",
-      "weekend_key": "2027-06-24",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Amsterdam",
-      "country": "Netherlands",
-      "continent": "Europe",
-      "lat": 52.3675734,
-      "lon": 4.9041389,
-      "url": "http://www.neverlandswing.com",
-      "year": 2027,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-06-25",
-      "has_results": true
-    },
-    {
-      "id": "confirmed:t-neverlandswing-dutch-swing-championships-2027-amsterdam-nether:2027-06-24",
-      "event_id": null,
       "name": "NeverlandSwing Dutch Swing Championships 2027",
       "start_date": "2027-06-24",
       "end_date": "2027-06-28",
@@ -12692,7 +12646,7 @@
       "lon": 4.9041389,
       "url": "http://www.neverlandswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "confirmed:369:2027-06-25",
@@ -12712,7 +12666,7 @@
       "lon": 6.129384,
       "url": "http://frenchconnectionwcs.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:331:2027-06-25",
@@ -12818,7 +12772,7 @@
       "lon": 13.0987448,
       "url": "http://swing-valley.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:225:2027-07-01",
@@ -12884,7 +12838,7 @@
       "lon": -80.84089329999999,
       "url": "https://carolinasummerswing.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:362:2027-07-08",
@@ -12973,7 +12927,7 @@
       "lon": -94.6707917,
       "url": "http://www.midwestwestiefest.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "scheduled_events"
     },
     {
       "id": "expected:385:2027-07-15",
@@ -13259,7 +13213,7 @@
       "weekend_key": "2027-08-05",
       "status": "expected",
       "kind": "registry",
-      "city": "Washington",
+      "city": "Herndon",
       "country": "United States",
       "continent": "America",
       "lat": 38.9695545,
@@ -13347,8 +13301,8 @@
       "weekend_key": "2027-08-19",
       "status": "expected",
       "kind": "registry",
-      "city": "Christchurch",
-      "country": "New Zealand",
+      "city": "Perth",
+      "country": "Australia",
       "continent": "Australia",
       "lat": -31.9513993,
       "lon": 115.8616783,
@@ -13549,7 +13503,7 @@
       "weekend_key": "2027-08-26",
       "status": "expected",
       "kind": "registry",
-      "city": "LYON",
+      "city": "Lyon",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
@@ -13673,7 +13627,7 @@
     {
       "id": "expected:47:2027-09-09",
       "event_id": 47,
-      "name": "Swingtime in the Rockies",
+      "name": "SwingTime Denver",
       "start_date": "2027-09-09",
       "end_date": "2027-09-12",
       "weekend_start": "2027-09-09",
@@ -13827,7 +13781,7 @@
     {
       "id": "expected:342:2027-09-17",
       "event_id": 342,
-      "name": "Global Grand Prix - West Coast Swing Reunion",
+      "name": "Global Grand Prix -- West Coast Swing Championships",
       "start_date": "2027-09-17",
       "end_date": "2027-09-20",
       "weekend_start": "2027-09-16",
@@ -13959,7 +13913,7 @@
     {
       "id": "expected:361:2027-09-23",
       "event_id": 361,
-      "name": "Mooseland Swing",
+      "name": "Mooseland Swing 2026",
       "start_date": "2027-09-23",
       "end_date": "2027-09-27",
       "weekend_start": "2027-09-23",
@@ -13989,7 +13943,7 @@
       "weekend_key": "2027-09-23",
       "status": "expected",
       "kind": "registry",
-      "city": "WILMINGTON",
+      "city": "Wilmington",
       "country": "United States",
       "continent": "America",
       "lat": 39.744655,
@@ -14109,7 +14063,7 @@
       "lon": -84.3885209,
       "url": "https://www.atlantaswingclassic.com/",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "edition_calendar_dates"
     },
     {
       "id": "expected:8:2027-10-07",
@@ -14282,9 +14236,9 @@
       "continent": "Europe",
       "lat": 51.2230411,
       "lon": 6.7824545,
-      "url": "http://www.wcsfestival.com/",
+      "url": "http://www.wcsfestival.com",
       "year": 2027,
-      "source": "events_list_current"
+      "source": "edition_calendar_dates"
     },
     {
       "id": "expected:350:2027-10-21",
@@ -14363,7 +14317,7 @@
       "weekend_key": "2027-10-21",
       "status": "expected",
       "kind": "registry",
-      "city": "CHICAGO",
+      "city": "Chicago",
       "country": "United States",
       "continent": "America",
       "lat": 41.88325,
@@ -14375,11 +14329,11 @@
       "projected_from_start": "2026-10-22"
     },
     {
-      "id": "expected:346:2027-10-22",
+      "id": "expected:346:2027-10-21",
       "event_id": 346,
       "name": "Swingside Invitational",
-      "start_date": "2027-10-22",
-      "end_date": "2027-10-24",
+      "start_date": "2027-10-21",
+      "end_date": "2027-10-23",
       "weekend_start": "2027-10-21",
       "weekend_end": "2027-10-24",
       "weekend_key": "2027-10-21",
@@ -14390,11 +14344,11 @@
       "continent": "Europe",
       "lat": 50.6402286,
       "lon": 5.5689372,
-      "url": "https://www.swingside-invitational.com/",
+      "url": "http://www.swingside-invitational.com/",
       "year": 2027,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-10-23"
+      "projected_from_start": "2026-10-22"
     },
     {
       "id": "expected:229:2027-10-27",
@@ -14487,7 +14441,7 @@
     {
       "id": "expected:79:2027-11-04",
       "event_id": 79,
-      "name": "Sea to Sky",
+      "name": "Sea to Sky Seattle",
       "start_date": "2027-11-04",
       "end_date": "2027-11-08",
       "weekend_start": "2027-11-04",
@@ -14539,7 +14493,7 @@
       "weekend_key": "2027-11-04",
       "status": "expected",
       "kind": "registry",
-      "city": "Tampa Bay",
+      "city": "Tampa",
       "country": "United States",
       "continent": "America",
       "lat": 27.9516896,
@@ -14583,7 +14537,7 @@
       "weekend_key": "2027-11-04",
       "status": "expected",
       "kind": "registry",
-      "city": "TOULOUSE",
+      "city": "Toulouse",
       "country": "France",
       "continent": "Europe",
       "lat": 43.6048462,
@@ -14597,7 +14551,7 @@
     {
       "id": "expected:288:2027-11-11",
       "event_id": 288,
-      "name": "Midnight Madness",
+      "name": "Midnight Madness WCS 2026",
       "start_date": "2027-11-11",
       "end_date": "2027-11-14",
       "weekend_start": "2027-11-11",
@@ -14605,7 +14559,7 @@
       "weekend_key": "2027-11-11",
       "status": "expected",
       "kind": "registry",
-      "city": "Dallas Ft. Worth",
+      "city": "Dallas",
       "country": "United States",
       "continent": "America",
       "lat": 32.7831,
@@ -14627,7 +14581,7 @@
       "weekend_key": "2027-11-11",
       "status": "expected",
       "kind": "registry",
-      "city": "Providence RI",
+      "city": "Providence",
       "country": "United States",
       "continent": "America",
       "lat": 41.8245558,
@@ -14649,7 +14603,7 @@
       "weekend_key": "2027-11-11",
       "status": "expected",
       "kind": "registry",
-      "city": "LYON",
+      "city": "Lyon",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
@@ -14715,7 +14669,7 @@
       "weekend_key": "2027-11-18",
       "status": "expected",
       "kind": "registry",
-      "city": "Washington",
+      "city": "Herndon",
       "country": "United States",
       "continent": "America",
       "lat": 38.9695545,
@@ -14795,7 +14749,7 @@
     {
       "id": "expected:212:2027-12-02",
       "event_id": 212,
-      "name": "The After Party (TAP)",
+      "name": "The After Party aka TAP",
       "start_date": "2027-12-02",
       "end_date": "2027-12-06",
       "weekend_start": "2027-12-02",
@@ -14947,29 +14901,6 @@
       "provisional_unlinked": true
     },
     {
-      "id": "expected:196:2027-12-29",
-      "event_id": 196,
-      "name": "SwingCouver",
-      "start_date": "2027-12-29",
-      "end_date": "2028-01-02",
-      "weekend_start": "2027-12-23",
-      "weekend_end": "2027-12-26",
-      "weekend_key": "2027-12-23",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Portland",
-      "country": "United States",
-      "continent": "America",
-      "lat": 45.515232,
-      "lon": -122.6783853,
-      "url": "http://www.swingcouver.com",
-      "year": 2027,
-      "source": "expected_yoy",
-      "projected_from_year": 2025,
-      "projected_from_start": "2025-12-31",
-      "has_results": true
-    },
-    {
       "id": "expected:184:2028-01-04",
       "event_id": 184,
       "name": "BudaFest Open WCS Championships",
@@ -14992,8 +14923,8 @@
       "projected_from_start": "2027-01-05"
     },
     {
-      "id": "expected:t-swingco-portland-united-states:2028-01-06",
-      "event_id": null,
+      "id": "expected:196:2028-01-06",
+      "event_id": 196,
       "name": "SwingCo",
       "start_date": "2028-01-06",
       "end_date": "2028-01-10",
@@ -15011,8 +14942,7 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
-      "projected_from_start": "2027-01-07",
-      "provisional_unlinked": true
+      "projected_from_start": "2027-01-07"
     },
     {
       "id": "expected:200:2028-01-13",
@@ -15180,7 +15110,7 @@
       "weekend_key": "2028-01-20",
       "status": "expected",
       "kind": "registry",
-      "city": "WILMINGTON DEL",
+      "city": "Wilmington",
       "country": "United States",
       "continent": "America",
       "lat": 39.744655,
@@ -15202,7 +15132,7 @@
       "weekend_key": "2028-01-20",
       "status": "expected",
       "kind": "registry",
-      "city": "PARIS",
+      "city": "Paris",
       "country": "France",
       "continent": "Europe",
       "lat": 48.8575475,
@@ -15217,7 +15147,7 @@
     {
       "id": "expected:273:2028-02-03",
       "event_id": 273,
-      "name": "Charlotte Westie Fest",
+      "name": "Charlotte WestieFest",
       "start_date": "2028-02-03",
       "end_date": "2028-02-06",
       "weekend_start": "2028-02-03",
@@ -15292,7 +15222,7 @@
       "status": "expected",
       "kind": "registry",
       "city": "Waterloo",
-      "country": "United States",
+      "country": "Canada",
       "continent": "America",
       "lat": 43.4819752,
       "lon": -80.5261203,
@@ -15555,7 +15485,7 @@
       "weekend_key": "2028-02-24",
       "status": "expected",
       "kind": "registry",
-      "city": "New York City",
+      "city": "New York",
       "country": "United States",
       "continent": "America",
       "lat": 40.7127753,
@@ -15582,9 +15512,9 @@
       "continent": "Europe",
       "lat": 48.2672137,
       "lon": 7.725619099999999,
-      "url": "https://www.euro-dance-festival.com/",
+      "url": "https://www.euro-dance-festival.com",
       "year": 2028,
-      "source": "events_list_current"
+      "source": "edition_calendar_dates"
     },
     {
       "id": "expected:92:2028-03-02",
@@ -15720,8 +15650,8 @@
       "projected_from_start": "2027-03-11"
     },
     {
-      "id": "expected:t-h-town-throw-down-2027-houston-united-states:2028-03-09",
-      "event_id": null,
+      "id": "expected:153:2028-03-09",
+      "event_id": 153,
       "name": "H-Town Throw Down 2027",
       "start_date": "2028-03-09",
       "end_date": "2028-03-12",
@@ -15739,8 +15669,7 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
-      "projected_from_start": "2027-03-11",
-      "provisional_unlinked": true
+      "projected_from_start": "2027-03-11"
     },
     {
       "id": "expected:314:2028-03-09",
@@ -15841,7 +15770,7 @@
       "weekend_key": "2028-03-16",
       "status": "expected",
       "kind": "registry",
-      "city": "LYON",
+      "city": "Lyon",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
@@ -15895,29 +15824,6 @@
       "source": "expected_yoy",
       "projected_from_year": 2027,
       "projected_from_start": "2027-03-25"
-    },
-    {
-      "id": "expected:153:2028-03-23",
-      "event_id": 153,
-      "name": "Novice Invitational",
-      "start_date": "2028-03-23",
-      "end_date": "2028-03-26",
-      "weekend_start": "2028-03-23",
-      "weekend_end": "2028-03-26",
-      "weekend_key": "2028-03-23",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Houston",
-      "country": "United States",
-      "continent": "America",
-      "lat": 29.7600771,
-      "lon": -95.3701108,
-      "url": "http://htownthrowdownwcs.com",
-      "year": 2028,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-03-26",
-      "has_results": true
     },
     {
       "id": "expected:132:2028-03-23",
@@ -16056,7 +15962,7 @@
     {
       "id": "expected:218:2028-04-13",
       "event_id": 218,
-      "name": "Asia West Coast Swing Open",
+      "name": "Asia WCS Open 2027",
       "start_date": "2028-04-13",
       "end_date": "2028-04-16",
       "weekend_start": "2028-04-13",
@@ -16188,7 +16094,7 @@
     {
       "id": "expected:259:2028-04-20",
       "event_id": 259,
-      "name": "Swingover",
+      "name": "Swingover 2027",
       "start_date": "2028-04-20",
       "end_date": "2028-04-23",
       "weekend_start": "2028-04-20",
@@ -16375,7 +16281,7 @@
       "weekend_key": "2028-05-04",
       "status": "expected",
       "kind": "registry",
-      "city": "Washington DC",
+      "city": "Silver Spring",
       "country": "United States",
       "continent": "America",
       "lat": 38.9906654,
@@ -16734,7 +16640,7 @@
       "weekend_key": "2028-06-08",
       "status": "expected",
       "kind": "registry",
-      "city": "Gdansk",
+      "city": "Gdańsk",
       "country": "Poland",
       "continent": "Europe",
       "lat": 54.35202520000001,
@@ -16748,7 +16654,7 @@
     {
       "id": "expected:220:2028-06-08",
       "event_id": 220,
-      "name": "D-Town Swing",
+      "name": "D-TOWNSWING 2027",
       "start_date": "2028-06-08",
       "end_date": "2028-06-11",
       "weekend_start": "2028-06-08",
@@ -16882,29 +16788,6 @@
     {
       "id": "expected:261:2028-06-22",
       "event_id": 261,
-      "name": "Neverland Swing",
-      "start_date": "2028-06-22",
-      "end_date": "2028-06-26",
-      "weekend_start": "2028-06-22",
-      "weekend_end": "2028-06-25",
-      "weekend_key": "2028-06-22",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Amsterdam",
-      "country": "Netherlands",
-      "continent": "Europe",
-      "lat": 52.3675734,
-      "lon": 4.9041389,
-      "url": "http://www.neverlandswing.com",
-      "year": 2028,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-06-25",
-      "has_results": true
-    },
-    {
-      "id": "expected:t-neverlandswing-dutch-swing-championships-2027-amsterdam-nether:2028-06-22",
-      "event_id": null,
       "name": "NeverlandSwing Dutch Swing Championships 2027",
       "start_date": "2028-06-22",
       "end_date": "2028-06-26",
@@ -16922,8 +16805,7 @@
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
-      "projected_from_start": "2027-06-24",
-      "provisional_unlinked": true
+      "projected_from_start": "2027-06-24"
     },
     {
       "id": "expected:369:2028-06-23",
@@ -17480,7 +17362,7 @@
       "weekend_key": "2028-08-03",
       "status": "expected",
       "kind": "registry",
-      "city": "Washington",
+      "city": "Herndon",
       "country": "United States",
       "continent": "America",
       "lat": 38.9695545,
@@ -17591,8 +17473,8 @@
       "weekend_key": "2028-08-17",
       "status": "expected",
       "kind": "registry",
-      "city": "Christchurch",
-      "country": "New Zealand",
+      "city": "Perth",
+      "country": "Australia",
       "continent": "Australia",
       "lat": -31.9513993,
       "lon": 115.8616783,
@@ -17770,7 +17652,7 @@
       "weekend_key": "2028-08-24",
       "status": "expected",
       "kind": "registry",
-      "city": "LYON",
+      "city": "Lyon",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
@@ -17917,7 +17799,7 @@
     {
       "id": "expected:47:2028-09-07",
       "event_id": 47,
-      "name": "Swingtime in the Rockies",
+      "name": "SwingTime Denver",
       "start_date": "2028-09-07",
       "end_date": "2028-09-10",
       "weekend_start": "2028-09-07",
@@ -18071,7 +17953,7 @@
     {
       "id": "expected:342:2028-09-15",
       "event_id": 342,
-      "name": "Global Grand Prix - West Coast Swing Reunion",
+      "name": "Global Grand Prix -- West Coast Swing Championships",
       "start_date": "2028-09-15",
       "end_date": "2028-09-18",
       "weekend_start": "2028-09-14",
@@ -18203,7 +18085,7 @@
     {
       "id": "expected:361:2028-09-21",
       "event_id": 361,
-      "name": "Mooseland Swing",
+      "name": "Mooseland Swing 2026",
       "start_date": "2028-09-21",
       "end_date": "2028-09-25",
       "weekend_start": "2028-09-21",
@@ -18233,7 +18115,7 @@
       "weekend_key": "2028-09-21",
       "status": "expected",
       "kind": "registry",
-      "city": "WILMINGTON",
+      "city": "Wilmington",
       "country": "United States",
       "continent": "America",
       "lat": 39.744655,
@@ -18262,7 +18144,7 @@
       "lon": -84.3885209,
       "url": "https://www.atlantaswingclassic.com/",
       "year": 2028,
-      "source": "events_list_current"
+      "source": "edition_calendar_dates"
     },
     {
       "id": "expected:388:2028-09-28",
@@ -18526,7 +18408,7 @@
       "continent": "Europe",
       "lat": 51.2230411,
       "lon": 6.7824545,
-      "url": "http://www.wcsfestival.com/",
+      "url": "http://www.wcsfestival.com",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2027,
@@ -18609,7 +18491,7 @@
       "weekend_key": "2028-10-19",
       "status": "expected",
       "kind": "registry",
-      "city": "CHICAGO",
+      "city": "Chicago",
       "country": "United States",
       "continent": "America",
       "lat": 41.88325,
@@ -18621,11 +18503,11 @@
       "projected_from_start": "2026-10-22"
     },
     {
-      "id": "expected:346:2028-10-20",
+      "id": "expected:346:2028-10-19",
       "event_id": 346,
       "name": "Swingside Invitational",
-      "start_date": "2028-10-20",
-      "end_date": "2028-10-22",
+      "start_date": "2028-10-19",
+      "end_date": "2028-10-21",
       "weekend_start": "2028-10-19",
       "weekend_end": "2028-10-22",
       "weekend_key": "2028-10-19",
@@ -18636,11 +18518,11 @@
       "continent": "Europe",
       "lat": 50.6402286,
       "lon": 5.5689372,
-      "url": "https://www.swingside-invitational.com/",
+      "url": "http://www.swingside-invitational.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,
-      "projected_from_start": "2026-10-23"
+      "projected_from_start": "2026-10-22"
     },
     {
       "id": "expected:229:2028-10-25",
@@ -18733,7 +18615,7 @@
     {
       "id": "expected:79:2028-11-02",
       "event_id": 79,
-      "name": "Sea to Sky",
+      "name": "Sea to Sky Seattle",
       "start_date": "2028-11-02",
       "end_date": "2028-11-06",
       "weekend_start": "2028-11-02",
@@ -18785,7 +18667,7 @@
       "weekend_key": "2028-11-02",
       "status": "expected",
       "kind": "registry",
-      "city": "Tampa Bay",
+      "city": "Tampa",
       "country": "United States",
       "continent": "America",
       "lat": 27.9516896,
@@ -18829,7 +18711,7 @@
       "weekend_key": "2028-11-02",
       "status": "expected",
       "kind": "registry",
-      "city": "TOULOUSE",
+      "city": "Toulouse",
       "country": "France",
       "continent": "Europe",
       "lat": 43.6048462,
@@ -18843,7 +18725,7 @@
     {
       "id": "expected:288:2028-11-09",
       "event_id": 288,
-      "name": "Midnight Madness",
+      "name": "Midnight Madness WCS 2026",
       "start_date": "2028-11-09",
       "end_date": "2028-11-12",
       "weekend_start": "2028-11-09",
@@ -18851,7 +18733,7 @@
       "weekend_key": "2028-11-09",
       "status": "expected",
       "kind": "registry",
-      "city": "Dallas Ft. Worth",
+      "city": "Dallas",
       "country": "United States",
       "continent": "America",
       "lat": 32.7831,
@@ -18873,7 +18755,7 @@
       "weekend_key": "2028-11-09",
       "status": "expected",
       "kind": "registry",
-      "city": "Providence RI",
+      "city": "Providence",
       "country": "United States",
       "continent": "America",
       "lat": 41.8245558,
@@ -18895,7 +18777,7 @@
       "weekend_key": "2028-11-09",
       "status": "expected",
       "kind": "registry",
-      "city": "LYON",
+      "city": "Lyon",
       "country": "France",
       "continent": "Europe",
       "lat": 45.764043,
@@ -18961,7 +18843,7 @@
       "weekend_key": "2028-11-16",
       "status": "expected",
       "kind": "registry",
-      "city": "Washington",
+      "city": "Herndon",
       "country": "United States",
       "continent": "America",
       "lat": 38.9695545,
@@ -19041,7 +18923,7 @@
     {
       "id": "expected:212:2028-11-30",
       "event_id": 212,
-      "name": "The After Party (TAP)",
+      "name": "The After Party aka TAP",
       "start_date": "2028-11-30",
       "end_date": "2028-12-04",
       "weekend_start": "2028-11-30",
@@ -19219,7 +19101,7 @@
     {
       "id": "expected:214:2028-12-27",
       "event_id": 214,
-      "name": "New Year's Swing Fling",
+      "name": "New Years Swing Fling",
       "start_date": "2028-12-27",
       "end_date": "2028-12-31",
       "weekend_start": "2028-12-21",
@@ -19261,51 +19143,6 @@
       "projected_from_start": "2026-12-30"
     },
     {
-      "id": "expected:196:2028-12-27",
-      "event_id": 196,
-      "name": "SwingCouver",
-      "start_date": "2028-12-27",
-      "end_date": "2028-12-31",
-      "weekend_start": "2028-12-21",
-      "weekend_end": "2028-12-24",
-      "weekend_key": "2028-12-21",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Portland",
-      "country": "United States",
-      "continent": "America",
-      "lat": 45.515232,
-      "lon": -122.6783853,
-      "url": "http://www.swingcouver.com",
-      "year": 2028,
-      "source": "expected_yoy",
-      "projected_from_year": 2025,
-      "projected_from_start": "2025-12-31",
-      "has_results": true
-    },
-    {
-      "id": "expected:289:2028-12-27",
-      "event_id": 289,
-      "name": "SwingVester",
-      "start_date": "2028-12-27",
-      "end_date": "2029-01-01",
-      "weekend_start": "2028-12-21",
-      "weekend_end": "2028-12-24",
-      "weekend_key": "2028-12-21",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Wels",
-      "country": "Austria",
-      "continent": "Europe",
-      "lat": 49.1950602,
-      "lon": 16.6068371,
-      "url": "https://www.swingvester.com/",
-      "year": 2028,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-12-30"
-    },
-    {
       "id": "expected:334:2028-12-28",
       "event_id": 334,
       "name": "Countdown Swing Boston",
@@ -19322,28 +19159,6 @@
       "lat": 42.3555076,
       "lon": -71.0565364,
       "url": "http://countdownswingboston.com/",
-      "year": 2028,
-      "source": "expected_yoy",
-      "projected_from_year": 2026,
-      "projected_from_start": "2026-12-31"
-    },
-    {
-      "id": "expected:240:2028-12-28",
-      "event_id": 240,
-      "name": "Westie Gala",
-      "start_date": "2028-12-28",
-      "end_date": "2029-01-01",
-      "weekend_start": "2028-12-28",
-      "weekend_end": "2028-12-31",
-      "weekend_key": "2028-12-28",
-      "status": "expected",
-      "kind": "registry",
-      "city": "Stockholm",
-      "country": "Sweden",
-      "continent": "Europe",
-      "lat": 59.3251172,
-      "lon": 18.0710935,
-      "url": "http://www.westiegala.com/",
       "year": 2028,
       "source": "expected_yoy",
       "projected_from_year": 2026,


### PR DESCRIPTION
## Summary
- Republish `events_year_calendar.json` and `champion_news.json` after SwingVester location remap (Wels, Austria).
- Stale site JSON still showed Brno for 2024–2026 (and Brno coords even when city text said Wels).

## Test plan
- [x] Local rebuild asserts SwingVester city=Wels / Austria / Wels lat-lon
- [x] Champion News SwingVester locations = Wels, Austria
- [ ] Merge → GitHub Pages serves updated JSON; hard-refresh year calendar


Made with [Cursor](https://cursor.com)