### PR TITLE
Mobile: enlarge L2 website link arrow + tap target

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260808j">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260808k">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -2338,6 +2338,23 @@ h1 {
     order: 1;
     padding-right: 0;
   }
+  /* Website link: larger glyph + tap target (desktop stays compact). */
+  .l2-event-card__title-row {
+    align-items: center;
+    gap: 6px;
+  }
+  .l2-event-card__web {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 36px;
+    min-height: 36px;
+    padding: 6px;
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 1;
+    -webkit-tap-highlight-color: transparent;
+  }
   .l2-event-card__spark-ctrl {
     order: 2;
   }


### PR DESCRIPTION
## Summary
- On ≤700px, enlarge the L2 event website `↗` (18px, bold) and give it a ~36px tap target.
- Desktop styling unchanged.

## Test plan
- [ ] Mobile width: open L2 card with a website URL — arrow clearly visible and easy to tap
- [ ] Desktop: arrow still compact next to the title

Made with [Cursor](https://cursor.com)