### PR TITLE
Mobile: pull L2 website arrow next to event title

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -40,7 +40,7 @@
       gtag('js', new Date());
       gtag('config', 'G-LMLCY5PE8Z');
     </script>
-    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260808k">
+    <link rel="stylesheet" href="static/css/events-calendar.css?v=20260808l">
 </head>
 <body>
     <a class="skip-link" href="#main">Skip to content</a>

--- a/static/css/events-calendar.css
+++ b/static/css/events-calendar.css
@@ -2338,21 +2338,20 @@ h1 {
     order: 1;
     padding-right: 0;
   }
-  /* Website link: larger glyph + tap target (desktop stays compact). */
+  /* Website link: keep large glyph, sit tight to title; expand tap via padding. */
   .l2-event-card__title-row {
-    align-items: center;
-    gap: 6px;
+    align-items: baseline;
+    gap: 2px;
   }
   .l2-event-card__web {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 36px;
-    min-height: 36px;
-    padding: 6px;
     font-size: 18px;
     font-weight: 700;
     line-height: 1;
+    padding: 10px;
+    margin: -10px -8px -10px -2px;
     -webkit-tap-highlight-color: transparent;
   }
   .l2-event-card__spark-ctrl {


### PR DESCRIPTION
## Summary
- Keep mobile `↗` at 18px/bold.
- Align to title baseline, tighten gap, expand tap target with padding + negative margin instead of a 36×36 box that floated the icon away.

## Test plan
- [ ] Mobile: arrow sits close to the event name (not dropped/detached)
- [ ] Mobile: still easy to tap
- [ ] Desktop unchanged

Made with [Cursor](https://cursor.com)